### PR TITLE
basic charts support [WIP]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+
+# spceicifc
+examples/_matplotlib.ipynb

--- a/altair_pandas/_core.py
+++ b/altair_pandas/_core.py
@@ -90,6 +90,59 @@ class _DataFramePlotter(_PandasPlotter):
             color=alt.Color('column:N', title=None),
             tooltip=[x] + y_values,
         ).interactive()
+    
+    def area(self, x=None, y=None, **kwargs):
+        if x is None:
+            x = self._data.columns[0]
+        else:
+            assert x in self._data.columns
+        if y is None:
+            y_values = list(self._data.columns[1:])
+        else:
+            assert y in self._data.columns
+            y_values = [y]
+
+        return alt.Chart(self._data).transform_fold(
+            y_values, as_=['column', 'value']
+        ).mark_area().encode(
+            x=x,
+            y=alt.Y('value:Q', title=None),
+            color=alt.Color('column:N', title=None),
+            tooltip=[x] + y_values,
+            opacity=alt.value(kwargs.get('alpha', .5))
+        ).interactive()
+
+    def bar(self, x=None, y=None, **kwargs):
+        if x is None:
+            x = self._data.columns[0]
+        else:
+            assert x in self._data.columns
+        if y is None:
+            y_values = list(self._data.columns[1:])
+        else:
+            assert y in self._data.columns
+            y_values = [y]
+
+        
+
+        chart = alt.Chart(self._data).transform_fold(
+            y_values, as_=['column', 'value']
+        ).mark_bar().encode(
+            x=x,
+            y=alt.Y('value:Q', title=None),
+            color=alt.Color('column:N', title=None),
+            tooltip=[x] + y_values,
+            opacity=alt.value(kwargs.get('alpha', .5)), # NOTE: setup basic config instead
+        ).interactive()
+
+        if len(self._data) <= 12:  # NOTE: arbitrary - for discussion
+            return chart.encode(
+                x=alt.X('column:N', title=None),
+                column=x,
+                opacity=alt.value(kwargs.get('alpha', 1))
+            )
+
+        return chart
 
 
 def plot(data, kind='line', **kwargs):

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -12,19 +12,78 @@ def dataframe():
     return pd.DataFrame({'x': range(5), 'y': range(5)})
 
 
-def test_series_line_plot(series, with_plotting_backend):
-    chart = series.plot()
+series_cases = {
+    'line': {
+        'answer': {
+            'mark': 'line',
+            'encoding_x': 'index',
+            'encoding_y': 'data_name'
+        }
+    },
+
+    'bar': {
+        'answer': {
+            'mark': 'bar',
+            'encoding_x': 'index',
+            'encoding_y': 'data_name'
+        }
+    },
+
+    'area': {
+        'answer': {
+            'mark': 'area',
+            'encoding_x': 'index',
+            'encoding_y': 'data_name'
+        }
+    }
+}
+
+@pytest.mark.parametrize('kind, props', series_cases.items())
+def test_series_plot(series, with_plotting_backend, kind, props):
+    chart = series.plot(kind=kind)
     spec = chart.to_dict()
-    assert spec['mark'] == 'line'
-    assert spec['encoding']['x']['field'] == 'index'
-    assert spec['encoding']['y']['field'] == 'data_name'
+
+    answer = props['answer']
+
+    assert spec['mark'] == answer['mark']
+    assert spec['encoding']['x']['field'] == answer['encoding_x']
+    assert spec['encoding']['y']['field'] == answer['encoding_y']
 
 
-def test_dataframe_line_plot(dataframe, with_plotting_backend):
-    chart = dataframe.plot()
+dataframe_cases = {
+    'line': {
+        'answer': {
+            'mark': 'line',
+            'encoding_x': 'index',
+            'encoding_y': 'value'
+        }
+    },
+
+    'bar': {
+        'answer': {
+            'mark': 'bar',
+            'encoding_x': 'index',
+            'encoding_y': 'value'
+        }
+    },
+
+    'area': {
+        'answer': {
+            'mark': 'area',
+            'encoding_x': 'index',
+            'encoding_y': 'value'
+        }
+    }
+}
+
+@pytest.mark.parametrize('kind, props', dataframe_cases.items())
+def test_dataframe_plot(dataframe, with_plotting_backend, kind, props):
+    chart = dataframe.plot(kind=kind)
     spec = chart.to_dict()
-    assert spec['mark'] == 'line'
-    assert spec['encoding']['x']['field'] == 'index'
-    assert spec['encoding']['y']['field'] == 'value'
+
+    answer = props['answer']
+    assert spec['mark'] == answer['mark']
+    assert spec['encoding']['x']['field'] == answer['encoding_x']
+    assert spec['encoding']['y']['field'] == answer['encoding_y']
     assert spec['encoding']['color']['field'] == 'column'
     assert spec['transform'][0]['fold'] == ['x', 'y']

--- a/examples/basic_plots.ipynb
+++ b/examples/basic_plots.ipynb
@@ -1,0 +1,3786 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "pd.set_option('plotting.backend', 'altair')  # Installing altair_pandas registers this.\n",
+    "np.random.seed(2019)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.vegalite.v3+json": {
+       "$schema": "https://vega.github.io/schema/vega-lite/v3.4.0.json",
+       "config": {
+        "mark": {
+         "tooltip": null
+        },
+        "view": {
+         "height": 300,
+         "width": 400
+        }
+       },
+       "data": {
+        "name": "data-9e8a1deb68113a0fc52e584514228101"
+       },
+       "datasets": {
+        "data-9e8a1deb68113a0fc52e584514228101": [
+         {
+          "index": 0,
+          "value": -0.21767896374028844
+         },
+         {
+          "index": 1,
+          "value": 0.6037763908517348
+         },
+         {
+          "index": 2,
+          "value": 2.085054199890827
+         },
+         {
+          "index": 3,
+          "value": 3.416918242122044
+         },
+         {
+          "index": 4,
+          "value": 3.055052870125853
+         },
+         {
+          "index": 5,
+          "value": 3.740661701390467
+         },
+         {
+          "index": 6,
+          "value": 4.314423127686804
+         },
+         {
+          "index": 7,
+          "value": 4.602150794140218
+         },
+         {
+          "index": 8,
+          "value": 4.366516533828004
+         },
+         {
+          "index": 9,
+          "value": 5.320006778058893
+         },
+         {
+          "index": 10,
+          "value": 3.630381476045523
+         },
+         {
+          "index": 11,
+          "value": 3.28543876917823
+         },
+         {
+          "index": 12,
+          "value": 3.3023436662451164
+         },
+         {
+          "index": 13,
+          "value": 2.787360144208991
+         },
+         {
+          "index": 14,
+          "value": 3.0318694358800773
+         },
+         {
+          "index": 15,
+          "value": 2.842556828366233
+         },
+         {
+          "index": 16,
+          "value": 5.5147292461710125
+         },
+         {
+          "index": 17,
+          "value": 5.9795317350387105
+         },
+         {
+          "index": 18,
+          "value": 6.825462179401228
+         },
+         {
+          "index": 19,
+          "value": 6.321920597261879
+         },
+         {
+          "index": 20,
+          "value": 5.358585067415754
+         },
+         {
+          "index": 21,
+          "value": 5.423553696912329
+         },
+         {
+          "index": 22,
+          "value": 2.2185134640725876
+         },
+         {
+          "index": 23,
+          "value": 3.2734828904873123
+         },
+         {
+          "index": 24,
+          "value": 4.080759584335997
+         },
+         {
+          "index": 25,
+          "value": 4.554900138051219
+         },
+         {
+          "index": 26,
+          "value": 4.96582838485692
+         },
+         {
+          "index": 27,
+          "value": 5.452517653637267
+         },
+         {
+          "index": 28,
+          "value": 4.916987945011077
+         },
+         {
+          "index": 29,
+          "value": 4.078080001723468
+         },
+         {
+          "index": 30,
+          "value": 3.2657051816620273
+         },
+         {
+          "index": 31,
+          "value": 2.814912238889269
+         },
+         {
+          "index": 32,
+          "value": 3.8857135946357904
+         },
+         {
+          "index": 33,
+          "value": 4.103134744478959
+         },
+         {
+          "index": 34,
+          "value": 2.927276150201358
+         },
+         {
+          "index": 35,
+          "value": 2.001159361112061
+         },
+         {
+          "index": 36,
+          "value": 1.0072116999696281
+         },
+         {
+          "index": 37,
+          "value": 1.5940180092029606
+         },
+         {
+          "index": 38,
+          "value": 2.6578312521356438
+         },
+         {
+          "index": 39,
+          "value": 2.8955721127279253
+         },
+         {
+          "index": 40,
+          "value": 2.1205155497447388
+         },
+         {
+          "index": 41,
+          "value": 1.1414116033058854
+         },
+         {
+          "index": 42,
+          "value": -0.4079513325181001
+         },
+         {
+          "index": 43,
+          "value": -1.6147795773840339
+         },
+         {
+          "index": 44,
+          "value": -1.1697713448489386
+         },
+         {
+          "index": 45,
+          "value": -1.3428575525620638
+         },
+         {
+          "index": 46,
+          "value": 0.1460896364212152
+         },
+         {
+          "index": 47,
+          "value": -0.6464308567918783
+         },
+         {
+          "index": 48,
+          "value": 1.192566242489495
+         },
+         {
+          "index": 49,
+          "value": 0.7532041177694748
+         },
+         {
+          "index": 50,
+          "value": 1.9132072860119222
+         },
+         {
+          "index": 51,
+          "value": 1.336113833157092
+         },
+         {
+          "index": 52,
+          "value": 0.3050694347651961
+         },
+         {
+          "index": 53,
+          "value": -0.533816010813897
+         },
+         {
+          "index": 54,
+          "value": -0.2168819482849525
+         },
+         {
+          "index": 55,
+          "value": 0.1363720328685194
+         },
+         {
+          "index": 56,
+          "value": 1.6520950769613019
+         },
+         {
+          "index": 57,
+          "value": 1.2742448517561686
+         },
+         {
+          "index": 58,
+          "value": 0.18156530486525924
+         },
+         {
+          "index": 59,
+          "value": -0.46677721579248066
+         },
+         {
+          "index": 60,
+          "value": 1.0132082788293086
+         },
+         {
+          "index": 61,
+          "value": -1.0920924146035031
+         },
+         {
+          "index": 62,
+          "value": -0.8633975255009756
+         },
+         {
+          "index": 63,
+          "value": -0.5027686894903969
+         },
+         {
+          "index": 64,
+          "value": -1.942655217014441
+         },
+         {
+          "index": 65,
+          "value": -2.605360987794434
+         },
+         {
+          "index": 66,
+          "value": -3.266998206267096
+         },
+         {
+          "index": 67,
+          "value": -3.862995186311024
+         },
+         {
+          "index": 68,
+          "value": -3.8108001324488665
+         },
+         {
+          "index": 69,
+          "value": -5.364126962862649
+         },
+         {
+          "index": 70,
+          "value": -3.7098692077008155
+         },
+         {
+          "index": 71,
+          "value": -3.053010525590692
+         },
+         {
+          "index": 72,
+          "value": -3.5915764683062266
+         },
+         {
+          "index": 73,
+          "value": -4.588424247599213
+         },
+         {
+          "index": 74,
+          "value": -6.320551204516049
+         },
+         {
+          "index": 75,
+          "value": -7.980724585411982
+         },
+         {
+          "index": 76,
+          "value": -7.745641800853409
+         },
+         {
+          "index": 77,
+          "value": -7.630487313675264
+         },
+         {
+          "index": 78,
+          "value": -10.189871835156909
+         },
+         {
+          "index": 79,
+          "value": -10.423192290588963
+         },
+         {
+          "index": 80,
+          "value": -9.830024872718923
+         },
+         {
+          "index": 81,
+          "value": -8.358314369790154
+         },
+         {
+          "index": 82,
+          "value": -8.592553327694517
+         },
+         {
+          "index": 83,
+          "value": -8.677012362204078
+         },
+         {
+          "index": 84,
+          "value": -8.413664727803932
+         },
+         {
+          "index": 85,
+          "value": -8.930585529963219
+         },
+         {
+          "index": 86,
+          "value": -7.848083787670971
+         },
+         {
+          "index": 87,
+          "value": -8.536997847529248
+         },
+         {
+          "index": 88,
+          "value": -9.594262979225823
+         },
+         {
+          "index": 89,
+          "value": -9.116383234141601
+         },
+         {
+          "index": 90,
+          "value": -9.808759295922272
+         },
+         {
+          "index": 91,
+          "value": -10.586333145642776
+         },
+         {
+          "index": 92,
+          "value": -10.37478433832342
+         },
+         {
+          "index": 93,
+          "value": -10.650711703959578
+         },
+         {
+          "index": 94,
+          "value": -10.856956853030994
+         },
+         {
+          "index": 95,
+          "value": -11.386445026312877
+         },
+         {
+          "index": 96,
+          "value": -11.758757263881288
+         },
+         {
+          "index": 97,
+          "value": -13.599561306524677
+         },
+         {
+          "index": 98,
+          "value": -13.309853682360751
+         },
+         {
+          "index": 99,
+          "value": -14.662511622769625
+         }
+        ]
+       },
+       "encoding": {
+        "tooltip": [
+         {
+          "field": "index",
+          "type": "quantitative"
+         },
+         {
+          "field": "value",
+          "type": "quantitative"
+         }
+        ],
+        "x": {
+         "field": "index",
+         "title": null,
+         "type": "quantitative"
+        },
+        "y": {
+         "field": "value",
+         "title": null,
+         "type": "quantitative"
+        }
+       },
+       "mark": "line",
+       "selection": {
+        "selector001": {
+         "bind": "scales",
+         "encodings": [
+          "x",
+          "y"
+         ],
+         "type": "interval"
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbEAAAFMCAYAAABF3IJ2AAAgAElEQVR4Xu29DZAd1Xnn/e+R0IxiY4SDIZgYSREmTrBBsiPx+qOCVK/DOmgwkl3CV/baEmBlKx+shJ2EkeO1RlSWuYpfWxJO5S0HCMLZtQZerzVEI0wS20gpr1mDjYbAvuvFBAlXbIK/GMAGfU5vPfd2z5zb033v6fN03zn3zv9WUcDcc/o+/Xuec/59Tp/znAD8kAAJkAAJkECHEgg61G6aTQIkQAIkQAKgiDEISIAESIAEOpYARaxjXUfDSYAESIAEKGKMARIgARIggY4lQBHrWNfRcBIgARIggaJE7EwAPwcQEikJkAAJkAAJtIuAVsTOBnA7gJcAvA7AlwDsaZfx/B0SIAESIIHZTUArYhsBXAXgWgDvAHAXgF+f3Uh59yRAAiRAAu0ioBWx8wGMAfg6gHcB2AXgM+0ynr9DAiRAAiQwuwloRexKAH8L4K8BXA7gBIB+QTo0NDQYBME2E++5556LK664YnYT592TAAmQAAm4EAiXLFnSk6yoFTGZPvwugB0AZHHHiwDOA/CjNAur1Wo4MDCg/U2Xm7eq8y//8i8CifZZ0ZpeiPwcwUXVyI/8dAR0tX2OvzAMg6effnoirX/Wdth/DODXAPwhgIUAvgXgAgCnKGK6gEqr7XOQib20T+dz8iM/HQFdbZ/jr0wRk1HXfgDybkw+t0SrFVNpciTWvUFGEdP5lvzIT09Ad4XZKmIxtdcD+DGAk80wUsS6N8jYCet8S37kpyegu8JsFzErehQxK0yZhXwOMnbCOt+SH/npCeiu4HP/UuZ0Yi5qFLFcuKYV9jnI2AnrfEt+5KcnoLuCz/0LRczStz47kZ2cpRObFKN/dQzJj/x0BNxrU8Qs2bGRWoLKKEZ+5KcjoKvN+OtefhQxS9+yEViCoojpQJEf+ZVCQHdRn/s/ipilb312IqcTLZ3I6UQ9KIpsKQzZv7hjpYhZsmOQWYJiJ6cDRX7kVwoB3UV97v8oYpa+nUknXvWJe5fef+u1kkw58zOT9tkgpH02lOhfHSXym438KGKWXp/JTvjqgb17JoJg7MBQRU4CSP3MpH02CGmfDSV2wjpK5Dcb+VHELL0+U53wmsF9C069cvyImDk3CJeNVNcfTTN5puyzxMfcibag+JCiJMWHvDIA+ty/UMQsPT5TTrx6YO/GEIGcCACEGBndUVlLEbN0Wo5iM+VfWxNpny0pipiOVOfxo4hZenymOpH+geEHAayMzQyCYO3+oQ+MJM2eKfss8XEkZguKIzElqc7rhMVitl93t1PELNnNRJCtGdi76BSCIyHwQoBwFxBsQ4jxufN7F48Mrh03TZ8J+yzR1YrRvjy0ppclP/LTEdDV9jn+KGKWvp0JJ/YPDMtCjs0Bwrv3V9dv7B/YexAI5Pjr3aPVyhaKmKXzLIrNhH8tzJosQvvy0OJDgI5WZ/GjiFl6eyY6kdUDw0cCYBEQrhqtrj8Yj8zqJtf/Fps/E/ZZouNILA+ojLL0rw4i+XUvP4qYpW/b3Qiu3nrPmjAM9wF4ZrRaWRSb2T+wd1CmFUPg6IFqZTFFzNKBLYq12795raZ9eYk1lie/7uXXDhF7FYAeAC81w8ijWBrpyN6wEMEGINw+Wl0/aH7bPzAsy+wXTvT0LIs3QbORdm8jlTujf+lfHQFdbZ/jr0wR6wNwJ4CzAEwAOAxgWxZKitgUmdresGPHn5e/zEW4OLk3LH5XZr4b8znI2AnrOhDyIz89Ad0VfO5fyhSxjQBWAPgDAAEA2d90H4DTaTgpYlNU4r1hIXDfgWplTZKXpKHqmZg4bE4p+hxk7IR1HQj5kZ+egO4KPvcvZYrYLQB+C8DbAPwrgE8C+ApHYq2Dqf/m4cMIsDRAeN3+6vo9aTWSU4o+Bxk74dY+b1WC/m1FqPn35Ne9/MoUMcky8dsArgKwDMCnAVwoy+qGhoYGgyCYNrW4bt06HekuqH3wieew76HvY/68OahueGvmHX35oe/j0BPP4Yo3n4f3vV2w8kMCJEACs5fAkiVLZMav4TPtDznxfBbAcQBbo3rPAXgngKfSrsPpRKC2hD4MZBS2ICszR8wuOaXIJ82c0ZkoTn7kpyOgq834c+dX5kjswwA2AXg3gF8F8BCA1/OdWLaz4hRTWe/CkjXNKcXP3fC2w2lPIu6hUWxNNlIdT/IjPx0BXW2f469MEesFcFs0nfhytDJxOAvlbB+Jrd46vCUIsVNSTJ3R17somVYqjZu5SnH3puWbKWLuDdXnRip3RfvcfUt+Ona+8ytTxGJyZwN4MWsEFheazSIWTw3WWTRm4mgWfuaU4m2bli+iiLk3VoqEOzvfOznap/Ot7/zaIWJWBH0Ssfo+rWNbzE3GZXZy8WrEtJyIreDFU4p/+r5L8Nsr3qJ9j9nq52rfSzYRhBMLslZOpl2kTH5WRrcoRPt0FMmP/HQE3GtTxFLYyT4tOf5Eku7GX5fZSPsHhkP5nbl9vWfbTCOaJsdTipdffA4e/t8/WRMGwVIgXIkQS0d3VGQUXOin4ZDOlGz6WT9WJr8ibpD26SiSH/npCLjXpoilsFs9MDwShFg4uqMiWwNqn7Iaaf/A3pVAIGeGPTZarSzN68rGqcjG2qPVSuEjs/6bh/chQLwBe1o2fYpYXg/alS8r/ux+vXUp2teaUbMS5OfOjyKWYGemfDJFoKwgmxKx8NBodf3k4Zd5XCpTivPnzVn4yolThwDIcS0yglyYlrIqz3WTZWNb6+eb1dKJwczfyEaqodu8blnxV5TFtE9Hkvzc+VHEEuzilE/1P08tsigryOKs9C7vw2LTRXg/8+FLn48XdkydO2a/SKRVCMlvnDx2/LAcDRMGuCkI5YgYbBbRHK1WVrWqXxa/Vr9r+z3tsyWVXo78yE9HwL02RSzBrjaVCFwjfzbTPpXVSKdEbHq2+jxuNe0rQ8SmlvPXR4yRqB2VEVmz9FjxPZTFLw8jjhSLojX9OvSvji35ufOjiBnszKnE6M+T73zKCrJYNFtl6Gjl4oSI1c4cSzvGpdV10r433ts1TB8aiYqPntHXu6zZopSy+LncT1od2qcjSX7kpyPgXpsiZrAzOuXonc/Ue6qyGmlRo6ayRMycRkw/22yvvIO7opVglsXPPfQba9I+HUnyIz8dAffaFDGDXTwqit757JSv4sUdZTXS/puHn5dcidpFGKZ9sRgHCO82twm4hImxGjF19aS5OrLZFoGy+LncE0diRVGbug79q2NKfu78KGIRu4aDKPt6zz517PiYeXpyWUEW7xHTLodPjMSiZfvuKx4FS/y+rpYKC+HS5OGccdiZ4n9gqLKLIuHeILNqlhV/RVlK+3Qkyc+dH0UsYpc8iDL5rqqMIDNGMc+MViuy2s/5U7SIme/BWqXCkgweYRjuQ4gxc2+deTNl8HOGlVKR9ulokh/56Qi4156VIhZl5ICZNmlStKKDKJOrBstopEXsEYtdn7RPM8Izj4Rp9a7LGI2Ny0rFrH1jZfBzD/vpNWmfjib5kZ+OgHvtWSdiV988vDMMsKWGLMTI3Pm918l/njp2/Hn5d/xeZ3J0gfqUXBmNtMh3V0WKWJzL0fZImPrU47BMI27Oeg9XBj/3sKeIFclOrkX/6oiSnzu/WSViqweG7wqAWj7EOOtECBztCTEiwmZ22rXRCIIjCDEuOQjLCLKi9oildSJxYuC8C0aMzdfPzO3rXWqby3FyajTilQzJMvi5hz1FrEh2FDE9TbYPd4azQsSipLV3Sc4/Ea+eINg4J5wYO4VgBMBlMb7kpt3VA8O1KTIZnZkZMdxxN9a8emDvnhDBBlkNmbUgwva3po/EJpe+rxqtrj9ocx3XI2Hia/cPDMtimMvSNj+zkdp4ILsM+ZGfjoCuts/xNytEzJgeeyHs6Vl5/63XSmdb+xgHS07LIm/u4dq9acWDRZ/XVdQesfSRWH4R0xwJIzYkF8eYzcbnRsCRhK6DIz/y0xNwv0K7ROy1AH4B4HiWqWWdJ2bkQnxmoqdnjSlgsS3R+VhrknuqjFRL23dvWrGtaBFbPTB8RHIR2ibRbebmlJFYrqwdrtOIpk0N2xQQLjaX5FPE3BspRULHjvy6m187RGwhgMcBvAfAN9spYpNnXwVYYJPfL2mbObK4bdPya4oWMc0KwqStGhEzpxG1ghpPkSZXNeYRsbo9p9eYh5Lqm2HzK+Sxr2xb0q5P+3TUya97+ZUtYvMA3AtgMYDfb7eIGQsnnI45iTt3Wfxx26bli4oUsXjUIu/oDlQrC3QhNn11WJ6Vj/GI0HY5fTNb41WdwuxAtSJ+r31sO5H+gXsk5+NgvKBGy8W2vq19ttcruhzt0xElv+7lV7aIfRbA1wDcCOCWdopYYq+T9eKGpKvj0dLuTctRpIgVuUcsTSRsrz+1lQDqDdcxu3hlZJ6jbGoPDKcnZPGNcTBocUfJtGrC7ORaEeJIVkeI/MriV6aIvR/1I00+AuABU8SGhoYGg0CyrDd+1q1bV9h9/tdDR/Dwkz/BWxYuwEevfKPzdT83+l089exLuLH/Tbjo/DOdr5Os+PjR53HHPz5Vu6Zcu+iP2Cy2t7r+Hf/wPTz+zDjWvv1CrHzzeYWY8ZXv/AAPPPpDrLj4HHzoisnBWOa1Dz3xHKTOKydO47WvnocLfvmXaja9562vx+++7YJCbOJFSIAEuptA2iBDe7T9QwDOBfBTAMsBPAngQwC+nYayyIUdDUlpEwsM8roxfscjnfwN17xDy2Ty54vcI5Y2EpO/tXrn1mwhRl5OZvnJPXbG5vGskU7i+Jvdc/t6B08fP7GyVRorjX1pdTkS0xElP/LTEXCvXeZI7A0A+iLT7gTwVwD+DsDLZYtY/8DwgwBWFvGOZ/XW4S1BiJ0yqvjU9e/uKhGL7y1PZg7bUEsmBc7q5LKW5ccC3Cwzvq0tNuXYCdtQyi5DfuSnI+Beu0wRM60aBXBrO96Jxe+CapnX+3oX2WacyEIYX0+m5XZtXl2kiMXncDm/rzNtTutEWmXtiBd0aA/kTGOXXOCR1cllZcCP99CVYRtHYu4dRlZNipiOKfm582uXiLW0sKjpxLhTLGIUFhsdjwpaZXNveZNGgSI3Ostl00Use8OzkaW+sAUdyfs3F3hkbRbPOk8tHiUWcSaajV/YidhQ4khMR4n8yuDXkSImU1BmBvoYTPwupqhRWHzdyb1PIcYn5vSsStswndc5rd5X5b1eXhHL2s+V93eblTeTAu/atGJD8sWrsTJy2oGb5vYGc6l+kfa1GsmW9Vsu16XIulCbqkN+3cuvI0VM0iOFAcYOVCu1DPRJsSnj6f2Wv/lqKKsdZf9SEULWJhFLzdpR1oKOZDMxkyhXN751wZt/4+KG6Vgj5dfu0WqlfrKA8ZnMXalcnGPTfNnJ2VDiSEJHifzK4NdxIpZczRZ3fg0r4kro9KST23L7w3dLwt5YyOaEp86KnXI6mPuC7QjNmMqbNgJxdXLGSCxVxMpc0JG0P542/eAVi/HB3728QcRapd0qMkFyK64UsVaEmn9PfuSnI+Beu+NEzJiCqt11nE6q1XlW7ojqNeNGGmdqn3a9EONz5/cutllIYrsROY/NaZ1IVtaOMhd0JG2ObZC9X5//k/dOipg59ZuVsaRZQuE8bGzKshO2ocSRhI4S+ZXBr+NEzJiCeiw+RkWELAyDnQiwIO/5WbZQ404uGgnK0SaXAeGhev1gEYCFcsjm6I7K2lbXjEdCAFKn0VrVT/s+YyS2EggeFDvlYE+pZ+yhK21BR9K+eFrQPHLGZuFG8kw3Fy62dShitqTSy5Ef+ekIuNfuPBG7efhwPTVRuKq+F8zM/DHVWbsjyd9IpbM9iWBMzh6zWcFY9EZnc6RoWp824rMRj6LZmaPnOMGw7RL6qZFvuSmo2AnrvE5+5Kcj4F67o0TMfB82Wq3UpqamVtnJ/5XX0bVqpLEwSeLbM/p6l8XTilEm/QcRYHyip+cmeW8WbwNwyayf5eos+5ILSOIzw9q1/yq299P/5cFQ0kshxNjcIFxbOzXbyOiRdV/mcThlZrVv5V/3JlZMTdqn40h+3cuvo0Rs6om+ccRVF4VwQTxlpnNX/pFYXMMYNWyXDrc2EgqDfTLNGZcJQuwKZQQZjSZtT11udU82Ipb2ENDqukV9/8T/ejIcuPvR+hRwiDG5f5tMIZM+DzE2uqOyrAh7ZOR8GlhpbtNgJ6cjS37kpyPgXrujRCxrGk465xMnTi6yXR3ogsumkRqrDlETqwDRsnF5dxbIadKbzd8u8v1dExE7Ku/r5Lek4w4R3GUjHi6MmtUR+2688zvLeiYmDsflzHdkzepOpqAqYNVpTRQnwrvk90Z3VM6Of9fGv0UzyXM92peH1vSy5Ne9/DpNxGqpmto9FSbut20ExsKTKGrC2qhM/ic67HGX3EOtE42mRHXhVa+dLWJTWTtCBFsC4JoipzFtbY/tMxa1wFbEs1JT2f52XO7qm4d3Tj1YTK1szePfvL9ZVHnb+Cvq9/Jeh/blJdZYnvzc+XWYiA2HcqvtSgprYrUNMhkVnjx2XEY/svxfTieWlYwNn/oU2cSWIqc/bUSsvlIR1uLhHlbNn4SjRR0LRqsV4+yw7F+Ll9rLNKTLlGLyrDIZiYqYAzg4Wq3IAiHrh5QimeS5lm385blmkWVpn44m+bnz6xgRK2ODcB5seYJMbJ0LHB2prq+JWTs+TUQs2vCMeEtCYRus89yXaV/93dwxEfHaCNXmo8neEednBPDMRE/PmnnzzjgqDxqymjReLZnHvzb2Fl2G9umIkl/38uskEYs748L2VuVxa6c2gqn3iPW7tX0PlYeNTVktP9fsHWZ+xrl9vSvjVaPJzfFa+2wYaMrQPg09jrR19Pzm10kiNmPvwyQAOrUTmZyKi6I4HnlogzpvfS0/11WKWfkZzY3UkmnlMx++9Pm0k2Hz3mdZ5bX8yrIrvi7t0xEmP3d+HSRiM/c+rJNFzFwxKdNpo9WKZBdp+6eIRuoypdgsP2O84VpGp7d9dPlOiph7WBThX/dfb12T9rVm1KyEz/w6QsRmIlVS0qE+O7GZyCZEbEamYot6CMh7fIxxnMsLafkZzYM7b9u0fBFFzL2j69T24X7HxdYkP3ee7RAx2YvzIoDTzcxsdijmTKRK6hYRk/uI91nNxNaEIqebkqdFtwp7m7iJD+68sf9N+HfvWlrYyd2tbMv7PTu5vMQay5Nf9/IrU8QuBHAPgB8DOAXgUQB/noWyqYjVMnLMzP6mIjthXRg1r92skYqIyUGhWdniy7SraH6x6Ni827NJsRUvfFlx8Tn41PXvpog5BgNFwhFcVI383PmVKWKfBHAGgG0A+gC8AuACAD9MM7eZiGUdYe9+2/lrdnKQybsk2RN1oFpZk//Oi6lRFL9WB2nG1jYc/NnXe3bWETkN59A1KVcMBberiI2f2bTiCKc73fhJraLiz90C94fQsn4zz3V95lemiM2XFd0AjqG+sfSzAC6K/jaNX5aIGZ3MjC1K6PRGIAsYAmCPmSswTwAXUbaoRmC85zp6oFpZnGVbnrPIykjIXASz+BryLvCP+n9jA6c73akWFX/uFlDEymJXpoiJzfMAbAXwcQAyCvi6/HFoaGgwCMwjVOq3t27dumn3+a0nf4IvHjqCtyxcgI9e+cayOHT1dT83+t0au/nz5nTFfW7f+xh+9vMT+NP3XQI5bDPtc8c/fA+PPzOOtW+/ECvffF7T+/Y9xrYP/3PNd3K//JAACaQTSJup0L4fkCnEewGcAHAjgGebwc8aibXrKI5WgdHJT3KyIGL/0AdGWt1jmd8Xyc9mSjHPFLTt1GOZfLKubU53zkTOS9t7LtK/tr+Zpxzty0Nrelmf+ZU5Evs9WRgH4L02+DJFzDgEs6hjS2zsSZbx2Yli62yyr9WUopmlwzY/49b/94FQRm6+CYWZMDl5Vp1LHKfVkalX7VTzbIq/orib1yE/d6plipgcd7ExYdrFAL6XZm6TkVgt6W+RGd9dcDHIXKhN1SmaX7zxOW2Vos1ILXk3d973zXDfQ9+Xl7j3zeQCmKRd8fs6mU585YTsUpk6FUHnkanasoozDDB2oFq5zvWaRfvX1Y6serRPR9RnfmWKWC5qaSI200l/+aSUy4VNCxfdCJptfG6WpSPLyEfG/v9Q3j3JZyZOSciyK97j98ErFtfeDSPEuKTJylptmddj5lSqZhRatH/z3ker8rSvFaHm3/vMz2sRs9msqnONfW2fnSh3Mdvsy8qlaOSKzLWaVfhtvv2RWqZ/TWduH1GtS5oPcbs3Lb9s8+0Py+GqVwQI795fXZ+c5Wh9wZQSiYwucN0QP9vizwl2k0rk507UbxHzYJNzjJZB5h5kZYlsMpdidJbb4QBYlFeIxL//8Y5HbgpC7PRlStGcFt29afnmj9/+8OJTCI7URosFnHIt14k3e8tmeDmaRkZ6E3N6VuU9JZ3tw7/2obOosbbP/vVdxI5Ih2STnaFIh6Vdy2cnliUSRTItg1/yeBbj2JncZ6aJfZMiEWJ8dEdF0qW15SPimzY9GGccAcJVuzeteFCWEE9No04d6Kkx0twjB2BliGCDywKSv//GWMh9bO6eKKN9uFszvabP9nkrYvFc/UynS+JIrJimUEYjMKcU587vXXXqleNHEGCBdPp5V7LG9vUPDI/VphSDYG27tiWIkJyBcIt5iKr5rkoWNcX2xSeHy6ipiNFYcitCfP95TtGW1aLvv/xXD99wzTu023KKCbaUq5QRf0UaS/vcaXorYlPLpMNDo9X1K91vsZiaDDIdx7L4xVOK8p5IRhGAW7zE9s3Ee9iakABHR3dUlsWUkxlHTH7x6El7wGm8B818UDRF0nYGRJitvOS8nX/y71dRxBybSVntw9GcadV8ts9bEZuaGip+SbGLY3124mydTpT7jjv02Ke2HW8yBiZHOgN7F9XeO7VpStEccZnL55NTpWb85Ump1SzWsx4U856iLeWXnP+aDbs2r6aIuXQus3BhliOm1Go+i9iMnuSc1ckVCb/Ia81WkTVPrtas2jP55cmUr/VhcnVgPBUaT/PFomzaV1SGkawHxbyzIPLu7rWv6V36hT9bSxFzDIjZ2n4dcTVU81jEZvYkZ4pYEeE1dY2yGmlDh65YsZc2XZd3haMLsXj60lwdiCBcCwQPmidxJ/nFp1JrbJy8RuL9Xx6RTL67c2HQjjplxV9RttM+d5JeipgPJzlTxNyDKq1mmY20PqUYjo1W1w+6Wt0gYluHt8hSewCln4RtTt0FYbhG9oHJVKYsUDFHlkl+Rby7izdSp23uzhK4JN/GkWT+BTWu/spbr8z4y2tLu9tHt9vnpYgVNedfhPPia7AR6GiWyU+mv+b0zjuoyWLROJ24d2V9JOS2SCQPqVgsZBpxbl/f2Mljx4/W9msBDRuPk/wmEwM7vrtr9aBoK5LGtgbnjdJ5eLmWLTP+XG0y69E+d4q+itie2n6VADcdGKrscr+94moyyHQsO41fPEopO2dncjRkJC9uSH+Vxk+zHaDVg+KkyLUQySkRlvjwYxEWRzq6ttpp/LwUMXOTZ979PsW7r37FTuuEy+Lget1O4ze5X8phz5kto6wDX6NMHSvNDPzpIrZ3EAi2uSxosTniyGaBS7wApTZyLDAdli1D23KdFn+299Wucj7z807EzPOTyn4KzhMAPjuRIpvHk+llk/7Nu8zcxYKp90nTpy2TZ8ClxV+rI2ma2WTzoNhK6My2Wv+t8qdfXTizfbhSm6rnc//nnYjFc+y+PdX57EQ20uIbqe07Ic0v59kLmRV/NqOlNBttpkuzkizH15va3hDWEhPL33168DTvm+1XE6l+z0R5J2LxMRouqYN0bmpem41AR7fT+E2OkkKMmZk0dBQaa5t5C1sdStlExOSd8eY8KynzHHE0+c4uZfuCOVKbP2/uNjnvzKdjbChixUWrz+3XKxH7xvjCVcn9McW5QXcln53IkZjOt1n8bEYrNr8sI5Y5fX0jydWTNlN68fWz4q/VaCnNvjyjzGZCa66svOj81zz41LMvyZRi7ryVNgy1Zdh+dQR95tcOEXsVgFcATDTDKIdi/vfxhXH+u+2aPT86d6XX9tmJFDG9x5ut/tN2zCIEPQhHkqOtPCLZLP6anXKdRiZ+32ezUbrZKkbT/lv+5qvhw0/+BD6tKOZITN8uWj1EFfcL7lcqU8TOAfBFAKcALATwaQB7skwVEfvG+KLa10Vk53ZHQhErml2nimw8XabtmGtT5PWl6pMJfo19WlbHxjQTMfPcsdFqZUsr/+U5+drcj2aeKJ2ckvzLe/8pfODRH3q7zJ4Poa2iovn3PvMrU8QGAJwJ4M8A/AqAZwHIqOzlNFyxiPlyIGHSRp+d2KkioWtWxdZO82+rvVQ2FphpmczkxPE0oG28N4s/2z1dYu/qgeG7AmBjniOOjGnDyRmS5JTkyNe+Hd7xj095u0KR7dcmWrPL+MyvTBG7A8BXAQzXtpDUpxOXAHi6mYi18xynPG712YkUsTyetB9pa5awx79ibl42V9zmWZlo49/Jjc8Ir8taJGImS84zRWoschmPR2PJd2X/9PDj4V98+X9CDtQ8UK0s1nuk2Cuw/ep4+syvTBG7F4D886UI33MALpdzk4aGhgaDINiWxPqdl5eguuGtOtqsTQIFEth8+yO1q0lczp83J/eVv/KdH6A+zYZa/W3rL6v9+3Oj34UshPjo71yEtyzSHyJ98InnsO+h7+MtCxfgo1e+cZqd33ryJ/jioSO1v3/wisW4/GKZ7bf/xPa+562vx+++7QJsH/5n/Oyl4/jT912CC375l2oXilnt3rTc/sIsSQIFEZCTz5OX0h6r8CkALwKQJcDS+uXgvwVZCzyi6cTSE6668vL5ScTmSd31vouq16n8zBV4Ltlj4vpxlvp4MUWe91I2/m2Wzd9M0muzmCPN5w2jsSBcVkYNbJUAACAASURBVDtzzdgXJv7dfPsjz8j7b9cz3YqKtbTrdGr8lckkz7V95lfmSOy9AP4IwJUA1gH4GIC3Z4ETEfsf4wsXm0e054FcdlmfnWjTyZXNp9X1O5Vfq6wVre47XsEni0MkM3483ZZnZaKtf9OyjNSmRE9PPJjMit/K7gwhq53xB+AggJVmho66iD0cbXr2b5l9p8afi5/KqOMzvzJFbD6A+wH8psykAPgdAN9qJmIDAwPa0V8Z/qtd02cn0j692zP3YQ3s3RgiuMt2AYZpSTJTfLwUXhLlSs7DPGmabOLPWCxSey9VpIDJfaUc4Dm50CMSsfi+uEUmZ0ja+DfnJQst7rN9ZYpYDPENAP4NwMlmVGUkRhFzjzufg6yTRTZeYu6yYCG5unFyMUfKeWGtPG/r3zgNVW3kN4FtRYzATNvMrPXmIiyx7z/e8UhttGmTMk7YtMpS0opJnu9t+eW5ZpFlaZ87zXaImJV1FDErTJmF2AjK4xePoPLuX0xO76UkzLUesdj619gzVgNiIyh5yJmjMTPFVDQSizLuNE8ELMv8ZTqynasYbfnlYVFkWdrnTpMiZsmOQWYJKqNYJ/PLk+OwYdRy8/BhBFhqLmePr1UvZ//uyJafKZRFC1h8b9FobNFotVLPThBNt3/8b//57FPHjj8vJ1OP7qikLrk0RbadeRZt+emi3L027XNnRxGzZMcgswTVhSLmuuk5bfFGw6GXKUl1syjniT8RmQA4ur+6fqPOa+m1ZTQWIthyoFpZY4qYLHFOHvJpXqFxn1rjydVl2GleMw+/sm1Juz7tc6dOEbNkxyCzBNWFImamXsoaYSRvu1mmeHlvFQILDlQrsuXE6pMn/mRBx/23XjtmdWHHQnJ/5paD2L6sLQkJAXsMwGXtPAk6Dz9HJKpqtM8dH0XMkh2DzBJUF4qY3FLec7umMnJg2t7H+ncQEVhpS7VT4i9t6tVcJSkLTnoQHA3DcF+e1Zm2nIoYyWp/y6V+p/jX5d7KrkMRsyTMILME1aUilvek52bv0aKR3RabZL0xzk6Jv2Q6rdoILAx2mqskJzdmN3l3pou26bU7hV/R913U9XzmRxGz9LLPTpRboH2WjnQU2al3Wc1X3sWXb5WRI++UX6f41+SEMHgeAWrvzZKLTPKObHXeZfvoZn4UMUvvdkonYnk7bS/W6fzMtE6j1UrTTfnG3rIX8rz3auaUTuGX3BAt6bZ6EG5J7gnLc6ZZEcHaKfyKuNcyruEzP4qYpcd9diJHYpZObFLMxr9xpvjk0vj66GNiPF7okHfUZmO9jX021ymrjGlfvEIRwGNzEa5JSyWX53TpImzuJH5F3G/R1/CZH0XM0ts+O5EiZulEvYhJMuvN5qo6I7WUXP3gXITXnQI2RmmlrDczt7qDToq/+lRhuKfZ6ezGGWhj5mGhrTi4ft9J/Fzvscx6PvOjiFl63mcnUsQsnagUsckRVohax1ubYnzluCTXXdpw6SitVJ7NzK3uoJPiT6ZTbRJ5N9tT1opH3u87iV/ee2tHeZ/5UcQsI8BnJ1LELJ2oFDGpbna8p44dl6Xym+Nps1MItkT/X/ulIjNSdGP8aY+5yeP1buSX5/61ZX3mRxGz9K7PTqSIWTqxEBHbWzuORFbbhQg2yCXN87NkFHIaGAwRrDTTMmkt7Mb4y3u6tYZhN/LT8Mhb12d+FDFLb/rsRIqYpROLEbHB+vuu+kc27x4Yqsi7soaPTDWODK4d11tWv0I3xl8ZC2CyeHcjv6Jiy+Y6PvOjiNl4sEs7EctbL6SYz40gj0g0LuSw2zNWBMBu4WeyaOem527kV0Rc2V7DZ34UMUsv+uzEPJ2w5e0WXqyb+MnRLALojL7eRUWOtppB7yZ+5n22a9Nzt/IrvKFmXNBnfu0QMTmS4UUAp5sB53liunD0Oci6TWTrKaXCXWYCXJ33WtfuVv+2a9Nzt/JrHTnFlPCZX5kidiGAewD8GMApAI8C+PMspBQxXbD5HGTdJmK2S8h1Hm2s3a3+bdem527lV2SMdepMQJki9kmZcQEgL8H7ALwC4AIAP0yDRRHThSMbKfnpCOhqu8ZfuzY9u9qno2Jfm/bZs0qWLFPE5sviLQDHAFwD4LMALor+Ns1iipi7E7ttpKMj4VabnYgbt7iWhp+8YwyAs4rcHJ68G419OjJ2tWmfHae0UkWK2DkAqtGPfAHAPwGYB2ArgI8DtWzWX5fvh4aGBoNgaplybNi6devc74Q1SYAEOpLAV77zAzzw6A9x0fln4sb+N3XkPdDomScgJ4snrWiaqTvF5LMAXB/9/WsAngRwL4ATAG4E8Gyz2+RITBcEfJIjPx0BXW1N/MlS+5PHjh+V0dhchIttUlbltVZjX97fcilP+1yo1esUORJLWvF7kqUHwHttzKOI2VDKLsNGQH46Arra2vjrHxiuJVdOnjums2qqtta+ouzIug7tcydcpojdhVo274bPxQC+l2YuRczdiVKTjYD8dAR0tbXxF5/BJlaUMRrT2qej07o27WvNKKtEmSKWyyqKWC5c0wqzEZCfjoCudhHxZ+wZu3t/dX3yAVhlYBH2qQxoUZn2udOliFmyY5BZgsooRn7k14pAmaMxxl8r+s2/95kfRczStz47kdOJlk5sUoz+1TEsil9Zo7Gi7NNRyq5N+9zJUsQs2THILEFxJKYDNcv5lTUaY/vVhaXP/Chilr712YkciVk6kSMxPag2iGw8GgOwe7RakYNG1R+2Xx1Cn/lRxCx967MTKWKWTqSI6UG1QcQmR2MhxufO711cxEkBbL861/vMjyJm6VufnUgRs3QiRUwPqg0iJj/RP1A/QRsIt49W1w9qDWf71RH0mR9FzNK3PjuRImbpRIqYHlT7RGwlEDyIgkZjZvvtH9i7cqJnzvj9t147VhqQnBdm/5ITmFGcImbJjkFmCapNnZzOmum16V8d0TL4FTkaaxSx4QflbkerlVW6uy6udhn8irPO72QKFDFLTzPILEFRxHSgyG+SgIyYihqNxe138poAAoTX7a+u31OKw3JelP1LTmAcieUHxiDLz8ysQX7k50KgqNHYlIjVRmEra7YUNFXpcl/JOmwf7hQ5ErNkxyCzBMWRhA4U+TUQKGo0Ju138+0Pr5KRXQi8ECAcK3LhiNbp7F/cCVLELNkxyCxBsRPWgSK/aQSKGI3VReyRg/VRWLh9omfOSM/ExGH5sTISDucNAvYveYlNlaeIWbJjkFmCYiesA0V+aSKmfjf2998YCz83+l05av6FM/p6F8nes/j4FwAHZ3qRB/sX92ZDEbNkxyCzBMVOWAeK/FIJTI3G3LJ4bNl9IHzq2ZfkRdjkvjPzMM4gCNbuH/rASCnOs7go+xcLSBlFKGKW7BhklqDYCetAkV8qgas+ce9S1+m/+L2aOQqLf2T11uEtQYidIXD0QLWyuBTnWVyU/YsFJIqYOySpySAjPx0BXW3GH+Ca4X71wPBIAFyTlf2jf2D4KICFEz09y2ZqAzT9694+2jUSey2AXwA4nmUqD8V0dyJFVseO/DqDX1qGe/nb6SBciDBYnLXnq39gOJQ7nNvXe3ZaHkbj3VhhCYfzEqWI5SU2Vb4dIrYQwOMA3gPgmxQxd2c1q8lGoONKfp3BLxYcmf4LgEWm1aPVSpC8i3gq8aLzz8SuzaunfS/l46nKmZxSZPy5x1/ZIjYPwL0AZK759yli7o5qVZONoBWh5t+TX2fwMxdjRBY/EwILAuCstOnA+J3XiovPwaeuf3eqiMl1ZnpKkfHnHn9li9hnAXwNwI0AbqGIuTuqVU02glaEKGI6Qv7wq4+cTi8Yra6XfV+T78rCADcdGKrsMi2N36OtffuFuOGadzQTMam3ucgzzPLwZvvNQ6uxbJEidg6AanT5LwB4HWovU/ERAA+YIjY0NDQYBMG2pNnr1q1zvxPWJAESmJUEDj7xHPY99H3IaOtDVzQuMPyLL/9P/OCnL+PG/jdBphSzPrL8XvaRvfbMXmyrXDorOXb6TS9ZsmTaQ0rmU0vGzZ4F4ProOxl9fR7AuQB+CmA5gCcBfAjAt9Pqc2GHLoT4JEd+OgK62jMZf0ZqqrHRHZVl5p3Eizp2b1qOtE7OLLt6YHhcpiVnIoPHTPKz8bzP9hU5EkuyeAOAvuiPdwL4KwB/B+BliphN2OQr43OQyZ3Qvnz+TJYmv+b8YrEyF3cYGesf271p+WWtRCyeekybltR5r3Vt+rc1o6wSZYqY+ZujAG7lOzF3R7WqyUbQilDz78mvs/n1DwzLAZeXAeGq+F1ZvKgjQHj3rk0rNrQUsa33rAnDcB9CTBvR6ei0rs34a81opkWspYWcTmyJqGkBNgLy0xHQ1Z7p+EsbRU0uxw9w020fXb6zlYgJgZmaUpxpfq2877N97RqJtWIEilhLRBQxHSLy62J+5qhrf3X9RrlVI/v9qt2bVjxoI2IzNaXos0gIS5/to4hZNmyfneh7kNE+yyBrUozx15zhZG5FYyrQzNTxmQ9f+ryViM3QlCL9695GKGKW7BhklqAyipEf+ekItK5titaJEycXRQmDnxmtVhbZxp9spj517Pjz8mtpGUBaW+FWwtY+t6vra/lsH0XM0r8+O5EjHUsncqSjB+XxQ4o5fSgpqUIEd4XAfQeqlTV52m/aIpHSwEUXzmNf2bakXd9n+yhilhHhsxMpYpZOpIjpQXktYsNR1o1wOxAsqGfgqJ8flqf9zsR7sTz2lebEDm0fFDHLiGCQWYLyuJNrdgf0b+f79+qBvRvj0VeAcAEQXBEvuc/j33iRSDtTUOWxT+cpt9o+20cRs/Spz07kSMzSiR36pEn/2vnXzEYfZ7iPj1/J036nNkmHh0ar61fa/bquVB77dL/kVttn+yhilj712Yns5CydSBHTg/J8pB0v7ojMrC3qyNs+ZmJxB/sX99CkiFmyY5BZgvK8k8u6C/q3O/w7tbhD7mdqJJXXv/HRLO3Ko5jXPp238tf22T6KmKU/fXZi3idNy1sutBj56XCSnx0/45RmEbHaog6X9hGLYRAEa/cPfWDE7tfdS9G/7uwoYpbsGGSWoDgS04EiPxW/q+PNygBMAcrbfvsH9g4CclzUlBCqDGtROa99ZdqSdm2f7aOIWUaDz050edK0vO3CipGfDiX52fFbM7B30SkER6S0ORWYl9+UGLZncUde++xoFFfKZ/soYpZ+9tmJFDFLJzYpRv/qGPrET5L4yt0cqFZkr1jtk9e+WAxD4OiBaqXxpE0dqtTaee0rwYSml/TZPoqYZTT47ESXRmp524UVIz8dSvKz51d/nyVpo6aWx7vwM9NYjQyurQljWR8X+8qyJe26PttHEbOMBJ+dSBGzdCJHYnpQGVfwqX3U32fVRKz2b9f2Yaaxis8oKwugT/woYo5e5lEsjuAUjVT3i/lqs5Hm45UsTX72/OR9lpQ2VxW68DPPIzswVJGUVqV9XOwrzZiUC/tsXztGYq8C0APgpWbQKWK6kPQ5yFyfhHVE8tUmv3y8fBZZeZ91omfOgvtvvVZOe3YeiaWdUaajlF2b8edOtkwR6wNwJ4CzAEwAOAxgW5apFDF3J1IkdOzIj/zSCEymnzLOKNOTSr8CRcydbJkiJqerrgDwB7JlA8BaAPcBOJ1mLkXM3YnshHXsyI/8sgjEizvKPluMIuYeg2WK2C0AfgvA2wD8K4BPAvgKR2LuzmpWk41Ax5X8yC99NDZ8FMDCiZ6eZeb0pI7W9NqMP3eiRYrYOQCqkSlfAHAdgN8GcBWAZQA+DeBCyQUzNDQ0GASyG77xs27dOvc7YU0SIAESKJjAHf/wPTz+zDg+eMViXH6xdHH8+EpgyZIlMuPX8Jn2hxbGy7uv66MyXwMg04nHAWyN/vYcgHcCeCrtOpxO1IUGn+TIT0dAV7tb469d6ae6lZ8uquxqFzkSS/7ihwFsAvBuAL8K4CEAr+c7MTvH5C3FRpCXWGN58iO/NALtOluM8ecef2WKWC+A26LpxJejlYnDWaZyJObuRKnJRkB+OgK62t0af5O5GEOMj+6onK2jlF27W/mVxcu8bpkiFv+OOP7FrBFYXIgipnM3GwH56Qjoandz/EkuxgA4q8yzxbqZny6yWtduh4i1tkJWhFSr4cDAQN73cFbXLqIQg0xHkfzIT0dAV1sTf+1IP6WxT0fGrrbP9lHE7HzI6TpLTlnFfG4EnI5VOrfLp7PbsbiD7cM9BililuwYZJagMoqRH/npCOhqa+IvPlssBO47UK3U8jIW/dHYV7Qtadfz2T6KmGUE+OxEjiQsndikGP2rY9jN/K76xL1LeyYmDpd5tlg389NFVuvaFLHWjGolGGSWoDgS04EiPy/5lX22GPsXd7dTxCzZMcgsQbET1oEiPy/5lb24g/2Lu9spYpbsGGSWoNgJ60CRn5f84rPFgHC7edhmUcayf3EnSRGzZMcgswTFTlgHivy85Hf1wN6NIYK7ylrcwf7F3e0UMUt2DDJLUOyEdaDIz0t+8eIOlHS2GPsXd7dTxCzZMcgsQbET1oEiP2/5lXm2GPsXd7dTxCzZMcgsQbET1oEiP2/59Q8MjwG4DAhXjVbXHyzSUPYv7jQpYpbsGGSWoNgJ60CRn7f8rh7YuydEsCEMcNOBocquIg1l/+JOkyJmyY5BZgmKnbAOFPl5y2/11uEtQYidAcK791fXy3mJhX3Yv7ijpIhZsmOQWYJiJ6wDRX7e8ps8W6yExR3sX9zdThGzZMcgswTFTlgHivy85tdqcUf9/LGeDQjDNaM7Kstsb4b9iy2p6eUoYpbsGGSWoNgJ60CRn9f84sUdEz09y+6/9VpZ6IE1g/sWnHrl+AYAGxFgaXwDo9WK9dFSZfYvsj0gttUVbpn2udoU12uHiJ0J4OcAwmbG8jwxnSt9DjK5M9pH/+oI6GoXFX+rB4ZHAuCaAOF1+6vr99Qy3E+EdyHAArEwBF6Qf8shmqbQtbK+KPvSfkeyjQQIx8TeVnZkfV+mfa42tUPE5ETn2wG8BOB1AL4EIBMiRUznSp+DjCKm8y35+cMvPltMFncgDJ4PA2ypWxceCoA9IhQueRbLbL+rB4aPiIUHqpXFriTLtM/VpnaImKzeuQrAtQDeAeAuAL+eZTBFTOdKn4OMnbDOt+TnD7/JxR2GSckl9y5L8ctqv5OZRupC67y/rSz79J4FypxOPB+AzBl/HcC7AMi+is9QxIpw2/Rr+Bxk7IT1Pqd/dQyL4ld7/3Xs+PORNY9N9PRsTL5vcjkJuij7kpTibQHR3w+OViurXEiWZZ+LLck6RYrYOQCq0Q98AUAfgL8F8NcALgdwAkC/fD80NDQYBMG2pDHr1q0r4p54DRIgARIojcD2vY/hote/Bu97+4WYP2/OtN/51pM/wRcPHcFbFi7AR698Y2l22Fz4c6PfxVPPyhud+ufG/jfhovNlmUL3fZYsWTJtIY31ypoIx1kAro/++2sAbgLwXQA7AAi1FwGcB+BHafg4nagLKp+flOTOaB/9qyOgq11k/LVa7Tc15RgeGq2uX2ljeZH2xb+XGDXuBrDZdaN2GfbZcLEpU+RILPl7fwzg1wD8IYCFAL4F4AIApyhiNq7JV8bnIKOI5fNlWmn6V8ewnfzqe8WCIwgxPrqjIgvcWn5M+0R8RgbXjres1KJAfHyMLDqZ29e3Jp4GnYtw8Uh1/dE8128nvzx2SdkyRUxGXfsByLsx+dwSrVZMtZEjsbyuayzvc5BRxHS+Jb/O49dqU3Tyjsz22z8w/GA0YrJeEp8mfMkFJvH/u4zGfO5fyhSx2E+vB/BjACebhSJFTNdQfQ4ydsI635Jf5/HrHxiWkc5C271iCRGr76kNMTJ3fu91zUZl0Ubr2j615KKN/puHn5e/xyOvyREigLyjMZ/7l3aImFUEUsSsMGUW8jnI2AnrfEt+nccv716xuP0ml/CHwNGwp2dtWsaN2vL50xMiYLUsIfEGbPlvY2n9M6PVyqKYYDwaA8Lto9X1g7Zkfe5fKGKWXvTZiezkLJ3YpBj9q2NIfo388u4VM0RsEAi2yZRfiEDE6bKaQIXYhZ6Jkf1DHzwk/18TuzDYF2UKeaa27iDE+Nz5vYtl5CZZOmQhB4Ddo9VKtCE7qofgwTzv63zvXyhilm2XjdQSVEYx8iM/HQFd7XbHX969YrF9ybRWhhjVAYQYR1Dbf1tb9RgC953R17vx1LFjI0BwRfy+q//m4cP1Edr0Dc5x/scgCNbuH/rAiA3ZdvOzsSkuQxGzpOWzE31/UqJ9lkHGkaIelCcPUfHKQBGZA9XKmlY3NjkSS7zHmhx1IZBriHDVRmaRok1OCZrvu2RaMURwl+RxPFCt1HI6mp8pgW0cpTWz0ef+jyLWKrqi7312IkXC0okUCT0oT0Qi7420u/3m3Ssm9n389ocXy9L8LPGRexaxOi1iFvSMJ0dRk+JUH60tyBLQ+H2ZvG+zzafYbn55/EsRs6TlsxMpYpZOpIjpQVHErBjm3Ssm/cuWO769NgzDfbKvy3aT9PRRVn1VpPzdXOiRVc5l9aQVgDYWoohZwqaIWYJiJ6cDRX5dwy/PXjHpXzbf/kgtq0belYOJqcKVkIUbsoy+r/fsrOX5eVcp+tz/UcQsm4zPTuRIzNKJHInpQVFkrRnm2StWF7GHD8niDE22eTEuEqilo9XK5AGdSaNr56DJqC/EWPIEapkKDYBF5vljPvd/FDHLkPTZiRQxSydSxPSgKGLWDPPsFYtGYrVrNxtB2fy4bIA+fezYmlaHYMYjRXPjs9Q9eez4Yfkd832Zz/0fRcwmKpjA1pJSdjGfGwEfAtTuZYLnFIR59or9/TfGQsk4D+CxZiMovaemrpBczi/fmEv6zXdqPrdfiphlVPjsRHbClk7kSEwPiiMxa4Z59orded83w30PfV8WY9y9v7peDhQu/ZPcBjDtwE9jqtHn/o8iZhkqPjuRImbpRIqYHhRFzJphnr1it/zNV8OHn/wJkqdEW/+YQ8GGXIp9vWfLNKK8C5OFJUAgQrowfj/nc/9HEbN0vs9OpIhZOpEipgdFEbNmmGev2Ef+877wZy8dh+2Sd2sjWhSMs3fIAo8oB2NtOtPYEF07Ddrn/o8iZhkNPjuRImbpRIqYHhRFzJqh7V4x8/DK0Wol72HE1vakFVy9dXhLEGJn/F0sotECj6MBcJb87XM3vO1w2snJqh8vqDJFzBIkRcwSFDs5HSjy6yp+NnvFJpe7KzY5u0Izst1LJsaGzPbxaEze0+3atGIDRawFZR7F4hqG9XoUWfLTEdDVZvyl87PZK5ZnAYjOS01tHE+uijTfmW2rXIrlS3+zraNE23steiT2agC/qCdXnvy8CsArACaaGUURs3VZejl2IuSnI6CrzfjLEoi9B1ttYI73k+XJKq/zVmNtWVY/0dOzJ+3MsnibwIqLz8Gnrn93V4vYuQAuBfBlABcB+BGAcwB8EcCpKJfXpwFkHrdNEdOFJTsR8tMR0NVm/KXza7VXLDqZ+Yh5ArPOE/lriw1Z6ani0dj8eXNwsmduZhqr/L9aXI2iRmLvB/BOADcBOC8SsQEAZwL4MwC/AuBZADIqeznNfIqYzqnsRMhPR0BXm/GXORKrHXKZlQ8xnkq86PwzsWvzai9HOvGm6HYu/88TjUWJWPybMo0Yi9gdAL4KYLiWULk+nbgEwNMUsTwusivLTsSOU1Yp8iM/HYHMkdjG6GyvaeeKmaOwG/vfhH/3rqVeili88CTP0S1lsMy6pquIyUa4dwF4EcDHjIubInYvAPnnS9H3zwG4HMDRoaGhwSCQp5PGz7p169p57/wtEiABEiiVwFPPvgRJJyUjLREq8/Plh76PQ088l/pdqUY5XHz73sfws5+fqN2D3IuPn7TVk82eCq4EcEk0Nfj5DBH7VCRyuwDMAfA8ADllNHWBB6cTdWHBkQT56QjoajP+0vll7RUzV/75vg9L7uwv7/2n8IFHfygr9qxOqtZFU77ariOxzJGdMZ34XgB/BEAET4ZYMmJ7e1ZFilg+xyVLsxMhPx0BXW3GXza/eK8YgINzEV43Ul1/NF7wEedK9J3fE//ryXDg7kdrN2lmvddFTTG1yxAxWan4YwDzAdwP4Dej//4dAN+iiBXjOIpYsRx970Ron87fM8lP0k+FCEYk+wVCjAMYRACZoZoUhJm0z4as2Lfl9ofvDhFsSC5SkQ3Tco20Jfo219aWKVrE0ux5A4B/A3CymbEcielc2QmNwNcd/0Ke/Bh/OgLNa0dpnPYEwDVTJacyZHRC/G2+/eFVcmq0ucCjf+AeWXk5KPdkHt1SJsvktdshYlb3QxGzwpRZqBMaAUXM3cf0rzs7nx5S4lyFIfDCGX29i+L9WZ3i3zgDSRBiVwisjJIGG7qMLaM7Krt13spXmyJmyatTgszydtpejPx0yMmve/jJ9NucidNLzZOXO8W/8fEyhjceA8ItcoSLbCWQv4fAngPVynU6j9nXpohZsuqUILO8nbYXIz8dcvIjPx0BXe04/szs9sl3Y7KfbCIMZcr0LHMRi+6XW9emiLVmVCvBTsQSVEYx8iM/HQFdbcZfcfxkSjQMeg6mLeSQUWYwMXHQXMRS9vQiRczSt2wElqAoYjpQ5Ed+pRDQXTRP/zdtEUuIsYk5PdeVtXqRImbp2zxOtLxkocVonw4n+ZGfjoCudjfGX3SytSR9XyhbC+bO712clWhYQ48iZkmvG4PM8tYLKUZ+OozkR346ArrarvFnjsrijd06S6bXpohZEnV1ouXl1cVonw4h+ZGfjoCudjfHn6TYOolgrL7gI1w1Wl1/UEersTZFzJJmNweZJQJVMfJT4ePCIh0+8pthfpOnV4cYG91RWaY0p6E6RcySJjthS1AZxciP/HQEdLUZfzPPL94onXW2mquFFDFLcmwElqAoYjpQ5Ed+pRDQXbSI/i9a6PFgbZFHDG7oygAAECtJREFUEC6TRMg6q+q1KWKWFItwouVPORWjfU7YJiuRH/npCOhqz5b4i0+JRoiR0R2VtTpqFLFc/GZLkOWCkqMw+eWAlVKU/MhPR0BXu6j4Mxd5hAFuOjBUqWXz13w4ErOkV5QTLX8udzHalxtZQwXyIz8dAV3t2RR/Zv7FIjLfU8QsY282BZklklzFyC8XrmmFyY/8dAR0tYuOvzibv7wfm5jTs0qTzYMiZunbop1o+bPWxWifNarUguRHfjoCutqzMf7i0621Cz2KFrFXA/hFPRv/5OdsAC8CON3MzTxPjI1AR0BXezZ2IjpijbXJT0dztvLrH9h7EAiugGL/WFEidi6ASwF8GcBFAH4E4EIA9wD4MYBTAB4F8OdZrqaIsRHoCOhqz9ZOREdtqjb56UjOVn7m0S5z+3rPdsmtWJSIvR/AOwHcBOC8SMQ+CeAMANsA9AF4BcAFAH6Y5m6KGBuBjoCu9mztRHTUKGLkpycwORpzTElVlIjFdyLTiLGIzY+mFY8BuAbAZ6NRmjnVOEmAIqYLBnbC5KcjoKvN+CM/VwL9A8OyzH6zayYPVxHbCOBd0buujxnGmyImf54HYCuAjwNYA+Dr8sehoaHBIAhkhNbwWbdunSsH1iMBEiABEuhAAgefeA77Hvo+Vlx8Dj50xWLnO1iyZEmQrDztD0aBKwFcAuBlAJ/PEDGZQrwXwAkANwJ4tpl1HIk5+65WkU/C5KcjoKvN+CM/VwKT6agQHhqtrl+Z9zquI7Gs3zFHYr8HoB/Ae22MoojZUMouw06E/HQEdLUZf+TnSkAWd5w6dvx5qT9arTQbPKX+RBkiJisVZUXiXQBk2tH8XAzge2mWUMRcQ6Bej50I+ekI6Goz/shPQyDOcD8X4eK8iYGLFjHn+6CIOaOjiOnQkR/5FUBAd4nZ/hAQr1AMgmDt/qEPjOShSRGzpDXbg8wSU2Yx8tMRJD/y0xHQ1S47/iYPzUS4fbS6fjCPtRQxS1plO9HSDIqEFlRGffpXB5b8yE9DIE4KHAL3HahWZCW79YciZomKjdQSFEVCB4r8yK8UArqLlt3/GQdmjo3uqCzLYy1FzJJW2U60NIMjMS0oikQpBNk+dFjJD+gfGK4lwsi7QpEiZhl7DDJLUBQJHSjyI79SCOgu2o7+r39geAzAZRM9PcvyHM1CEbP0bTucaGlKajHap6HHLQo6euRHfloCwOqB4ZEAuCbvQZkUMUv2FAlLUBxJ6ECRH/mVQkB30Xb0f64rFClilr5thxMtTeFITAOKIlECPY7EtFDZvwBXb71nTRiG+5Az/RRFzDL6GGSWoCgSOlDkR36lENBdtB3931WfuHdpz8TE4RA4eqBasc4ETBGz9G07nGhpCkdiGlAUiRLocSSmhcr+pU4wa4XimoG9i7LSUVHELKOPQWYJiiKhA0V+5FcKAd1F29X/pR2QefXNwztDYGXW/jGKmKVv2+VES3OmFaN9ruTq9ciP/HQEdLUZf3V+Vw/s3RMi2BAGuOnAUGXX6oHhu4Iokfzcvt6zRwbXjidJU8QsY49BZgmKIwkdKPIjv1II6C7arv4vXqEYILw7DIOzENQOU659spIDU8QsfdsuJ1qaw5GYKyiKRMHkOJItAij7lzrFqQMy6/8fAi8AOCj7x5CRHJgiZhmBDDJLUBQJHSjyI79SCOgu2q7+TxZwnEJwJLL2mYmenjVzwnBRs6X3FDFL37bLiZbmcCTmCooiUTA5jsSKAMr+ZYri6oHh8QA4Orevd6W8A2t18nPRIvZqAL+ojwIbPq+N/n48y+E8FFPXFNgIyE9HQFeb8Ud+OgJTtfsHhnfN7esdNBdxxHkVgXDVaHX9QfO3ihKxcwFcCuDLAC4C8CPjRxYCeBzAewB8kyJWlKsbr8NORMeV/MhPR0BXm/HXnJ8IG4DNae/FihKx9wN4J4CbAJxniNg8APcCkN3Xv08R0wV6s9psBDq25Ed+OgK62oy/5vyaHZpZlIjFFsg0oilinwXwNQA3AriFIqYLdIoY+ZVHQHdldsLkpyPQvPbkgo8Q46M7KmcXMZ24EcC7ALwI4GPGBU0Rk9HZNQA+AuABU8SGhoYGgyDYljR73bp1ZXLgtUmABEiABDqUwPa9j+FnPz+BP33fJbjgl39p2l0sWbIkSP5x2h+MAlcCuATAywA+nyFiDwGQd2U/BbAcwJMAPgTg22kMubBDF1l8EiY/HQFdbcYf+ekItK6dzOYxOf0XhsHTTz89kVfEsn7RHIm9AUBfVPBOAH8F4O8i4ZtWnyLW2onNSrATIT8dAV1txh/56Qi0rp31XqyMd2Iy+vpxwqRRALfynVhrR7mWYCfiSq5ej/zIT0dAV5vx15pf1lEtRYtYa0sySnAk5oyOnbAOHfmRXwEEdJegiNnxizZCnzUX4eL4aBaKmB07PqlbcsoqxkaqA0h+5KcjoKvtS/ytHhgekTyKAcLr9lfX75G7oohZ+tYXJ1IkLB2Wsxj9mxNYojj5kZ+OgF3t1VuHtwQhdkqW+/3V9bJKniJmh47vTGw5UWS1pNLrUyR0XMmvO/hNZrkPMRYfksmRmKVv2QgsQWUUIz/y0xHQ1Wb8dQ8/WaV4umfO2P23XjvGkVgOv7IR5ICVUpT8yE9HQFeb8de9/DgSs/QtG4ElKI7EdKDIj/xKIaC7qM/9H0XM0rc+O1FugfZZOpIioQNFfuRXCgH3i1LELNlRJCxBsZPTgSI/8iuFgO6iPvd/FDFL3/rsRI7ELJ3YpBj9q2NIfuSnI+BemyJmyY6N1BIURxI6UORHfqUQ0F3U5/6PImbpW5+dyJGYpRM5EtODosiWwpD9iztWipglOwaZJSh2cjpQ5Ed+pRDQXdTn/o8iZulbn53IkZilEzkS04OiyJbCkP2LO1aKmCU7BpklKHZyOlDkR36lENBd1Of+jyJm6VufnciRmKUTORLTg6LIlsKQ/Ys7VoqYJTsGmSUodnI6UORHfqUQ0F3U5/6vaBF7NYBfSHZ8A9mrAPQAeKkZRh6K2b1BxpGizrfkR356ArorzAYROxfApQC+DOAiAD8C0AfgTgBnAZgAcBjAtiyUFLHuDTJ2wjrfkh/56QnorjAbROz9AN4J4CYA50UiJgeWrQDwBwACAGsB3AfgdBpOilj3Bhk7YZ1vyY/89AR0V5gNIhYTkmnEWMRuAfBbAN4G4F8BfBLAVzgS0wVTVm2fg4ydsN7n9K+OIfl1Lz/Xd2IyynoXgBcBfMzAY4rYXQB+G8BVAJYB+DSAC+V92dDQ0GAQBA1Ti2eccQZOnjypI83aJEACJEACs47A6173Otxwww0y49fwmfYH49srAVwC4GUAn88Qsc8COA5ga/T9c9GU41OdOJ3o+3Qn7dO1W/IjPx0BXW3GXzn8molY1i+aI7EPA9gE4N0AfhXAQwBe36nvxBhk5QSZ7qrF1aZ/dSzJj/x0BHS1s+LPVcRkpeKPAfQCuC2aTpQRm0wfDmeZykZQjhN1Vy2uNv2rY0l+5KcjoKvdqfHnImJppM6O3p2lrkqMK3QqJF1oFFeb/HQsyY/8dAR0tRl/5fArSsSsrJPFHlu3bh20KjwDhWifDjr5kZ+OgK4242928muriOkQszYJkAAJkAAJNBKgiDEiSIAESIAEOpbATImY5FmcH+VgnGl4cwHMi7YSxLb4ZF/a+0bf7Hs+4USf7BPTXhvFmmwHkY9v9iXbgE/2peVF9cm+tP7DJ/vOBPDzRK7Z2W6fpCuU9RPmpuEsJhJ/r0RpDVO1YiZE7DoAWwD8AIAIyIeilY7tFrM5AN4M4IYIqKTTko8v9smm8XsiNqcAPArgzz2y700A/iuAfwHwSwD+S7Qy1Rd+cTwtBPA4gPcA+KZH/GRlr6zwfSAy9H8D+E8e2ZeVF9UX//5JtCc1fii5GsBbASz1pH+Rh8/bo6TorwPwJQB7PPLvrwP4VCQO0kb+OmrDZfpXBOktAP4CwE4A+5r0ubKV64sApO8T+ySRhvCb9mm3iIloifouAPBCtDz/WQBD7VYwAJKNP06b9Z0oJ6RP9kkKrzOibQvSocjTiDjzGU/4SRYX8d3eaJ/gZ6L0Y774V0JKRtj3AlgM4PcBPOxR/MlDgMTfB6OGKvb6FH9peVEPADjmSfyZXcYOAP8G4HMe+Vf4SSajawG8A4BkN5LkEb60DxGtJwH8PwDeGP23iIycUFJW/3wZgA0ArgHwx5GIZcW8iJiMYv8MwK9EfY3YJ1u5Gj7tFjHpTL4KYElkxY3Rk5OMhmbq84dRVn4Ziflkn0y3iiOl0xCnS3aU3wHwj57xk+TP/wHA3wL4b575V5h9DYDEmQiGiK4v8dcfPWlKQ30EwM0AjnpkX1pe1O96ZF/cX8jJGvJE/xsALvDIvvMBjAH4epS+b1d0Aogv8SejMBFUGUD8X1GiirdHsytl988yKpVZHPFbVp8rfZ+wkn3HolNySorY9fRMi5gE3P8HQIay8pGMH1cA+OhMKRgAU8R8s09GEpLS6+MA1gD4iYf8RPzlhAN5QpKnK1/8KzaJ+H8kmrKTTlneTfhi3/8dTX/9JYAPRH6Wp3YZOfrQPtLyoorw+mJf3GXcEXXAciSUT+1X0vbJg52MeC4HcALAJzyKv98E8D8iYRXxuhiA/PvuNsSfKWJZPntNFGtSVj6S0lA4yoPejI7EZHQhnZ28xBOljd9DyfzoTH1MEfPJPplClA5Dgl9GEjKK8Mk+EVWZnvthNP0gizvkSUnekfngX0mBJpllfgpgeTRdcj2Ab3hinzygyMtt+Ufez8rcv0zrfM8T+9LyoorwyvtFH/wr/cUvRw928v5p3LP2IQ8BMnKVqU4ZbUsi9fh1gC/85BxIeTCRNisPdyJk7eifTRHL6tNiZjKClfYh/YtMc8qIbEZFTH78sej8MWkMfx+98/mHmVKwxEjMJ/t+Lwqw9ybY+MKvGiV/3g5Anupk2k7yZsoCFJlinGn/viE6tFXwyVP6XwH4u+ip3Qf7hJu88Bdb5J2JPLXLQ4Av/s3Ki+qLf8WvMtqWdyxmG/GFn8xK/FrUv4h4fSua7pT37z7Enzy8i30yyyOvc2RGTGYt2sHPFLGsPlce4v8IgIxo10UnqchIcdqn3e/ExAAJOFnJJh95USwvtmVUNlMfcaZ0HvFxM77YJ09y8nLY/MiTksz9+8BPhEumSmT0EE+VSEfsCz+T2yiAW6PVib7YJ+9MZM5fRmDyj+QdFTt9sS8rL6ov9ol/ZbQo00wy2ok/vtgnZy7uByB+lo9MZ8tqRV/sE2G9PxohSvJ2maqTWZV22CciJn3YSMQm7TdFxMQ+6WdktCbrAeRBwAsREyNkSbYMZWWKzMcP7bP3ijRS6UjMYT752fOTlVeyss78+MQvbZ+iT/alkfbJPpmdkK0U5p4on+yTGQs50NgcSMyEfVm/KfZJ+8g8iHImRmL2zZslSYAESIAESKAJAYoYw4MESIAESKBjCVDEOtZ1NJwESIAESIAixhggARIgARLoWAIUsY51HQ0nARIgARL4P5kniP0w2UMoAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<VegaLite 3 object>\n",
+       "\n",
+       "If you see this message, it means the renderer has not been properly enabled\n",
+       "for the frontend that you are using. For more information, see\n",
+       "https://altair-viz.github.io/user_guide/troubleshooting.html\n"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data = pd.Series(np.random.randn(100).cumsum())\n",
+    "data.plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.vegalite.v3+json": {
+       "$schema": "https://vega.github.io/schema/vega-lite/v3.4.0.json",
+       "config": {
+        "mark": {
+         "tooltip": null
+        },
+        "view": {
+         "height": 300,
+         "width": 400
+        }
+       },
+       "data": {
+        "name": "data-9e8a1deb68113a0fc52e584514228101"
+       },
+       "datasets": {
+        "data-9e8a1deb68113a0fc52e584514228101": [
+         {
+          "index": 0,
+          "value": -0.21767896374028844
+         },
+         {
+          "index": 1,
+          "value": 0.6037763908517348
+         },
+         {
+          "index": 2,
+          "value": 2.085054199890827
+         },
+         {
+          "index": 3,
+          "value": 3.416918242122044
+         },
+         {
+          "index": 4,
+          "value": 3.055052870125853
+         },
+         {
+          "index": 5,
+          "value": 3.740661701390467
+         },
+         {
+          "index": 6,
+          "value": 4.314423127686804
+         },
+         {
+          "index": 7,
+          "value": 4.602150794140218
+         },
+         {
+          "index": 8,
+          "value": 4.366516533828004
+         },
+         {
+          "index": 9,
+          "value": 5.320006778058893
+         },
+         {
+          "index": 10,
+          "value": 3.630381476045523
+         },
+         {
+          "index": 11,
+          "value": 3.28543876917823
+         },
+         {
+          "index": 12,
+          "value": 3.3023436662451164
+         },
+         {
+          "index": 13,
+          "value": 2.787360144208991
+         },
+         {
+          "index": 14,
+          "value": 3.0318694358800773
+         },
+         {
+          "index": 15,
+          "value": 2.842556828366233
+         },
+         {
+          "index": 16,
+          "value": 5.5147292461710125
+         },
+         {
+          "index": 17,
+          "value": 5.9795317350387105
+         },
+         {
+          "index": 18,
+          "value": 6.825462179401228
+         },
+         {
+          "index": 19,
+          "value": 6.321920597261879
+         },
+         {
+          "index": 20,
+          "value": 5.358585067415754
+         },
+         {
+          "index": 21,
+          "value": 5.423553696912329
+         },
+         {
+          "index": 22,
+          "value": 2.2185134640725876
+         },
+         {
+          "index": 23,
+          "value": 3.2734828904873123
+         },
+         {
+          "index": 24,
+          "value": 4.080759584335997
+         },
+         {
+          "index": 25,
+          "value": 4.554900138051219
+         },
+         {
+          "index": 26,
+          "value": 4.96582838485692
+         },
+         {
+          "index": 27,
+          "value": 5.452517653637267
+         },
+         {
+          "index": 28,
+          "value": 4.916987945011077
+         },
+         {
+          "index": 29,
+          "value": 4.078080001723468
+         },
+         {
+          "index": 30,
+          "value": 3.2657051816620273
+         },
+         {
+          "index": 31,
+          "value": 2.814912238889269
+         },
+         {
+          "index": 32,
+          "value": 3.8857135946357904
+         },
+         {
+          "index": 33,
+          "value": 4.103134744478959
+         },
+         {
+          "index": 34,
+          "value": 2.927276150201358
+         },
+         {
+          "index": 35,
+          "value": 2.001159361112061
+         },
+         {
+          "index": 36,
+          "value": 1.0072116999696281
+         },
+         {
+          "index": 37,
+          "value": 1.5940180092029606
+         },
+         {
+          "index": 38,
+          "value": 2.6578312521356438
+         },
+         {
+          "index": 39,
+          "value": 2.8955721127279253
+         },
+         {
+          "index": 40,
+          "value": 2.1205155497447388
+         },
+         {
+          "index": 41,
+          "value": 1.1414116033058854
+         },
+         {
+          "index": 42,
+          "value": -0.4079513325181001
+         },
+         {
+          "index": 43,
+          "value": -1.6147795773840339
+         },
+         {
+          "index": 44,
+          "value": -1.1697713448489386
+         },
+         {
+          "index": 45,
+          "value": -1.3428575525620638
+         },
+         {
+          "index": 46,
+          "value": 0.1460896364212152
+         },
+         {
+          "index": 47,
+          "value": -0.6464308567918783
+         },
+         {
+          "index": 48,
+          "value": 1.192566242489495
+         },
+         {
+          "index": 49,
+          "value": 0.7532041177694748
+         },
+         {
+          "index": 50,
+          "value": 1.9132072860119222
+         },
+         {
+          "index": 51,
+          "value": 1.336113833157092
+         },
+         {
+          "index": 52,
+          "value": 0.3050694347651961
+         },
+         {
+          "index": 53,
+          "value": -0.533816010813897
+         },
+         {
+          "index": 54,
+          "value": -0.2168819482849525
+         },
+         {
+          "index": 55,
+          "value": 0.1363720328685194
+         },
+         {
+          "index": 56,
+          "value": 1.6520950769613019
+         },
+         {
+          "index": 57,
+          "value": 1.2742448517561686
+         },
+         {
+          "index": 58,
+          "value": 0.18156530486525924
+         },
+         {
+          "index": 59,
+          "value": -0.46677721579248066
+         },
+         {
+          "index": 60,
+          "value": 1.0132082788293086
+         },
+         {
+          "index": 61,
+          "value": -1.0920924146035031
+         },
+         {
+          "index": 62,
+          "value": -0.8633975255009756
+         },
+         {
+          "index": 63,
+          "value": -0.5027686894903969
+         },
+         {
+          "index": 64,
+          "value": -1.942655217014441
+         },
+         {
+          "index": 65,
+          "value": -2.605360987794434
+         },
+         {
+          "index": 66,
+          "value": -3.266998206267096
+         },
+         {
+          "index": 67,
+          "value": -3.862995186311024
+         },
+         {
+          "index": 68,
+          "value": -3.8108001324488665
+         },
+         {
+          "index": 69,
+          "value": -5.364126962862649
+         },
+         {
+          "index": 70,
+          "value": -3.7098692077008155
+         },
+         {
+          "index": 71,
+          "value": -3.053010525590692
+         },
+         {
+          "index": 72,
+          "value": -3.5915764683062266
+         },
+         {
+          "index": 73,
+          "value": -4.588424247599213
+         },
+         {
+          "index": 74,
+          "value": -6.320551204516049
+         },
+         {
+          "index": 75,
+          "value": -7.980724585411982
+         },
+         {
+          "index": 76,
+          "value": -7.745641800853409
+         },
+         {
+          "index": 77,
+          "value": -7.630487313675264
+         },
+         {
+          "index": 78,
+          "value": -10.189871835156909
+         },
+         {
+          "index": 79,
+          "value": -10.423192290588963
+         },
+         {
+          "index": 80,
+          "value": -9.830024872718923
+         },
+         {
+          "index": 81,
+          "value": -8.358314369790154
+         },
+         {
+          "index": 82,
+          "value": -8.592553327694517
+         },
+         {
+          "index": 83,
+          "value": -8.677012362204078
+         },
+         {
+          "index": 84,
+          "value": -8.413664727803932
+         },
+         {
+          "index": 85,
+          "value": -8.930585529963219
+         },
+         {
+          "index": 86,
+          "value": -7.848083787670971
+         },
+         {
+          "index": 87,
+          "value": -8.536997847529248
+         },
+         {
+          "index": 88,
+          "value": -9.594262979225823
+         },
+         {
+          "index": 89,
+          "value": -9.116383234141601
+         },
+         {
+          "index": 90,
+          "value": -9.808759295922272
+         },
+         {
+          "index": 91,
+          "value": -10.586333145642776
+         },
+         {
+          "index": 92,
+          "value": -10.37478433832342
+         },
+         {
+          "index": 93,
+          "value": -10.650711703959578
+         },
+         {
+          "index": 94,
+          "value": -10.856956853030994
+         },
+         {
+          "index": 95,
+          "value": -11.386445026312877
+         },
+         {
+          "index": 96,
+          "value": -11.758757263881288
+         },
+         {
+          "index": 97,
+          "value": -13.599561306524677
+         },
+         {
+          "index": 98,
+          "value": -13.309853682360751
+         },
+         {
+          "index": 99,
+          "value": -14.662511622769625
+         }
+        ]
+       },
+       "encoding": {
+        "tooltip": [
+         {
+          "field": "index",
+          "type": "quantitative"
+         },
+         {
+          "field": "value",
+          "type": "quantitative"
+         }
+        ],
+        "x": {
+         "field": "index",
+         "title": null,
+         "type": "quantitative"
+        },
+        "y": {
+         "field": "value",
+         "title": null,
+         "type": "quantitative"
+        }
+       },
+       "mark": "bar",
+       "selection": {
+        "selector002": {
+         "bind": "scales",
+         "encodings": [
+          "x",
+          "y"
+         ],
+         "type": "interval"
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbEAAAFMCAYAAABF3IJ2AAAgAElEQVR4Xu2dC7QlZXXnf3W6QdpHsBkeLQRZeBUJ9JgENC4f0XElKo8GVPpC+8oQX1ETMr4S+o4kfSUk5xIjUZejUVQcjdBij4nS2pgJuJKVyDgCangsgtrqGnlHSRB59r01a99bh657btU5Xz3Pvuf8a61e4rlfVe367/3t37e/qvoqQpsUkAJSQApIgVWqQLRK7ZbZUkAKSAEpIAUQxBQEUkAKSAEpsGoVEMRWretkuBSQAlJACghiigEpIAWkgBRYtQoIYqvWdTJcCkgBKSAF6oLYE4D7gFiSSgEpIAWkgBRoS4GqEFsPXAT8DDgI2AF8qi3jdR4pIAWkgBSYbAWqQuws4CTgDOC5wMXA0ydbUl29FJACUkAKtKVAVYg9Cfg2cBXwfOD9wPvaMl7nkQJSQApIgclWoCrEXgJ8BvgY8GzgYWCTSdrtdmejKNqWlvfggw/mhS984WQrrquXAlJACkiBMgrEU1NTnf4dq0LMpg9vBi4A7OGOe4FDgLuyLJybm4u3bt1a9ZxlLv7Rfb7//e+bECO1wYzxYIds2BtK0mJJCw86eLHDgxYebPDgjziOo927dy9k5e6qyfxdwFOA3wWOAL4BHAbsEcQGs9ZDcMoGQaw/Sj3EhIekKRuWR8ao46JJiFnVdTlg98ZsOy95WjEzg6sSU9JU0swf3Iw6UXhJ3F7skD/85KsmIda7ykOBu4FHBtUfgpifoFCi8DXSlD/kj6zc6QGkHmKzDYgNnjtL/iqICWKqxFSJhSQLD8lbNvjJV4JYqtd4CEwPIxvZoJG/Rv6DceohV3iwwUOuEMQEscze6qGDeLDBQyeVDRpUaFCRP6gQxAQxQWzIHJYHmMoGP9NXGlT4GlQIYoKYICaIhdyK0ntiznKFh4GNB6ALYs4C00NQyAZfI035Q/7QdKKmEzXSDFJAUzZek4WHUbcHGwR0X33Ugz9UiakS03SiphODhjiCmC+AyB9L/hDEBDFBTBATxIIUEMQ8zlQIYhMGsVPOueTYOIqO6g/GnXOv/Jv0bx5GeR5s8DBdIht0T8wjPHo2jbqfCmITCbHODX2d4sadc1s2CmLZw/FRd1JBTBATxPJLZUFMEDMFBLEB00mC2JI4HnTwYocHLTzY4MEfgpggJojpnljQHSElTd0T81gRCmKCmCAmiAliQQoIYoLYgEDRKvbtdJClBzt0T6xIzvJQgciGdvpHaFzIH378oUpMlRgx0U2P3S/61XQHnnvt8Q9lfe47tJPX0c5DovAw5y8blkeTh7iQDZMFsccBHeBngxKbKrF2giKnElvmmvmoc+yH3nD8jYLYkixKWH50kD/ayRNFBqGj7h9NVmL7AZ8A9gcWgG8B2/LEEcTaCU5BrEj39JO8R50ovMDDix3yRzv5KqS3Ngmxs4BfA94KRMDLgS8C81mGCWLtBIUgFtItNH2VpZKHxC2ItZMnivSSUcdFkxA7D3gmcDzwY+BcYJcqseHh0WRQCGLD9e9v0aQ/Qq2RDb6St/zhxx9NQuxi4AXASYA9NPBe4Mm2XmO3252NomjF1OL09HRon1a7AgrsuvZWvn/HfYt7PLxngR/dtfTfedvM5o1sWL+uwBnUVApIASkwWgWy7uHbFGCV7ULgIWAmOcidwPOA72UdVNOJzY1sNm29dBZWDhrynKsHO5Yro1H3kh4edPBihwctPNjgwR9NVmKvBd4I/Cbwi8DVwKG6JzZ8XFB3cApiwzUf1KJuf5SxRjY0N8iTP8oo4McfTULsMcAHk+nE+5MnE7fnyaVKrLmgEMRWdyf1MNr1YoMXOzSoaC5fFe2tTUKsZ8t64N68CqzXSBBrLigEsaLdQtOJWYp5SNyCWHN5omwvGXVctAGxIG0EseaCUxALCsHcRqPupErcGlRoUJHfhwWxlDYeklVdCeuUrdtvjOFJdryYeF1EZC+fB21NPNhxyswlR2ed/PLuq27OM2qc/BEk/IBGHrTwYENd/UP+qKpAc4PuopYJYuMNsWOKBoS1N4ide/oxN3Z33PDN/v13zm2xF9gLb6ELD6cPrKTpJ1F4gYcXOzzEpgcbPPhDEBsRxJaS+prNe0+/sPhKw865V87WEZxJJVYKYsCeTidau7AQ98NqxcczQ2kmiIUqld2ujpioZoEesfc2wPIQE4JYKiom7Z7YoKReR3BWhFhevhPEqpKg5P51xETJUz+6mwcbPCRN2bA8kkYdF6rERlqJZX/Xq46gEMSqpmxN5fUrWEdc1uEVD3bIBj/9QxATxIrkFVViRdSqsa2Spp+kqUpMlVhm19Z04qIsi5CoI2F5qMRe+vbLDug5e+2+80dHUfTPfc4fCMU6dKiDIx7skA2CmCrj7N6sSkyVWJE8X6gSC3g/7U7iBVtjc3Gb76zduat7xk29/+8hcWvU7Qse8of80Z+wBDFBbJQQW3Zue7RfEMt2hwege7BBEBPEBLEBKbvNTjoJTycGVGKCWOAQos3YzDPJgw2CmCAmiAligWkzs1nd04mCWKA3PADEgw2CmCAmiLUMsVNmPven/afcQ/TZtQt7ojga70fsVYkFEiqgmQeAeLBBEBPEBLG2Iba0huGylTPs3s+4Qqzqmo26J6Z7YsOY7gGmssEPTPVgR6rHNBGYWY+6TwDESi13pQc78tN3E7E5DBb9f/dggyoxP/DoWTLquBDERgAxIi5ZPG3Mq/oSxap/T6zK+2mCmCAWAtZRJ02BdLmXRu2PtiBmL73+HHgoL0jH5WXnxacOO51/fPQ6Y/YH1oR0znF42VkQC/R0wWajThReErcXO+QPPxVhGxA7ArgeOAH4+kRAbOUDG6EpS5WYXnbOjBUlTT9JUyCdrEpsX+Ay4EjgLYLYUJatOojNzs520ld17YNHX9//IMvQq04aFJlOXKp419gAadm2s3vmV0LPF9pOAFlSyoMOXuzwoIUHGzz4o+lKzJYUuhI4GzhPEBuaNlcdxHJe2h56oTkNHl68U7i4Rd0PvPGZs1NTU4vfWevfynyfrKxRHpKFbFAl1h+/HmJi3CF2OnAa8FvAFWmIdbvd2SiKtvU7ZXp6umyecbPfHfc8QHfHDaXs2bB+HTObN5bat38ns8FsqXPLsq/K9Q6y7cTjD+OE4w7NbZJ13jr1q1M3HUsKSIHmFcga8GaOgAuYcjVwMPAT4FnALcCrgWuyjjFWD3ZM0D2xmiuxVGhEs/2V2NLL0531i3UaHBATv6YvlgqtKBIayx5GvLJBlZgqsewe2+R04uHAfslpPwF8GPgScL8glps+J306MQBiKyv41E6CWCiZS7TzAFIP01eyYXnwjDoumoRY+kp3An82rvfErEKIiF60eMERj41jnlkiR9gugtijwuVVYoJYydiqvNuok1XvAjzYIRv8VMZtQWxoB1rN04lF1wjMFSOKbmU+/qNXvejIT17ytR+8bn5N5xvpZZiGiphqUOV9rQHnWVHptD+dKIgViYM623pI3KqC/MDDy6BCEEv18rKdtDaI9WWc/kfOiyQkQayIWoPblo2L+izw8Xi7Bx0EMUGsv18JYoJYkVyrSqyIWjW29QAQDzYIYoKYIDYgsQzqpMm02Z/3775zbsvJqsRWfFKmhvSte2JpET0AxIMNgpggJohVg1j/C2CLlUljEFvDc9YsLERRvGbxhamFmPt65n/5gjO/OogUmk6sgaPJITwkb9ngK3nLH378oenEwOnEQStENAWxAWl46KPkTUIsud63LtkXr4Vo8d2tmrc7Dz1g3SG3/fSBf7Hj7pzb8ssBOg/VpYyNSlhLqnnQwYsdHrTwYIMHfwhigliRvN5o5TkM2oJY9hJcRRxYpa2Spp/qwwM8emqMOi4EsQoQiyO+H++Z3xx11rw5ividKgmi4L5DK44WKrEVy4YVvIYizUPhOVSXIif10km9JKxRJyv5Y3n0yh9LeghiFSBWJiHWtE86qb9h+TGji3bOnfkeQawmpZ1Mo3lIWB5sENB9VYMe/CGIrX6I9VVE0ezEQiyKfgrx53ounafzodCXxe2eZxRF9umgZduX5l75LQ/JWzb4St7yhx9/CGLjB7F/Ior/iRir0A6srx5ZPFLotF6tp7Vp22iB04miN0P85tCDF3lZfNCDO0pYS4p70MGLHR608GCDB38IYqsTYg8Bu4GDGgDVIEaMBGKh0OpvJ4iVVS57PyVNP9WHB3j01Bh1XAhiqxNi9Wan8KONFcQ2zVzynN6lR1F0ZLwQfbZPitoWZA6X2C9ARp2svCRNLwCRP5YiQhATxIrk1/GC2OL3yYYvKOwhWcgGVUH9HdVDTHgAuiAmiAli+QqoEgvsH0WCqGpbD8lbNvgZVAhigZ20uU+OVO3Sre6vSqxVuf0kCg8jbk0nLg8+DyD1EBeCmCBWJC0LYkXUqrGth4TlwQYPSVM2+IJpGxCzdfXuBeYH9WnvH8VUJbboPUGsRjAVOZQHgHiwQQDxVZ178EeTEHsyYC+e3g3sAa4Dzs/ruIJYkZQ2orYR90VEV8dxPAU8ZURWBJ922CP2oWsxekjessFX8pY//PijSYidC+wD2IoS+wEPAIcBt2VlIY8Qe9nbLn5iz9b5fdcdHXe4OjiDquHIFagBYndD9OETjnvStiuuu/0981F0WegKIHVfvJKmn6TpofrwYoMHO5qE2Dp7hB94EDgNuBB4avLbij7uEWIBI/W6c5WOV6MCC3HnGY/bzU29Q37+82csm9Iu6t9hUKzR9BWHEsQEsf6g8BAT4w4xuz5bi24GeCfwMuAq+7Hb7c5G0cr3c6anp5vMA4WPvevaW7niuszCsfCxtMNoFTjx+MM44bjFb4s+uhX178zmjWxYb2MzbVJACnhTYGpq5aeKoopG2hTiZcDDwNnA7YOOp0qsotrafYgCSwsjpxt5r8SW7Ou8xWx+/Lq1B9/3wJ67gA/3X0dbrtfIX9VgVqyNOi6anE58E7AJODWkkwliISqpTXkFVivE+mcsVl5HeU2K7TnqZNWz1oMdssEP0JuE2MXAWX3d5Cjgu1ldRxArllDUuqgCglhRxfrbe0jcZpMHO2TDZECsUJ8RxArJpcaFFRDEFqcno+hpy6SLo1tCpyc9JG5BzA88vFTGTVZihdKMIFZILjUurMCyj4UevLh7FD2WOH5s6KHafjox+55d+enEqscTxHwBRP5Y8ocglspg/UFR9MZ/aDJUu1EoUP2L14LY9+OsJ8Da9qaH5C0b/ABdEBPE2s5BIzqfIKZKrL7QE8QEsRXRpOnE+jqYjpSlwHhALCL615j4lt4V7pzbEvT0r7UXxOrrGYKYICaI1defdKQgBcYDYn2Xurggc9Dl50LMloOL7k/uLtwx6HgeErfZ6cEO2SCICWKhmUftalKgOsTiKH4DcedHPYO+PHfm31c1Lvk6Qv9xfmIwCbgnWwfE0pcw8HgeErcg5gcePUtGHRe6J6Z7YlXz8CrZvzrEll9o+acE08fJ+cRP6CdvBLERRd+oE7cXmHuwQxATxEaUBto+bfRNovgaYrYA9o27ittkQMwgu9BZ88cm1nFHrj/juh/cY0vJ8eXumWdWFLD07gLIknQedPBghyAmiJVOJpO94+RALI46N/T5ulAFWHeceEjessHPtKYgJojVnWMm5HiC2KgcLYCoEkvHniAmiI0qF63y8zYHsZjodojPj+Bk4KQBQhWqiMo8KDLont2oHCiICWKCWE7v04odo0pLq/G8zUGsgBqCWAGx6mwqkGo6cUU8eXnZ+W0fv+YvesbFcfxcwP5pkwJ9CghiowoJAUSVmCqxAZXY2y765k0xHDOqDqrzrhYFBLFReUoQE8QEMUFsVPlnjM4riI3KmYKYICaICWKjyj9jdF5BbFTOFMQEsbYh9jiw9dlYGBT0bu6JaTpxVLlplZ3XBcQeJObmnnDznc6rd3XPuClPSD2dWF+ICaR7tRy1Fk0+Yn8gcAmwBzgCeC/wqbwwEsTq62A6UhsKuIDYsgsd9r2zAIj9aGFh4Y29g8Zr1t66dmFPpJedV8bTqBO3WeTBBg92NAmxrcATgHcDG4DbAavKkhWzlweGINZG4tU56lOgGMQ2bd3+L/3nno86W3IgUcrMLIht2rr98tTBjgLsX9BmxxPEsqXyABAPNow7xD4O2Orc2+1D8Ml04hSwOyssBLGgvKJGbhQoBrFTtm6/sf+p1wGQKHWVWRDLOm/owQWxfKU8AMSDDeMOMVso1P7tSELhTuDZwA+73e5sFEXb+kNkeno6tH/V1u6Oex6gu2P50nAb1q9j6+bln2kyCpfZ4tRO6f9OH8/+O/23QefptRtmT7pd3rFDbRh0rv5j59k3zN7eNYfYmqVPqM7pfcucKyte7JghPrS4mtm8kV3X3spXr7tt2WWccPxhvPS4Qx/9rf94g2Kn/3j919WL55DrtfPa8a7os+/E4w/jhOMOXewrd95jt7iXx2za3kFa5LUL3Se0D4Yer2y7EH8Piov+/fOOF3qeQbrUcYz08Xt9+ZAknkN90nS7qampFWkmNO/k2WYrX98LvB9YA9wDPDHvAY9RVWJaVifbfR5GeR5s6B9p5sRLaP8c8ImVwZXdIC0C7nXVsLJHNPuBNz5zVu9Rhrp6ItotxtWo+2mT98Tss+m/B7wEsBLrHcBz8lw7Uoh1Ou8zu44+bP+X3nzrf3zV/ntnd8sJowrDUQdFf+KeZB1WMcS+B3y357udc1sGrcG4zMXZUBTERtUPHJ937CG2DvgKS6tf2H+/GPiGN4il7fEADwFkr0c8+mP1VGLF7tml+4Eg5hgbvkwbe4j15D4cuAN4ZJD+o6rEBDFNJw7LC2mYCmJalm1YvEzQ3ycGYkE+FcR8VSAeqiAPNvRXxqf+4aV7n76wG7yd6GsFHltv8Z5YtUosIlr2lFVMdJnuiQWlsklqJIilvS2ICWL9vd8jxPptLPgIe5MQW/44LdH1O+fOfE+dGdX8EfBgx2ejmM/GEX8FPLnO8+tY7hQQxAQxTeUN6paCmL+BzXCILVWABeHuLjvLoCAFBDFBTBCbRIidOHPZQVnXvat7xt15engAelglJogFpf/xaCSICWKC2CRCrEz+EsTKqKZ9GlZAEBPEBDFBLCzNOIeYLXmztIwH0Zc1nRjm0zFoJYgJYoKYIBaWyjxDrO41G8MUUSsHCghigpggJoiFpSJBLEwntWpVAUFMEBPEBLGwpOMHYtdc2m/xnig6v/9jnHo6Mcyvq7yVICaICWJjCbGYv6UTQRy/rO/6Ci3Em97XC8SyVgrP8qEgtsrxFGa+ICaICWLjCLEmvsMliIVlVbVqVQFBTBATxMYaYp3ok/3Xt7P7SvumXuFNECssmXZoXgFBTBATxMYVYv33iKrmE0GsqoLavwEFBDFBTBATxMJSiyAWppNataqAICaICWKCWFjSEcTCdFKrVhUQxAQxQWy1Q+ykP/jsr/RfQ7x2n4c1nbj9xnjpg7jaxleBiYHYeuBeYH6QL/Uplr3qrLZRd1N91IMOdm0e7FhtNugR+6Z6havjjj3E7FtCnwNsZe49wHXA+XkuEMQEsf7Y8JC4BbFycSmIuYJNU8aMPcTOBfYBtgH7JQuEHgbclqWoIFYuWTQVnR4A4sEGQaxcXApiTfVMV8cde4itA2LgQeA04ELgqclvKzwhiJVLFk2FtAeAeLBBECsXl6ecs/3E3p5xxKth8Z+28VJg7CB2IDCX+OjTwD8C+wIzwDsBW4LnKvt7t9udjaLIKrRl2/T09Hi5WFcjBaQAu669lSuuy5yAkTqrWIEN69cxs3mjmyvIWhItKmjd/sDrkn2uBG4BLgMeBs4Gbh90PFVi5Ua8BX0U3NxDFeTBBlVi1eNy09ZLZ2HloDU4GNXQqwJjV4n1C/0mYBNwaogHBLHqySJE59A2HgDiwQZBrHpcCmKhvW7VtRt7iF0MnNXnlqOA72a5ShCrnizq7AIeAOLBBkGselwKYnX2TFfHGnuIFVJbEKueLAoJPqSxB4B4sEEQqx6XglidPdPVsQSxtDsEserJos7w9gAQDzYIYtXjUhCrs2e6OpYgJohlB6SH5C0bqifvOtPNavaHIFZnJLg6liAmiAlig7qkh8StSqw6zJcg1rHl54jggJj4Na5SsYwpq4AgJogJYoJYWP7wAPQ6bDjlnEuOjaPODWFXrVbOFRDEBDFBTBALS1N1ACTsTPmt6rBBEKvqBVf7C2KCmCAmiIUlpToAEnYmQayqThO0vyAmiAliglhYyhPEwnRSq1YVEMQEMUFMEAtLOoJYmE5q1aoCgpggJogJYmFJRxBbqdN8HJ3a6URRFC98MUxFtapZAUFMEBPEBLGwtCKIZUAs6hy7dmFPpKcdw2KogVaCmCAmiAliYallzCD2+dRVPwV4TJgKy1vNC2JlZKtzH0FMEBPEBLGwnDIuEOu/2ipfgBbEwmKnwVaCmCAmiAliYSlGENN0YliktNpKEBPEBDFBLCzpCGKCWFiktNpKEBPEBDFBLCzpCGIDIfZ3qb8eDKwNU1WtKiogiAligpggFpZGBLFsiO3qnnFT+i9V7rGFeUKtUgpMFMQOAH4OPJQXAvqe2F5lxjVhFe3+HnQwmz3YMa42FITOrQvE5772hU+5+DP/sPu342jN/xXEivaqWttPDMSOAK4HTgC+LogND6JxTVjDr3x5Cw86CGLNDq5yIHY58eJ3W07pi5mhSbMgFIuGpNovV2CoP9oQLI7jaPfu3QtTU1NR//lW/FDCoH2By4AjgbcIYmEKekjesqHZ5B0WCeNvw6aZz53Ur8U80Q9zXmIemjQFsaKRVan9UH9UOnrgzk1D7ELgSuBs4DxBLMwrAsiSTh508GKHBy3atCHnky1Dk6YgFpZjamo11B81nWfgYeqE2IHAXHK2TwMHAacBvwVckYZYt9udjaJoW79l09PTbVyzziEFpIBzBe645wG6O5Z/O3PD+nXMbN440HLbx/bV1rwCIf5o3oq9Z6hjOnF/4HXJIa36+ihgj7v+BHgWcAvwauCarAvTgx3jP3VUNKDbHPkPss2DHZNmgyqxor1lJO3HrhLrV/FwYL/kx08AHwa+BNwviA0OuElLWHlqeNBB04mjGVwJYiOBUtGTjj3E0oLsBP5M98TCYsRD8pYNo0nenoHeZkwIYmG5YsStJgpiQ7XWdKKSZn+QtJk0NZ04tIu2+qCNIDbcHw5aCGJpJwhigpgglp+WPAC9TRsEMQeIGm6CICaIZUdJm8lC01fDe6r8saRRmzoIYsPj0kELQUwQE8S8T+O1nbw1qFhSoCzENm3dbk9AL25RxCvimFc4SPbjaoIgJogJYoJYWH5rswryANKyEEvbvmnrpbOw8n3UMMXVKkABQUwQE8QEsYBU0fJUniAW5hO1QhATxAQxQSwsFaoSW9SpUNJUJRYWWxVaFfJHhfMM3LXOZacq2ainE/fKN2kJy8PI3ztMJy0mNJ1YKZ22tbMgpkpMlZh3eJh9kwYQD4MKQawtDlU6jyAmiAliglhYEpk0kApiYXEx4laCmCAmiAliYWlIENM9sbBIabWVICaICWKCWFjSEcQEsbBIabWVICaICWKCWFjSEcQEsbBIabWVICaICWKCWFjSmTSInTj717+Qpcyu2dfcG6qFHrEPi60KrQQxQUwQE8TCUkho4g47WrlWHmwwy0PtEMTK+bnAXoKYICaICWJhKSM0cYcdrVwrDzYIYuV819BegpggJogJYmHpxQNAPNggiIXFS0utJgZijwM6wM8GCasVO/aq4yFZyAb5o7+/eogJQawlPIWdZuwhth/wCWB/YAH4FrAtTxtBTElztSfNsH5frpUHgHiwQRArFz8N7TX2EDsL+DXgrfZpH+DlwBeB+SxBBTFBTBDLTzUeAOLBBkGsIRyVO+zYQ+w84JnA8cCPgXOBXarEhkeLh2QhGzSoWO2DCj2dODzXVGwxdhA7EJhLRPk08NvAC4CTgF8F3gs8GYi73e5sFK38WN309HRFTbW7FJACUmBJgV3X3soV190mORpSYMP6dcxs3tjQ0Ysfdmpqymb8lm0rfhhyWLv39bqkzZWATSc+BMwkv90JPA/4XtZxNJ2okf9qH/kX73bhe6gyLt4/VImFx1fJlmNXifXr8FrgjcBvAr8IXA0cqntiw8NFCWtJIw86eLHDgxYebCjiD0FseK6p2GLsIfYY4IPJdOL9yZOJ2/NEUyVWfKRZMQAH7u4hYXmwoUjSlD+aVKB4/xDEGvfH2EOsp+B64N68CqzXSBAr3kmbDFEPAPFggyDmKy6L+GN2dtbeT13cvvPw0cc8ssD1TfaZCTz2xEAsyLeCmK9k4QEgHmwokjSDAr1kIw9aeLChrD9yPrJZ0hvaLVFAEEuHgiAmiPWnhtWcNOtOcx608GCDIFZ3ZFU6niAmiGUHkIdkIRs0qBinQYUqsUqwyttZEBPEBLFBXcsDSMuO/OtOGR608GBDWX8IYnVH5OLxBDFBTBATxMKSiweAeLBBEAuLl5ZaCWKCmCAmiIWlGw8A8WCDIBYWLy21EsQEMUFMEAtLNx4A4sEGQSwsXlpqJYgJYoKYIBaWbjwAxIMNglhYvLTUShATxAQxQSws3XgAiAcbBLGweGmplSAmiAliglhYuvEAEA82CGJh8dJSK0FMEBPEBLGwdOMBIB5sEMTC4qWlVoKYICaICWJh6cYDQDzYIIiFxUtLrQQxQUwQE8TC0o0HgHiwQRALi5eWWgligpggJoiFpRsPAPFggyAWFi8ttRLEBDFBTBALSzceAOLBBkEsLF5aaiWICWKCmCAWlm48AMSDDU1CLKZzbhTPR0TRn4R5ZeJbTQzEngDcB8SDXK5PsexVx0OykA3yR39/9RATNUPsQeC7veucjzpb1i7sieKoc8PE4ylMgLGHmH3R+SLgZ8BBwA7gU3naCGJKmuOUNMNyQHgrDwDxYEPNEFtMwmkvaLX78JichFXsz6CKv+gAABdXSURBVAJOAs4AngtcDDxdEBseJB6ShWzQoGKcBhU5cHIBsT3EL1q7KHb0teHZwVWLsa/EngR8G7gKeD7wfuB9gtjwIBRAljTyoIMXOzxo4cGGsv5IIPaR/t63c27LC0Zdic1HnWNX6TTm2EHsQGAuCYhPA/sBnwE+BjwbeBjYZH/vdruzURRt6w+o6enp4RleLaSAFJACDSlwxz0P0N3R7i2xmc1LM5ptn7eqhBvWr6Nne9Vj1bH/1NRU1H+cFT8MOdH+wOuSNlcCbwduBi4A7OGOe4FDgLuyjqN7YntV8TDilQ3yR38/9RATZSux0CQ5intiqsRCvZPdLo7jaPfu3Qt1QKz/DO8CngL8LnAE8A3gMGCPIDbYaR6ShWwQxASxask1dG9BLFSp9iFmVdflgN0bs+285GnFTEtUiSlpTmLSDO2+GlS00z9UiYVG5GK7sbsnlnf1hwJ3A48MkkcQa6eThoaokqb8MYmDiuIQi6+KiK6C6Pdj4oND+1e6nSqxMqrt3afJ6cRClgliSpqTmDRDO4kGFe30j+IQi2Z3zp35nlO2br8xhmPy/BnBhxc6fCSK+VtipgSx0Mgf3k4QS2nkIVGYOR7skA3tJM3hXXSphfzRjj+aghjkwy5Vib03FQ+/Djw+ND5G1G5iphOD9FUl1k4nDXKGkuYymQQQPyBtGuhlIXbyOdvf0guaThSdHBOfvLyvDYbYru4ZN6XbD6vsQvtxw+0EsbTAgpggpunE/JQjkLbTP8pCLO25k7deek6WJ78898oLsuBklZggVh63mk7UdGJm9ChptpM0Q7uu/NGOP+qA2CCfCmKhER/eThATxASxIf1FANF0Yn6ILE0ThqZcQSxUqfB2gpggJogJYkEZwwPMzdAm7Wi6Etu0dfv/7Bd7PupcoOnEoBDMbCSICWKCmCAWlEGahEeQAUmjJu1oGmKh16kHO0KVAkFMEBPEBLGgjNEkPIIMEMQeSCRYV0SvBtvq6cS0uHo6ca8aHpKFbJA/+pOfh5hY7dOJoUDJu3fm7JMtgpgglh3SHpKFbBDEBLEQ5BR7sCPkiNZGEAtVStOJy5TykLibHmmGhoYHLTzYIH/4gnnT/vB8T8zhGouqxFSJqRIbBFVBzBdAJsEfgljoMHexnSAmiAliglhY0vAAEA82qBLbE8VRp91PT+eHqCAmiAligpggFqZAO1Wpq0osYkNam3k6v64HO1ZGix6xT2kyCSPN0IThQQsPNjQ98pc/QhWYLIjlqVIcssX1LbDHWFZi9umAnwNxSojHAfZ+w8IgcfSIfTudNDRAPQDEgw2CmK+4bNofxSHRzNOJglhopqrv6UT7oukzgC8ATwXuAg4ELgH2AEcA9q2cT+WZJoj5ShYeAOLBhqaTZmhX9aCFBxua9kcgxG474PH7HvrT+x7+EUQXF1k7MdTfgyBGp/N2+/uzjzrw9f/n5n/7dyKeWPW4Jfcfq0rsdOB5gIl7SAKxrcATgHfD4tzu7YBVZfdnCSaICWL9cTEJSTM0eXjQwoMNHiBmj7p/6A3H3zg1NRWF+q+JduaPt130zZsGfVG6ifOmjjlWEOtdl00j9iD2ceDvge2AOdumE+2z3LsFscGh5SFZyAYNKiZxUBFSiQlij0bGqobYWcDzgXuBd6SCPQ2xywD7tyP5+51WAQM/7Ha7s1EUbevvJNPT0w0PHHR4KSAFpEC+Anfc8wDdHYOfYJ/ZvJEN630sX2i2ms2j2EwD08LLllUZDyqVXwIcm0wNfjQHYn+cQO79wBrgHlicu818wEPTiRr5T+LIPzQBqDJup3+oEguNyMV2q7oSy7vSdCV2KvB7gAHPSiyr2J6Tt6Mg1k4nDQ1RJU35YxIHFQax+Sh6Vu/aO0R/Chya1kLTieMxnTgIYvak4t2A1dtfAY5J/vvFwDcEseEYEUCWNPKggxc7PGjhwYa2/ZG3EK8e7BjfSiwrQx8O3AE8Mih9qxLTyH8SR/7DhzR+gC6ILfnCfSUWceXiTZuI3wiNr5LtxnI6saQWIIgJYoJYfvfxABAPNrRdiZ18zqUn93tlobPmB54rsRZXuxfE0sEhiAligpggFjIK9gBTLzZkvScmiO2NolZf5BPEBDFBTBATxEIU2DvF/PsXffOMFZVi1LmxpYWCVYmpEssOWC+jPA8rEozahranr/JSmGJCg7wig7wT/2C7LSzx6LZmDVckSwKGU3J4S0FMEBPEBvUTD4lbEPMFD/mjnD+ynrIczqihLQQxQUwQE8SGJorFBh6A7sEGaVEOYpu2brfXnXrb02qqygQxQUwQE8QEsTAFyiXvoscObe8B6GVt2LT10llYuexf6LWn2gligpggJoiFpY6yCSvs6GGtPNigSqw6zAWxsHgv3EpPJ1YPzsKiD9jBQ8LyYIOSpq+4lD+q+0MQqzNTpo4liFUPzjpd4wEgHmxQ0vQVl/JHdX8IYnVmSkEsU00PyVs2VE8WdXYV+UP+6I+nsjEhiNXZMwUxQcz5lKZG/r7gIX9U94cgJog1pED14KzTsLKjvHGzQUnTV1zKH9X9cfLW7Y9+fTiKOZyI95Xst3o6MS2c7olVD86SgahqcIhwAvqSQB508GKHBy3qsCHkI6ADuocgJohlh0cdwVkVaLJBg4r+GPIQE4JYvXEpiFXNlKn9VYnVG5xVXeMhYXmwQUnTV1zKH/X6QxBbmSkfD/wciFN/Wg/ca9+SG5RYBbF6g1MQq6qA/KFKLD+GPAyw6rAhgdh3Ule6pkDPGavpxIOBZwBfSNbkugt4MvA54G5gD3AdcH6eQIKYkqaS5vgnzQIJMrdpHcm7qh3jakPBhYLHCmKnA88D3g4cAhjEzgX2AbYB+wEPAIcBt2UFkCAmiAliglgIXMYVICHXnm7ThA6TDLGetjaN2IPYumRa8UHgNODCpEpLTzU+6hNBTBATxASxkETeRPIOOW/TAPFgwyRB7Czg+cm9rnekxE9DzH7eF5gB3gm8DLjKfux2u7NRtHIV5enpR19fKOpPtZcCUkAKSIGKCnR33MAd99ik2fBtw/p1zGzeOLxhSy2yPqAbDTj3S4BjgfuBj+ZAzKYQLwMeBs4Gbh90LarEVImpElMlFpLvVIktqdSEDpNUieXFWroSexOwCTg1JDAFMUFMEBPEQnJFE8k75LzpNuNqgyC29Gi9PaloTyReDNi0Y3o7CvhuVsAIYoKYICaIhcBkXAEScu1Ng1QQK+qFVHtBTBATxASxkBQiiGk6MR0ncRxHu3fvXih6Tywk1gq1EcQEMUFMEAtJGoKYICaI5fQUD53DTPNgh2zQoEKDiskbVGg6MWQYldNGlZiSppLm5CXNMilDAyxVYqrEVIkNzR1KFBpUaFAxeYMKVWJDU2N+A1ViSppKmpOXNMukDA2wVImpElMlNjR3KFFoUKFBxeQNKlSJDU2NqsRCJBJAmhtphujvMXkrJjSoaCMuBbEyGSLZR9OJ6qRtdNIyISqAaFDhMTabiEtBrEyGEMRWqNZEcBZ1jWzQoMJj4jabFJvNDSoEsaKZMtVelZiSppLm5N2DKZMyBDFBLB03WrEjpYaHzqGRpi+Yyx/yRxZoPeSKJmxQJVZmWKXpRE0n5sRNE520TIh6sEM2+ILpuPojC2JxHL+bKIoiOL+v/9y4c27LxlFroUpMlVhmXh91YHqpgLzYIX8IYm1Mt2dBbD7qHLt2YU8UR50bBLEBw2DdE1MnbaOTqhIro0Bz92DKWCOgN+cPQaxMRGo6UdOJmk4c2nOUuDXIa2OQl0Dsl9Lnmo86G1WJDe2ioEpMnbSNThoQihpUaFAxNEwmbVBxyjmXHDsp04mPB37O0hee09sBye8P5UWHICaICWL5uXPSkuYgikiL5qYT83SfBIgdDDwD+ALwVOCulBhHANcDJwBfF8SGDvL0MmcikYdkZaZ4sEM2aJA3ykHeJEDsdOB5wNuBQ1IQ2xe4DDgSeIsgNhxgSpq+kpX8IX9k9dpJG1RMAsR6frZpxDTELgSuBM4GzhPEBLEwBdqfLtH01XDPeEjcGlSMZlAxjhA7C3g+cC/wjlT4pyFm1dlpwG8BV6Qh1u12Z6Mo2tbfbaanp4f3JLWQAlJACkiBVhW4454H6O5Y/prYhvXrmNm8sVU7Bp1samoq6v/7ih9SDV4CHAvcD3w0B2JXA3av7CfAs4BbgFcD12QZogc7RjPCygsKD6NuDzZo5O8rLuWP0fhjHCuxvNyXrsQOB/ZLGn4C+DDwpQR8K/YXxEYTnILY8IGkB5jKBvWP/khtMyYmDWJWfd3dJ/hO4M90T2x4wtRI01eykj/kj6xe2yZAPAw0JwliYVk6o5UqMV/JYtI66aDAlRZL6njQwYsdHrRo0wZBLABtgpggNsrpEkFseCdtM2nKH778IYgN94eWnUpp5CFZyAYNKjSoyE9ck9Y/BDFBLEABJU0lTSXNkI4yaQDRPbHBUaHviTmrgDTn7wvm8of8kZVCJw2kVolB58n9Wlx+wZZdo9ZCEBPEMoc5ow5ML/DwYof84Qum8ocffwhigpggNmQOSwlrSSAPOnixw4MWHmzw4A9BTBATxASxkFtRgpizXCGILTlEEHMWmB5GNrJheU73kCxkg5/pK/UPX/1DEBPEVImpElMlFqSAQJol06gHWIKYICaICWJBKXzUyapnpAc7ZIMfoAtigpggJogJYkEK+EncXqY0PdghiAligpggFpTCPVQfHpKmbNA9scwOo7UTNcrrDwwlTcWEx3swgpggJohp5K+Rf5ACgpgglh8oGuQtaaPpRE0najpRg4ogpCppalDhcVAhiAligpggJogFKSCITQLEHg/83Cq81MU+DugAPxsUJ7onpg6ie2K+p45UiamPjjPEDgaeAXwBeCpwF7Af8Algf2AB+BawLa+bCmLqIIKYIBZSEHmAqWzwk6/qmk48HXge8HbgkARiZwG/BrwViICXA18E5rMCVRDzExRmiTqp/KFBhQYVq2FQURfEetdq04g9iJ0HPBM4HvgxcC6wS5XY8LAQQJY08qCDFzs8aOHBBvnD1+DKgz/KQsyqrOcD9wLvSKXlNMQuBl4AnAT8KvBewD6qFne73dkoipZNLe6zzz488sgjwzO8WkgBKSAFpIAUSClw0EEH8frXv95m/JZtK35I/fUlwLHA/cBHcyB2IfAQMJP8/c5kyvF7Wep7mE70YINp48EO2bA3SqXFkhYedPBihwctPNjg3R+DIJY3CkhXYq8F3gj8JvCLwNXAoZ7viSkolLg1wMof4Kt/qH+stv5RFmL2pOLdwGOADybTiVax2fTh9rwu4qGDeLDB+8imzTkM+UNJc7UlTfWPNhUY3j/KQCzrCtYn984yn0rs7eAhYXmwQRAbHphtdxMPcSEbfMWF/LE6/FEXxIJyjj3sMTMzMxvUuKFGHmywS/Ngh2zYG2TSYkkLDzp4scODFh5s8O6PViHWEJd0WCkgBaSAFJhQBQSxCXW8LlsKSAEpMA4KeIGYLV9l99PSL5HZWozrknUa69Ta1nl8IFkmq87jhhwra91JezjGnvh8OOQANbTJun/ZlNZ55j4h8cGevgb2+8D1N2u4/vQh1gKmhz2k1Nva9kfWJbXtD9PhicC/jdgfWVq07Q+Lwfv61oZt2x9Z+dC0aaN/FMnFVXJpVi7MW5d3YL4eNcRMhP8M/Dnwl8DfJFH828DbgFsB62Cv7ks0ZXLZgcAlgCXOI5IXsz9V5kAl9slad9Kuy67ZXhJfA1wHnN0gXO0l9M8lOpoGdr7zgSa0zpPoscCOZLFoe4n+B8A5yYovnwR+lPjm9cA1JXQuusv7kvizdyLb9oclZ4PnFYnR/wr8Ucv+sFNvBTYl2tug8ZXARqAtf1hc2hPOve2XgO8Ar2q5f9hg5qJkEHVQEqeWH9rsH5YP/wL4hWQ92luAPwB+pQV/FMnFNugum0uzcmHWb8H5etQQ+2XgvwKnAe9KIGbJxCoyGxn+RxLgt9s956IZqq+9dVYbybwb2ADYMc1x9mpA01vWupPPBd6frD1p57ck9jrgnxsyxpYE2yd5DcJGWza6MZgbOOrWOu8SbAWYaeC/Jb4wkFmwXpp03r8DTKvfAQwsTW6nAm9O4GXnatsfRwO2bJsl615F2lTs5+loC3l/NVnQ2xKTrb5zM/DXI/CH2Wjx+CXgvwAGszb7h61QZCsPnZHEgq1GZIs9NJGL8vxhg3X7Z3ZY9Wc5ynKjxYnBrcn+USQXW6yUzaVZuTDrt+B8PWqI9Zxpo/PPJhA7Evh7YCr5o1UnNhKx0XmV7ePJce09NrtuW3XfzrG7ykEL7pt+Ufw1yeomb0mO8bfA/wI+U/CYoc1tlG3nfzDpGLbayouB/92A1sNsOjEB1b5Jh/1/SeKw/7XK1KoTW5+zqe0pwF8llajB3SDWtj+s+rHRrCWDbyYV6Q8biv08HW2RggsSkNvAzpaNs2TZtj969tlMgfneANK2P54EfBu4KlluzwBqX+xoIhfl+cPg/d+TeLT+agNsg6r1VRtktdE/QnKx5RHTpUouTefCnh7p34LzddsQs1H3XGLxp4F/TP47LZx97uXzwNOTv9mqIC8E3lAxo10G2D87l222RNazAUscbW1pJ9nK/zbaNEjbZp+0+VoyCm7KHoOGLRH2TuBlyT2QJrQeZr8lcPOrdVobAdq0ifnbRp4GmH8ADh92kJJ/tyrUdLZBkVWg9sqHQaxtf/wGcBzwIeDMxC+WsCxG6479PKms+jBgvChJmJcnfeJfWvRHz7ae3+1/rfpp2x8WAzaA/Fiigd2jNqC02T+sErcZmRuBA5JB7kuTnNVW/wjJxTbdWTWXDoNYcL5uG2L23TGbMrPtSsA6i21p4XojECun7ULt0y+22f2jKtsfJy9k2wjL7kHdkyQxq8ja2tKOswRuCyvbtJZtNo1i0wZN3Quy5G2BYZ3TwGnAaErrPD3tsz2mgVUettkyZR9IEpb5+drkqwjmq54udfvGkpVNoZkNFo9HJYnLpjTb9IcNKOxhJvtn8WhTik8DvptMJdUZ+3ka2lSVTa+bX2wzoNkAwvpoW/7o2Wa3C0wDuy9oW9v9w67dplKtMrXq2Ka6e9PtdeeiQTFtILPpRKvC/iSZXrR7c235IyQX9/SpkkuHQSw4X7cNsTznpYWzNnZj10Zi1ycJx5azsvngKpslxd9LRt12X8YS1nOqHLDEvmnH/afkwQbrKDbqsg+KWvVh9wGb2N6U3MDvh0MTWufZb9OIdj/sFUkDG3XaSNOqInsyzh7wseksezqsl8zq1sIeLjksOahNU1scWDzYPUJ70KQtf7wHsAcILM5tqsiqAJvebtMfdj5brNturNvX2i0GLT4sVtryR8+/Fgt2P6g3iGu7f9g9easCfzeJgW8kcWIDq7pzUV5M2yetPpLkJau8bLBlt1cMrG35IyQX24C4ai4dBrHgfO0JYnYz2e4L2WYXYP/fti8nN7/toqtsVnV8BTgmqUDsfpAFapubXUNv3Uk7r02tWgexkY0Fxf9o0Bgbadr0UXqzKsSmNOvWOu8yDCA2qrTpYdvsPqhBxJLp15Pf/j3pxD9tUIveoa0CsSc0ew+RtOkPuwdj9xWs+rB/NlDb2VDsD5LSqvI/TCp0q9Rturltf1ifsOl9e2Iz/apJm/6we7A2nWp+sc1mRexpxSZyUZ4/rOKzGLAnJe2hks3J4L1NfxjEhuVig1jVXNqfC02T9G/B+doLxLKcagnPpnts2qvOzaqdO/reSavz+EWPZfcJrePa9MWotqa0zrseqzxtusQeMultNo1iX0Cwm9dVByxVdGzbH/ZAhcVjemvbH5YwLIFaNTbp/rAYtFcf0u+stu0PiwkbxKWBPsr+kXf9beTSoefwDLEqiUj7SgEpIAWkwAQoIIhNgJN1iVJACkiBcVVAEBtXz+q6pIAUkAIToIAgNgFO1iVKASkgBcZVAUFsXD2r65ICUkAKTIAC/x9E1PiFn0z84QAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<VegaLite 3 object>\n",
+       "\n",
+       "If you see this message, it means the renderer has not been properly enabled\n",
+       "for the frontend that you are using. For more information, see\n",
+       "https://altair-viz.github.io/user_guide/troubleshooting.html\n"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data.plot(kind='bar')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.vegalite.v3+json": {
+       "$schema": "https://vega.github.io/schema/vega-lite/v3.4.0.json",
+       "config": {
+        "mark": {
+         "tooltip": null
+        },
+        "view": {
+         "height": 300,
+         "width": 400
+        }
+       },
+       "data": {
+        "name": "data-9e8a1deb68113a0fc52e584514228101"
+       },
+       "datasets": {
+        "data-9e8a1deb68113a0fc52e584514228101": [
+         {
+          "index": 0,
+          "value": -0.21767896374028844
+         },
+         {
+          "index": 1,
+          "value": 0.6037763908517348
+         },
+         {
+          "index": 2,
+          "value": 2.085054199890827
+         },
+         {
+          "index": 3,
+          "value": 3.416918242122044
+         },
+         {
+          "index": 4,
+          "value": 3.055052870125853
+         },
+         {
+          "index": 5,
+          "value": 3.740661701390467
+         },
+         {
+          "index": 6,
+          "value": 4.314423127686804
+         },
+         {
+          "index": 7,
+          "value": 4.602150794140218
+         },
+         {
+          "index": 8,
+          "value": 4.366516533828004
+         },
+         {
+          "index": 9,
+          "value": 5.320006778058893
+         },
+         {
+          "index": 10,
+          "value": 3.630381476045523
+         },
+         {
+          "index": 11,
+          "value": 3.28543876917823
+         },
+         {
+          "index": 12,
+          "value": 3.3023436662451164
+         },
+         {
+          "index": 13,
+          "value": 2.787360144208991
+         },
+         {
+          "index": 14,
+          "value": 3.0318694358800773
+         },
+         {
+          "index": 15,
+          "value": 2.842556828366233
+         },
+         {
+          "index": 16,
+          "value": 5.5147292461710125
+         },
+         {
+          "index": 17,
+          "value": 5.9795317350387105
+         },
+         {
+          "index": 18,
+          "value": 6.825462179401228
+         },
+         {
+          "index": 19,
+          "value": 6.321920597261879
+         },
+         {
+          "index": 20,
+          "value": 5.358585067415754
+         },
+         {
+          "index": 21,
+          "value": 5.423553696912329
+         },
+         {
+          "index": 22,
+          "value": 2.2185134640725876
+         },
+         {
+          "index": 23,
+          "value": 3.2734828904873123
+         },
+         {
+          "index": 24,
+          "value": 4.080759584335997
+         },
+         {
+          "index": 25,
+          "value": 4.554900138051219
+         },
+         {
+          "index": 26,
+          "value": 4.96582838485692
+         },
+         {
+          "index": 27,
+          "value": 5.452517653637267
+         },
+         {
+          "index": 28,
+          "value": 4.916987945011077
+         },
+         {
+          "index": 29,
+          "value": 4.078080001723468
+         },
+         {
+          "index": 30,
+          "value": 3.2657051816620273
+         },
+         {
+          "index": 31,
+          "value": 2.814912238889269
+         },
+         {
+          "index": 32,
+          "value": 3.8857135946357904
+         },
+         {
+          "index": 33,
+          "value": 4.103134744478959
+         },
+         {
+          "index": 34,
+          "value": 2.927276150201358
+         },
+         {
+          "index": 35,
+          "value": 2.001159361112061
+         },
+         {
+          "index": 36,
+          "value": 1.0072116999696281
+         },
+         {
+          "index": 37,
+          "value": 1.5940180092029606
+         },
+         {
+          "index": 38,
+          "value": 2.6578312521356438
+         },
+         {
+          "index": 39,
+          "value": 2.8955721127279253
+         },
+         {
+          "index": 40,
+          "value": 2.1205155497447388
+         },
+         {
+          "index": 41,
+          "value": 1.1414116033058854
+         },
+         {
+          "index": 42,
+          "value": -0.4079513325181001
+         },
+         {
+          "index": 43,
+          "value": -1.6147795773840339
+         },
+         {
+          "index": 44,
+          "value": -1.1697713448489386
+         },
+         {
+          "index": 45,
+          "value": -1.3428575525620638
+         },
+         {
+          "index": 46,
+          "value": 0.1460896364212152
+         },
+         {
+          "index": 47,
+          "value": -0.6464308567918783
+         },
+         {
+          "index": 48,
+          "value": 1.192566242489495
+         },
+         {
+          "index": 49,
+          "value": 0.7532041177694748
+         },
+         {
+          "index": 50,
+          "value": 1.9132072860119222
+         },
+         {
+          "index": 51,
+          "value": 1.336113833157092
+         },
+         {
+          "index": 52,
+          "value": 0.3050694347651961
+         },
+         {
+          "index": 53,
+          "value": -0.533816010813897
+         },
+         {
+          "index": 54,
+          "value": -0.2168819482849525
+         },
+         {
+          "index": 55,
+          "value": 0.1363720328685194
+         },
+         {
+          "index": 56,
+          "value": 1.6520950769613019
+         },
+         {
+          "index": 57,
+          "value": 1.2742448517561686
+         },
+         {
+          "index": 58,
+          "value": 0.18156530486525924
+         },
+         {
+          "index": 59,
+          "value": -0.46677721579248066
+         },
+         {
+          "index": 60,
+          "value": 1.0132082788293086
+         },
+         {
+          "index": 61,
+          "value": -1.0920924146035031
+         },
+         {
+          "index": 62,
+          "value": -0.8633975255009756
+         },
+         {
+          "index": 63,
+          "value": -0.5027686894903969
+         },
+         {
+          "index": 64,
+          "value": -1.942655217014441
+         },
+         {
+          "index": 65,
+          "value": -2.605360987794434
+         },
+         {
+          "index": 66,
+          "value": -3.266998206267096
+         },
+         {
+          "index": 67,
+          "value": -3.862995186311024
+         },
+         {
+          "index": 68,
+          "value": -3.8108001324488665
+         },
+         {
+          "index": 69,
+          "value": -5.364126962862649
+         },
+         {
+          "index": 70,
+          "value": -3.7098692077008155
+         },
+         {
+          "index": 71,
+          "value": -3.053010525590692
+         },
+         {
+          "index": 72,
+          "value": -3.5915764683062266
+         },
+         {
+          "index": 73,
+          "value": -4.588424247599213
+         },
+         {
+          "index": 74,
+          "value": -6.320551204516049
+         },
+         {
+          "index": 75,
+          "value": -7.980724585411982
+         },
+         {
+          "index": 76,
+          "value": -7.745641800853409
+         },
+         {
+          "index": 77,
+          "value": -7.630487313675264
+         },
+         {
+          "index": 78,
+          "value": -10.189871835156909
+         },
+         {
+          "index": 79,
+          "value": -10.423192290588963
+         },
+         {
+          "index": 80,
+          "value": -9.830024872718923
+         },
+         {
+          "index": 81,
+          "value": -8.358314369790154
+         },
+         {
+          "index": 82,
+          "value": -8.592553327694517
+         },
+         {
+          "index": 83,
+          "value": -8.677012362204078
+         },
+         {
+          "index": 84,
+          "value": -8.413664727803932
+         },
+         {
+          "index": 85,
+          "value": -8.930585529963219
+         },
+         {
+          "index": 86,
+          "value": -7.848083787670971
+         },
+         {
+          "index": 87,
+          "value": -8.536997847529248
+         },
+         {
+          "index": 88,
+          "value": -9.594262979225823
+         },
+         {
+          "index": 89,
+          "value": -9.116383234141601
+         },
+         {
+          "index": 90,
+          "value": -9.808759295922272
+         },
+         {
+          "index": 91,
+          "value": -10.586333145642776
+         },
+         {
+          "index": 92,
+          "value": -10.37478433832342
+         },
+         {
+          "index": 93,
+          "value": -10.650711703959578
+         },
+         {
+          "index": 94,
+          "value": -10.856956853030994
+         },
+         {
+          "index": 95,
+          "value": -11.386445026312877
+         },
+         {
+          "index": 96,
+          "value": -11.758757263881288
+         },
+         {
+          "index": 97,
+          "value": -13.599561306524677
+         },
+         {
+          "index": 98,
+          "value": -13.309853682360751
+         },
+         {
+          "index": 99,
+          "value": -14.662511622769625
+         }
+        ]
+       },
+       "encoding": {
+        "tooltip": [
+         {
+          "field": "index",
+          "type": "quantitative"
+         },
+         {
+          "field": "value",
+          "type": "quantitative"
+         }
+        ],
+        "x": {
+         "field": "index",
+         "title": null,
+         "type": "quantitative"
+        },
+        "y": {
+         "field": "value",
+         "title": null,
+         "type": "quantitative"
+        }
+       },
+       "mark": "area",
+       "selection": {
+        "selector003": {
+         "bind": "scales",
+         "encodings": [
+          "x",
+          "y"
+         ],
+         "type": "interval"
+        }
+       }
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAbEAAAFMCAYAAABF3IJ2AAAgAElEQVR4Xu2dDZBdZZnn/6dJSGeUMWEABUZJpjM4jh8kaOLOSJlQioukI81YDd1SI0GJW85IEXR2vWFY01IW96IrJM6WVY66ibrSTcYljemgsyOSbM3qwjgS1rHKjUrC1iCDwJIBgc5Xn62n+9z0ufeec+97nuecc8+993+rUlC33+c9z/k973n+933P++GBHxIgARIgARLoUAJeh/pNt0mABEiABEgAFDE2AhIgARIggY4lQBHr2NDRcRIgARIgAYoY2wAJkAAJkEDHEqCIdWzo6DgJkAAJkEBaInYGgN8A8ImUBEiABEiABPIiYBWxpQC+DOAFAGcD+BaAnXk5z+uQAAmQAAn0NgGriG0EcAWAqwH8MYAdAF7f20h59yRAAiRAAnkRsIrYuQAOAPg+gEsAbAPw+byc53VIgARIgAR6m4BVxN4D4BsA/hrA2wEcAzAoSMvl8pjneVvDeM855xysXbu2t4nz7kmABEiABDQE/IGBgb56Q6uIyfDhzwDcAUAmdzwP4NUAfh3lYaVS8UulkvWampt3svnlL38pkOifE63GQuSnBBeYkR/52QjYrIvc/nzf9x577LGZqPxsTdh/AeD3APw5gAsAPATgfAAnKGK2BhVlXeRGJv7SP1vMyY/8bARs1kVuf1mKmPS69gCQd2PyuS2YrRhJkz2x7m1kFDFbbMmP/OwEbDX0qohVqZ0H4GkAx5thpIh1byNjErbFlvzIz07AVkOvi5gTPYqYE6bYQkVuZEzCttiSH/nZCdhqKHJ+yXI4MRE1ilgiXA2Fi9zImIRtsSU/8rMTsNVQ5PxCEXOMbZGDyCTnGMQmxRhfG0PyIz8bAb01RcyRHR9SR1AxxciP/GwEbNZsf93LjyLmGFs+BI6gKGI2UORHfpkQsFVa5PxHEXOMbZGDyOFExyByONEOiiKbCUPmFz1WipgjOzYyR1BMcjZQ5Ed+mRCwVVrk/EcRc4xtkYPInphjENkTs4OiyGbCkPlFj5Ui5siOjcwRFJOcDRT5kV8mBGyVFjn/UcQcY1vkILIn5hhE9sTsoCiymTBkftFjpYg5smtnI9uw5Z4h359ZOVUZHYtzt53+uSCkfy6U4suQH/nZCNisi9z+KGKOsW1nENeXJiY94MqZvr5V999+tRw02vBpp38uCOmfCyWKmI0S+fUiP4qYY9TblYSHxnYvOTF99LnAzX1TlZFLKWKOQUtQrF3xdXWR/rmSii5Hft3LjyLmGNt2PQTrt0xs9nzcVXXT93Dz3vLItnq32+WfIz6eJ+YKKqYc42sDSH7dy48i5hjbdj0Eg5+ceAQeVp5y08eRBZ6/arIyejjserv8c8RHEXMFRREzkmJPLAuARc4vFDHHiLcjiFfcsmtl38zMIw0u+picumPkKoqYY/AcirUjvg5unSpC/5LQaixLft3LLw8RewWAPgAvNMPIo1ga6Wwoje/04V0Xxa1+kgcf0u59SOXOGF/G10bAZl3k9peliPUD+CqAVwGYASA9iq1xKClijWQGPznxHDwsiWG2faoysrn6tyI3MiZhWwIhP/KzE7DVUOT8kqWIbQSwBsCfAfAAyPDXfQBORuGkiNVS2VAa3+jD2xHX9Hzg8N7KyHKKmO3hJD/yS4eArZYii0TRf0RlKWK3AXgbgLcC+GcAtwL4Dntibo29ujasWenwkCIfAjeucaXIj/xsBGzWbH96flmKmPQi3gngCgCrAHwOwOsA+OVyeczzvIahxeHhYf2ddJHlE8++hM/e+9OWd3T5xefhvW89v2U5FiABEiCBbicwMDAgI341n4YvEkK4E8BRAFsCu6cAvAPAL6Lq4XDiPJWGafVx4H0cmLpjRH4g8MV/wsZZX5y/hG0AyY/8bAT01ln2xP4UwCYA7wbwuwB+COA8vhNrHqzB0oQsZL7JNaQL4C+XNWNMIq7EosuRH/nZCNis2f70/LIUsUUAvhAMJ74UzEyciHOVPTFgsDS+DvAeTBLO6g4efAiSUGssS37kZyNgs2b70/PLUsSqXi0F8HxcD6xaqNdFTPZIPD599BEPWJYonMGQIh+CRNQaCpMf+dkI2KzZ/vT88hAxJ+96XcSSDiOGocqQ4uc3rTkU9WLTCX4OhfiQ2iCTH/nZCNisi9z+KGKOsc06iIOlCd/RlYZiMqT4hRtW30UR0xLkxBg9uTnLrJ8P+mclYLMvcnwpYo6xzTKImndhNW77OFDZePHKLV//0TrfP20dfH9l/d6KjrfpVEx21u/z/SN7KqM7nQyY5FwxxZbLsv2ZnWN8zQgZXz1CilgEO3k/NTl21ZHwn7JsZGYRi7iH6qxFfdOIthwqjS874XuzmxIvWLxoeT2nuOtlyS+Ne6R/NorkR342AnprilgEO9ny6WTfaQfCpyhn+ZDWnxmmD2fY0r90qjK6L5265msZLE3I7Ml1wTc1+zc2u1aW/NK4R/pno0h+5GcjoLemiEWwky2f+uBPhofLsnxIB0vjY0DjDib6sIpl+iIWJbb1u+mzJ2aLGvmRXzYEbLVmmf9sngEUsTqCMpR4YvrocwBy2yXeZZ/E5IH2Pz1VGR1LbhdtcWoYsXFX/X1TlZFLW12nyA+B+E7/WkWw+d/Jj/xsBPTWFLE6dvO7x/v7pyqj1WGzTJPcYGl8H+Ct1YcxyjJdEasbRqy5oAf/+laTPJjkbNElP/KzEbBZF7n9UcTqYhvuFU1VRk7tH5llEFucG6ZqfR78r+2pjMpxOOZPy3d2Po60muSRJT/zDbInZkbI+NoQkp+eH0UsxC40lDj7bXiGX5aNzLJGLD70tT1JbRNxnTnZqjeWJT/tvYXt6J+NIvmRn42A3poiFmJXfxCl53lX7SlfMylFsnpIZ981wTukD2GcpV3EZkX95aOHmpwuHb5403djWfFLixv9s5EkP/KzEdBbU8RC7BonWMy/V8rqIXXt6WhCHB4O1dg7HwkTVN5sbVpW/DT3FWVD/2wkyY/8bAT01j0pYlfcsmulIAuvA6sfSpxDOt+byeohre/96UPZaGkRMd1ejvGTSbLilxYv+mcjSX7kZyOgt+45ERMB6zs58+DsEJmPzVN3jGwXfFFi4gOH91ZGlmc5nJjNGrG5BqHdtWPDlnuGfN/fnbRZhXnV2zLJJaVZW578yM9GwGZd5PbXUyI2m5xn/B0173h8TC5YvOj649NHd3rAlfWhXtC/aKlsrZRVEHU9HtcGmXzBc8L3YA2OhN8jhv+YFT9XEq3K0b9WhJr/nfzIz0ZAb90zItZs2E56EPHneM0JQVYPaTZrxKoNIrmIDX5yYjc8DGmbVNzU/qz4af1kTzEtcnP1ML42nuSn55eXiJ0J4EUAR+NczfI8Mdvkibn3PFk1sqSTJ5KFOtmCZ+0wYlzvlT2xZNFqVjqr9peWh/TPRpL89PzyELELAPwEwOUAftAeEavZtDYRLR+4b29lZCirRpbNGrFTPTHnraesw4hhqFFrxrLilyiYTQrTPxtJ8iM/GwG9ddYidjqAXQBkcsRH2yFi5tl/Pg5M3TGyKouHNHpGpD6Y9ZZJdu2wDiPWXDtgpu2JRR2Fkx6V6JqyiG+aPtM/G03y615+WYvYnQAeAHAjgNvyFjFJhsenjz4S/77LLbAyVT2Lh8A2zOniu9uC59kZmzMzs2eEpfWp393elZ8w8eHt8Pv6rgovgUjLr7h6XP3L2g/6lw1hxtfGtcj8shSx92Nutt8HAXw3LGLlcnnM8xqPHhkeHraRrrP+zj8+ge/++FfmOm8c/AOsOPcMcz31FfziyRfwV1M/S73eaoXis/je6vPN/Yfw8MFnWhVL9Pc1F56Fa9fOrk5w+rx87CS++49PYN8/PTVb/vKLz8N733q+ky0LkQAJkMDAwMCpvW6rNBq+SIjphwDOAfAsgNUADgK4FsCPoupJe2JHmu94fA83f+GG1XdFQUrIpKZ4lmvEqhdqteA5TU41N+fjyNQdI0ur3zX7JRfdY3brRVr4h22L/EtT/KR/tkiTX/fyy7In9loA/QG6rwL4IoBvA3gpDxHbUBrf6cO7zha6U9bbt29afVM3ipj5nWETwOEJHs2SSNysyOoavZRi2LQaJjkbZfIjPxsBvXWWIhb2agrA7Xm9E0t/U11///ZNa9ZmIGIZnCNW2xha7dqR7RR/nNoUuKmIxfzgiFs4rW/u8ZZMwjaq5Ed+NgJ667xErKWHaQ4nptwLm/W9ct3FeNMbLrQOsdYPJ2YuYkD8gucsJnTUB7oqos2SXJPz1GpO127ZiAwFmIQN8DjcaYNHfiZ+XSdiWU1bP/93fgtPvXhydgsqE/GQcbZrxKoXihexLMQ+gs2sEMWJRDMhbbYXY1oxqNZDEbMRJT/ysxHQW3ediGU8WaLpmVlJw5CTiEUueM5sQkc9hGCCR1ySa7V3ZKvh0KTM48ozCdtIkh/52QjorTtSxCQBHzt2fFn9OqI8ErMP7NxbGblej3zOMo+hvLkrRW89leWEjno2MsFj26Y1O6LeKbZ6J9fqxGhrHNgTS4cgRczGkfz0/DpSxKq70c+c1ndpWMgy7oWdolwVsg1b7l5b/XJP+QP7k4Qh+4XOc97E7doxWNJvxZXkPoOy+7ZvWr2uXsRcJuBUt/1SXDORCZNIIlwNhcmP/GwE9NYdKWJVsZJ3Jgv7F62qvqdaX5o4ZN2dw4DSeZ9Cucb6LRObPR936a/natm43spFPFxrdy0ni67/7SUraybGODGoW2/mer2k5ZiEkxKrLU9+5GcjoLfuVBGbn9Xn48CCxYsuPTk9PSTbFelRGC19HFng+asmK6OHXWrKq9cYPp266peTeLjcRIIyZ56xCM8fR83EmPWlicmoM9zqq63fwirBZZ2LMgk7o4osSH7kZyOgt+5QEZvwa27Zx6TvQX7mL9OjSMXSeeKHawJPw6v6XTvyvHZ9nKbuGLlKvks2izTZkTIaZkzCGmrzNuRHfjYCeuuOE7G83iVpkUYt0B0s3bPVh79sYf+im6tDn9kehlnrfVjEkomHlkK8XZVPsrPLst+CiknYFmvyIz8bAb11J4rYGNC4ebAeQcqWMqy4eNFyEatAMHYDWDd7FR+yxmxs6o6R7Xm+vwtPU89zVmIk2WDY9SQwlmRbsKy3oGIStj0H5Ed+NgJ6604UsRx2udADDSy3A/4kfG83PCxpqM3HAXhYab6KcwXzC55zWuDcyrN9PrAsyfBvWlPtZye1+N5ur8/79J7yNZNVR5mEW4Ws+d/Jj/xsBPTWHShide/D9PfeQ5bzItZki6dC80hjqn11aYb8sKivj0nYFn7yIz8bAb11R4lY0d+H6cOQteXcxIhO52cZUlxfmtjhARvDpMPDrEzCtjZIfuRnI6C37igRa8fUcD3aIllWRWxiG4CbiuRZEl+0Q4rxu6PMz3pkEk4Sicay5Ed+NgJ6684SMcd1RXoc3WlZ3bUjz8kkmZD0cWDqjpFVSeuO3Z8xtJCaSTgp1dry5Ed+NgJ6644SsU59n6MPT1qW/v4FwMYT8A6lVWO76tFsCNxsf8Zq745J2BZR8iM/GwG9dceIWH4b5uphFtfS3+973mQ+21xlS8H3cPPe8ogMizp9HLbYml2gziTshDO2EPmRn42A3joPEVsK4HkAJ5u52epQTL4P0wd51jL3af1Gf+PMEw4purQb6d19ftOaQ2mf3J0mAYqEjSb5dS+/LEXsdQDuAfA0gBMAfgzgM3EoW4oY34fZWmEXWScZUnTZYkveGW7btOY6ipi+kVAk9OzEkvz0/LIUsVsBLASwFUA/gJcBnA/gV1HuOohYG3eo1wOmZfoEXIcUnbfY8nFk+0dWL6GI6WPFJKxnRxGzsctSxBbPDmIB0wCuBHAngBXBdw1eNxMxh/caNgq07iwCjkOKSfZnvOGyFRh619tqjoopEhSKhC0a5Ne9/LIUMaF2OoAtAD4hG5cD+L58WS6Xxzyvcf/D4eHhSNI/OfwcvvJ3v7BFgdZdRWDryFsgx7s0+3xz/yE8fPAZp/tec+FZuHbtcqeyLEQCJFA8AlEjKdZfpTKEuAvAMQA3Aniy2W0364nFrvMpHkd6lBMBlyHFJEsyFp9+Gv7mtmFrm8/k7mUk4qODbzhUf6hoJhdTVsqejhJcYEZ+en5Z9sQ+AmAQwPtc3GsuYuOdsOmvy22yTFoEWgwpapZkRB2jk5a7lnrk5IGBc397x7ab1hdSZOXemIQtESY/C70sRUxOWa7Zqw7AhQB+HuVwi55Y7SGYljumbdcQaDZLUdN7r+5sUjRA1RmW2m238rgfipiNMvnp+WUpYom8ihMxzS/qRBdm4Y4l0GxIsdkuHbE3HNqGqkhQqsOiPnB4b2Ukkxd38pzdf/vVB7T3zSSsJTdnR356foUXMZfFqvrbp2VHE4gZUrTs1l+0IcXGH3HzmxanFTvh5cPbsbB/0arqyeNJ62YSTkqstjz56fkVXsQKcoijnjAtMyUQNaQ4WJp48NRp2gmvXrQhxcHSeO1J5qGTwxPeWmzxU9fwcWDB4kWXaoSMSdgWDfLT8yu8iHX8zuv62NDSgUD9kGKStWGR1RdsSDFmWHT7VGVkswMepyLhXU18YOfeysj1ToahQkzCSYmxJ2YjNm9daBFz3nEhLRqsp+MI1J/QnMaPnqIMKTZr/5YDQuuD3Mgs+ZAlRcz26JCfnl+hRczybkOPhJadRqCa0GUqurzbsfpflCHFZr3KtGYqxgllkv0phTeTsK3VkZ+eX9FFrPZ9gP4+adnFBCShn9bfP3ni5aOH4GGJ+VZzHlIUITl59Ni6PeVrJsO+N3sfXN8D1d5znFC6LCYPX5NJWBuBOTvy0/MruohxkbM+tj1jKQndg38AaNzKTAthpq9vlWXKeZLrzo44+N7uBYsXLQ9Pqmg1NDpVGTEvfm6YOBI4nlQkmYSTRLyxLPnp+RVbxD458Vwqv6z1fGjZKQR8HEmzraQ1XOeCL7SMZPaATrFx2fQ6jXd3g6X43XCSiCSTsEuk48uQn55fYUXM5SHW3zYtSaAlgVRnADa7Wu3uInOTKlzWR6bx7q7Z/pKuIik9yf/wJ2968J1r3mzuGbaMirIARUIJLjArMr/CilhaL+ltoaN17xLw909VRtflcf/1vSEZyvRmZsa8uSOM4j/Gd3etfii6iqQMSd5w2e9v5VE2+tZSZJGQuyqyf4UVMc3ed/omREsSaCSQZDjNwm+wNFGzN6hsL+UBy1zqtLy7a/VD0XWbK1ln9t6Lz7vyY1e/kz0xl6BFlCmySFDEHINav3eiau87x2uxGAm4ELAIhEv9UqZVb8ihHvWwp8sPRRcGMiS55vVnLfnUh95NEXMIWFQRipgSnJyy7PveY489NpPFeWKJvAqLGBc5J0LHwhkRyGNyh3UtpGtvKQpRs0kd1fKtptpXRXjFuWeAR8XoGyJFTM+ukCLWaphDf7u0JAF3Aq7vhNxrbCwZN8U9SZ0uvaVoEasdxoy+ZvN3g+F1ZnkNvyZhUy1LkdBQm7cpMr9CihiHEm0NjtYpEWhx8GYaV0ljg+tWvaUoP5MccdRsi6vwkGSaW2GlwTZcR5GTsPhJ//QRL5yIJXm49LdNSxJwI5B17yKVH2wKsXWZwl8l1GxYtXZI0r90qjK6z41svqUoEjbeReaXh4i9AsDLAGaaYay+E0vjl6ktXLQmgTCBbBNz/cxELfukex0mec6aDauG/c/jHaKWT5GTMHti2qjO2WUpYmcBuBvACQAXAPgcgJ1x7lZFrNniS9ut0poEkhPQDNW5XiXdUYdkO88n6gHGrEfL48BOV5atylHEWhFq/vci88tSxEoAzgDwlwBeA+BJANIreykKl4jY/zxywfVp7EJuCxetSWCeQBqTO2S2Laanl0xWRg+H2ZrPPgtVlmSWokY8o3pZjUOS+S0QT9pGi5yE2RNLGs3a8lmK2FcAfA/ABABZPyLDiQMAHosTsb8/skzG03PZJcGGjdY9Q0DxvqmeTTCNfqj+IMs0ZibWPc4t30nNCtjJmQeT7jMZJZINQ5IpsMqqXVHEbGSLzC9LEdsFQP59K8D3FIC3AzhcLpfHPK9xx/Hh4WEbaVqTQAYESl/7MV4+dlJd8+UXn4d1b34NpJ7w54bLVuDNy5aq6603fOjgM7h7/6HY+haffhq2jl4E+a/m8839h/DwwWdOmW4deQvOPGNRTVU3ffkfNFXThgQSEdi+aXVD+SwWO38KwPMAtgGQp+Y5YPasp8gJHvU7diS6oxwKF/mXiNw+/bM1gmb8XBYFN7/63OSQ+p5LkskYrvFdX5o44gGvqvfHB/7V7+tbZzleJry7iNS3tzJy6uy2qn+DpYkDAC6yRYPWJNCcQHjWcJY9sfcB+BiA9wCQLtbHAfxRnGsUMVuzdU1ytqvorTvZP+uwX3X9VP3uHEmm77vyi5p1mIaAVSM/X3/t+695EYs/2kXfemhJArUE8hKxxQDuB/CHAOT/LwPwEEUsm+bomuSyuXrrWjvZP+MEjMenKiOnNvMdLE3I5I4LgGSTIFz51U/aSFPAJMrzvbHa2ZAhEeNp7K0fB5YwEshLxKpuvhbAvwA43sxv9sRsUXVNcrar6K072T/LJr31sxurM/qSznpMwq8qlGkLWG1vDDvDC5ur/nHLOP0zQkt3AnmLmJNnFDEnTLGFkiQ525V01p3u33wPKtn9168zm9/cOtm6riT8RCjhY8z6DizuTkXU0d9/ZHLsqiPVMqGe2DrAezAZJZYmgWQEKGLJeM2WTpJEFNWbTeifDWErfkl2uKj1pHHHj7m6ansyrbxv5V/YXoTy2LHjyyyTOFr5U//3qn+OJ1A86gPLoiagJL0uy/cmAYqYIu5JkoiierMJ/bMhbMVPO0wWNXlDJngs6O8/EO7JtPK+lX+t7LP+e9i/FltpPbqgf9G6E9PTk4C3Nmu/WH93EqCIKeLaSUlEcXuZm3Q6P917sWSTN5oFoZP4xS1JkHd0C+GvlJ1LrDM+M2+wvEChCVDEFOHppCSiuL3MTbqBn2INlPrU5bjhuswDpbxAOL4u0/yth4Eq3aRZlxCgiCkC2Q1JWHHbqZl0A7/w2VkuYDzPu2pP+ZpJl7KtynQSv+heVu27Qcd3Z62w8O89SoAipgh8JyURxe1lbtIN/JKuF0uyI0erAHQSvzpOj8709W2MmmSi6Nm2wsS/9wgBipgi0J2URBS3l7lJN/BL0nuo35bJCriT+IUWXG9f0L9oLG4Ci37Gp5Um7TudAEVMEcFOSiKK28vcpFv4ue6j6AP37a2MDKUFttP4SW+s1VCqdsZnWkxZT+cSoIgpYtdpSURxi5madAu/qPc90uvyAFn4K4e/Bp9ki5lbwe8WfuH71Jxr1ooT/94bBChiijh3YxJRYFCbdAu/qFl11QMjqztlzC3ibVzkrIbXxYvt43bdt7CibfcToIgpYtwtSVhx66mYdBO/8GLe+mHDufdm05sX9PdvS7KYuRXkbuIXvlfX4dlWfPj33iJAEVPEu1uTiAKFyqSb+K0vTUx6wJUAHl/Qv2hlmmIVB7eb+NWJGHe9Vz1RvW1EEVPEv1uTiAKFyqSb+FV3op/p61uV1/6E3cSvTsS4YbDqieptI4qYIv7dmkQUKFQm3cRvbkLCyaGpyuiYCobCqJv4hW8/ybIFBTaadCkBipgisN2aRBQoVCbkp8J2yqib+XHRs61t9KJ13iK2FMDzAE42g83zxGxNsZuTnI2MmzX5uXHK4p0dFz3b2PeidV4i9joA9wB4GsAJAD8G8Jk44BQxW1NkEiY/GwGbtaX9cdGzjX0vWuclYrcCWAhgK4B+AC8DOB/Ar6KgU8RsTdGSRGxXdrOmf26csujp2K7sZm2JLxc9uzFmqXkCeYnYYgA+gGnMTUe+E8CK4LuGeFDEbE3UkkRsV3azpn9unHpRxOSeB0sTh2t3PLHxonV3E8hKxM4CUAnQfR3A/wBwOoAtAD4BQPaR+778vVwuj3meJz20ms/w8HB3k+fdkQAJRBJ46OAzuHv/IdIhAScC2zetbig3MDDg1X/Z8EWL2l8F4ENBmQcAHASwC8AxADcCeLKZPXtiTrGLLcSeDvnZCNis02h/7I3ZYtBL1ln1xOoZfkRGCQC8zwUuRcyFUnyZNJKIzYPm1vTPRrcX+EUfpmnjRuvuJJCXiO0AsLEO4YUAfh6FlSJma2y9kORshCiyRecnC5+PTx89PLeBMj8kEE8gLxFLFAOKWCJcDYUpYuRnI2CzTqv9sTdmi0OvWFPEFJFO6yFVXNrJhP45YYotRH7F4MfemC0OvWJNEVNEmklOAS1kQn7k50qAvTFXUr1bjiKmiD2TsAIaRcwGrUf5sTeWWrPp2oooYorQUsQU0Ho0CdtIRVv3WvtjbyyLVtQ9dVLEFLHstSSiQNTUhPxsRHuN31BpfNkJeFz9bGs2XWtNEVOEtteSiAIRRSxtaD3ek+Xu9hk2qA6vmiKmCCBFTAGtx5OwjVitdS+2P/bG0mxB3VUXRUwRz15MIgpMsSbkZ6PZq/zYG7O1m261pogpIturSUSBKtKE/Gwke5VfRr2xxwH/MOCttUWF1u0iQBFTkO/VJKJARRFLCxqHY2cJpN0b8+Bf7wMiYg9mECpWmQMBipgCMkVMAY1J2AaN/GYJpNwbe3yqMrIsC3FMLdisqCUBilhLRI0FKGIKaEzCNmjkd4pAWr0x6YXtqYzunBVHbjicWvvMuyKKmII4RUwBjUnYBo38ThFIqTd2qhdWrXj9lonNno+7UgsUK8qFAEVMgZkipoDGJGyDRn41/AZLE9sA3KSFGu6FhesYLE0cAHCRtl7a5U+AIqZgThFTQGMStkEjvxp+luG/M195Or5+659EnlY/WBpfx0keqTXVXCqiiCkwU8QU0JiEbdDIr4Gfdk/FD6xdjg+89+2RIiYXYW8staaaS0XtELEzAbwI4GjcHfJQTFvsKbLkZyNgs5tt77oAACAASURBVM6r/Wl7Y9s3rcbAwECsiPHdmC3+eVvnLWIXAPgJgMsB/IAilk2480oiWu/pn5bcnB35zfPbUBrf6MPbEXzjsHDZ379905q1zUTsilt2reybmXnEFiVa50UgTxE7HcAuAMsBfJQill2ImeRsbMmvs/jJe6ypyui+qtcthgO3b9+0+qZmIhYMKR4GID+6+Sk4gTxF7E4ADwC4EcBtFLHsWgaTsI0t+XU2v2bryGRW4rZNa3Y4iJhp9qONIK2TEMhKxM4CUAkc+TqAswFcCeCDAL4bFrFyuTzmed7WeqeHh4eT3AfLkgAJkMAsgX3/9BR2//D/RtK4cfAPsOLcM1qSeuLZl/DZe3/ashwLtJ+AvOOs/0T9SIl9CRpzC68C8KHgb9L7+hKAcwA8C0CueBDAtQB+FGXPiR22hsGeBPnZCNis293+mk2Tl1/trv4NliY4pGhrCrlYZ9UTq3f+tQD6gy+/CuCLAL4N4CWKWPpxdn1I07+yW430z41TXCnya81vsDThR5R6dKoystKVn3VBdWsvWSINAnmJWNjXKQC3851YGuGLrsP1Ic3Og+Y10z8befJrzW+wNL6v/ngVD/7X9lRGN7ry4yzF1pyLUKIdItbyvjmc2BJR0wKuD6ntKnpr+qdnJ5bk15pfVC/K93Dz3vLItiT81pcmjniAvB7hp6AEKGKKwCR5CBTVm03onw0h+XU+v7r1Y8EN+ZfKVPwk8U1rx3wbUVo3I0ARU7SPJA+BonqzCf2zISS/zucXNRRYTXZJ4rthyz1Dvu/vthGhdZYEKGIKukkeAkX1ZhP6Z0NIft3Br25yx+ykDs1wbMwkERskWqdGgCKmQMkkp4AWMiE/8rMRcLMOT+7wgfv2VkaGdCLWOEnEzQOWyoMARUxBmUlYAY0iZoNGfon51U7u8D89VRkd04gY34slRp+rAUVMgZsipoDGJGyDRn6J+dVO7pib1KERMe5qnxh9rgYUMQVuipgCGpOwDRr5JeY3VBpfdgLeITFc0L9o6eTYVUc0IsaDMhOjz9WAIqbATRFTQGMStkEjPxW/YJ3XkanKyLJqBZrnl5M7VPhzMaKIKTBrHgLFZdQm9E+NbtaQ/LqHn0zu8OEdqU7q0MaX+yja2kSW1hQxBV0mOQU09iRs0MhPxW+wND47maM6qUMrYutLE5Pe3Ekc/BSMAEVMERCKmAIak7ANGvmp+M0tVp45Ej40U/P8zolh45FRKqdolCoBipgCp+YhUFxGbUL/1Og4nGhDVzh+MrlDnJqsjMqxKmr/uHNHCg0joyooYgqwFAkFNPYkbNDIr638wjMdU3OEFaVCgCKmwEgRU0BjErZBI7+28+OO9qmFINWKKGIKnBQxBTQmYRs08ms7v6gzylJzihWpCVDEFOgoYgpoTMI2aOTXdn486Tm1EKRaUd4i9goAfQBeaHYXPBTTFmOKLPnZCNisu7X9RZ9RZmNFazuBvESsH8BXMXdC6gyARwBsjXOfImYLbLcmERsVd2vyc2cVVbJb+XH7KVu7yMo6LxHbCGANgD8D4AG4CsB9AE5G3RhFzBbubk0iNiru1uTnzqqXREzuldtP2dpGFtZ5idhtAN4G4K0A/hnArQC+w55YFiHltklWqhQxG8Fu5jdYmjgA4CIbIVqnSSArETsLQCVw9OsArgfwTgBXAFgF4HMAXgfAL5fLY57XuBJ+eHg4zftkXSRAAiRgJvDN/Yfw8MFnzPWwgvQIbN+0uqGygYEBGfGr+TR80cIFeff1oaDMAwBkOPEogC3Bd08BeAeAX0TVw+FEW4C7+ZewjYybNfm5cYor1c38uP2UrW1kYZ1VT6ze1z8FsAnAuwH8LoAfAjiP78SyCCmHE61UuzkJW9m42HczP07ucGkB+ZbJS8QWAfhCMJz4UjAzcSLuVtkTszWCbk4iNjJu1uTnxqkXe2JDY7uXnJg++pyNEK3TJJCXiFV9Xgrg+bgeWLUQRcwWYiZh8rMRsFl3e/vj9lO29pG2dd4i5uQ/RcwJU2yhbk8iNjqtrcmvNaNmJbqdH7efsrWPtK0pYgqi3f6QKpAkMiG/RLgaCpNfe/lxcoeNf9rWFDEFUSYRBbSQCfmRn42Azdra/ni2mI1/2tYUMQVR60OguGQiE/qXCBd7OjZcPcePZ4ul3GCM1VHEFAApEgpo7InZoJFfofhxckdq4TBXRBFTIKSIKaAxCdugkV+h+HFyR2rhMFdEEVMgpIgpoDEJ26CRX6H48Wyx1MJhrogipkBIEVNAYxK2QSO/QvHj2WKphcNcEUVMgZAipoDGJGyDRn6F4nfFLbtW9s3MyLmI/LSZAEVMEQCKmAIak7ANGvkVjh/PFkstJKaKKGIKfBQxBTQmYRs08iscP07uSC0kpoooYgp8FDEFNCZhGzTyKxw/Tu5ILSSmiihiCnwUMQU0JmEbNPIrHL/1WyY2ez7uSs0xVqQiQBFTYKOIKaAxCdugkV/h+PFssdRCYqqIIqbARxFTQGMStkEjv0Ly4+SO1MKirogipkBHEVNAYxK2QSO/QvIbLE0cAHBRjHOPA5gEcFNqzrOiBgJ5i9gZAH4DwG8WC54nZmupFFnysxGwWfdS+9tQGt/pw7suTMyD/zV4fZN7yteIgGGwNHEYwAU2qrSOI5CXiMmJzl8G8AKAswF8C8DOOKcoYrYG20tJxEYq2pr8bFR7iV/d5I7HZ/r6hu6//WrpnZ36cCq+rT21ss5LxDYCuALA1QD+GMAOAK+niLUKj+7vvZREdISaW5GfjWov8atO7vCB+xb2L9o4OXbVkXp6Ub01G2GTtQxxio9xQ6CmytthnJeInQtAfp18H8AlALYB+DxFLJuQ91ISyYIg+dmo9hK/obHdS05OTw/tqYzGjiwV7CTo7R78Az486Uh0xScrETsLQCUg9HUA/QC+AeCvAbwdwDEZKpa/l8vlMc/zttbTHB4e7grAvAkSIIHeJvDQwWdw9/5DhYBww2Ur8OZlS/Hp8Ufx/34jabjzP9s3rW64iYGBAa/+y4YvWtz6qwB8KCjzAICbAfwMwB0AZHLH8wBeDeDXUfXwnZitYfXSL2EbqWhr8rNRJb9afkVaT1bttXTTLvxZ9cTqn4K/APB7AP48mKXzEIDzAZygiNkSRpQ1k4iNKfmRn41ArfVQaXzZCXht74rJe7u9lZEh8U6GQY9PHz3sAdLh6OhPXiImva49AOTdmHxuC2YrRsJjT8zWppiEyc9GwGbN9tfIrwiLoj3414ff3RXsXZ260eUlYlUHzwPwNIDjzTymiKnjOWvIJEJ+NgI2a7a/SBGzrBV7NI3ZhAvgL5+sjIofs59u6Y3lLWJOTwdFzAlTbCEmEfKzEbBZs/1Fidj4PsBbm5ysv3+qMrrOdcd8WWjtA8sirvXoVGVkZf31XetN7nd+FhQxBWs+pApoIRPyIz8bAZt1O9qfYa3Y9qnKyGa54w1b7hma8f2dce+xqsOF0adO+5+eqoyO1ZMryvs6S0QpYgp67XgIkrhJ/5LQaixLfuRnIxDZExsDGpcStbqO53lXVbevmh0CnJskIqK2rjrE6AP/6vf1rQvvFFLfw5rp61tVv5NI9dot9n9s5WLb/04RU4SASU4BjT0xGzTy62h+2int9e+xwhBmF1ofPbbuNH/mQPhd16zYje1ecmL6qGwwcYGI3N7KyJI4gJ1+LhpFTPFoUMQU0JiEbdDIr6P5adaKtRKfVkBk+NH3/d3ynmxPZVS2/ov8dPqQIkWsVUuI+DtFTAGNSdgGjfw6mp9GKMLrurQ3v740MdnneTvDQ5JRdXXyTvsUMUXroIgpoDEJ26CRX8fzS75WLHoyRhIQIp7o7z8StTFxuJ5OnqVIEUvSIoKyFDEFNCZhGzTy63h+yXs7/qVTldF9qd14k4o0w515+OVyDYqYC6W6MhQxBTQmYRs08ut4fknPFQsn59RuvklF60sTRzpxGyqKmKJ1UMQU0JiEbdDIr+P5JVwrFrk4OTUIERVF+Sfv5Tz4S3QLtbP0dr5uipiCM0VMAY1J2AaN/DqeX5K9ClvNKEwNRqii+mUAMjtyYf+iZSemp1cC3oNZXDONOiliCooUMQU0JmEbNPLreH5J1orVb9ab2s03qShYW/ZctUh4oXXy93l5eDx3DYqYgjVFTAGNSdgGjfw6nl+SyRPNdthIDURERTIl3wOuBHBquysplkSAs/Qvqm6KmII4RUwBjUnYBo38Op6f61qxxaefhr+5bTjpQcSp8Al279i8oH/Ryvpp+UXtjVHEFKGniCmgMQnboJFfV/BzWSu24twzsO2m9W0RsTmhxbKoqf1F3Z6KIqZ4NChiCmhMwjZo5NcV/Fx6M5dffB4+dvU72yJizSAX9fyxLEXslQBeBOCHwLwCwMsAZprB4nlitueVIkt+NgI2a7a/eH4ua8VuuGwFht71tsKJmNxVkhmWtlbkbp2FiJ0D4C0A7gWwAsCvAZwF4G4AJ2RXZQCfA7Azzk2KmHsAo0oyiZCfjYDNmu0vnp/LWrHKdRfjTW+4sJAiVj+D0dZS0rHOQsTeD+AdAG4G8OpAxEoAzgDwlwBeA+BJANIreynqNihituAyiZCfjYDNmu2vaU+s6blisj5s26Y11w0MDBRSxOTObvsv3/MfPviMrZGkaJ2FiFXdk2HEqoh9BcD3AEwAkODIcOIAgMcoYilGM6iKScTGlPzIz0agaU9sow9vR1wJOT/s85vWHCqyiP3t3x/w/2rqZ1khSlxvGiIm59RcAuB5AB8PeRAWsV0A5N+3gr8/BeDtAA6Xy+Uxz2s88XR4eDjxzdCABEiABIpM4BdPvoA4AVhz4Vm4du3yIrt/yrfP3vtTPPFs5EBa7v5v37S64ZpRPwKadW3fA+CNwdDgl2JE7FOByG0DcBoAWRUuJ41GTvDgcKKtHbAnQX42AjZrtr94fnFrxapbPMnarE7gt/nLD1/frEdpa0HJrNPoicVdMdwTex+AjwEQwZMulvTY/ijOkCKWLIj1pTvhISjycAn5sf3ZCDS3jp6hOH92WCe0v098438vPT599HARdr3PWsRkpuLTABYDuB/AHwb/fxmAhyhi2TwqnfAQUMT0sWd89ezEsgj8wlPVw72wovjXjHCVn8tMS1uk3KyzFLEoD14L4F8AHG/mHntibsGLK1WEh9TlIbDdZXbW5GdjS35u/K64ZdfKvpmZSd/Dtr3lEXnVMvvpFH5RQ6MiyHIPefbQ8hYxp+hSxJwwxRbqlIfAdpfZWZOfjS35ufOTdVf1exR2Er/w0KicPbawf9HGY8eOLxNxDtYEu8NQlqSIKcB1UiNT3F7mJuRnQ0x+5GcjYLMOtz/Z3X4G3rY+z9u4p3yNCNfsJ1gUvQ/ARbartbamiLVm1FCCSUQBLWRCfuRnI2CzZvtLl19Ub7IqZMenj+4MjnaxXbSJNUVMgZYPgQIaRcwGjfzILzUCtoqS5j/Z/R4+xrJ6T0YRU8QzaRAVlzCZ0D8Tvo55sW67y+ys2f5sbLuRX3DEy07AW2uj02hNEVMQ7cZGpsCgNiE/NbpZQ/IjPxsBm7Wl/WVxJhlFTBFPSxAVl0tsQv8SI6sxID/ysxGwWXd7+0v7OBeKmKK9dXsjUyBJZEJ+iXA1FCY/8rMRsFlb218wc/FAWlPwKWKKeFqDqLhkIhP6lwgXRcKGi/zILzGBDVvuGfJ9f3diwwgDipiCIkVCAS1kQn7kZyNgs2b7KwY/l1OuXTyliLlQqivDh0ABjSJmg0Z+5JcaAVtFaeW/uB39k3pHEUtKjLPDFMRqTdJ6CMyOxFRA/2xkyY/8XAmkMcmDIuZKm7+EFaSiTZjkbCjJj/xsBGzWabe/wdKETPJQb09FEVPEM+0gKlxoakL/bETJj/xsBGzWvdb+ZLai5WwyipiivfVaI1MgosimDY0jAakR5fNrQ5kFPzmWxpuZ2afZmooipohnFkFUuBFrQv9sNMmP/GwEbNa92v600+6zFLFXAngRgB8K6VIAzwM42SzMPE+MD4GNgM26V5OIjdq8NfnZSPYyPznaxYe3IwnBLETsHABvAXAvgBUAfg3gdQDuAfA0gBMAfgzgM3GOUsSShLCxbC8/BDZyc9bkZ6NIfuRnIbC+NHEkybBiFiL2fgDvAHAzgFcHInYrgIUAtgLoB/AygPMB/CrqZililibAJGyjR37kZyVgs+/1HwFJF0FnIWLVCMowYlXEFgfDitMArgRwZ9BLCw81noo8RYwPgY2AzbrXk4iNHn8EkJ+NwGBpYhuAm1xrSUPENgK4JHjX9fHQhcMiJl+fDmALgE/I6dUAvi9flsvlMc/zpIdW8xkeHna9B5YjARIgARLoEgIPHXwGd+8/5Hw32zetbig7MDDg1X/Z8EWowHsAvBHASwC+FCNiMoS4C8AxADcCeLKZh+yJOccvsiB7EuRnI2CzZvsjPwuBwdL4OsB70LWONHpicdcK98Q+AmAQwPtcHKOIuVCKL8MkQn42AjZrtj/ysxEABksTka+aourNWsRkpqLMSJQpkzLsGP5cCODnUU5RxGxNgEmE/GwEbNZsf+RnIzArYoddzxvLUsTU90ERU6ObNWQSIT8bAZs12x/52QiIiI3vA7y1LvVQxFwo1ZXhQ6qAFjIhP/KzEbBZs/0Vn1+S3e0pYop48iFQQKOI2aCRH/mlRsBWUR75L8kWVBQxRTzzCKLCrVMm9M9Cj8OxNnrkR35WAoBsCNw3M/OIS00UMRdKHE5UUIo3ocjacJIf+dkI2Kzzan+uMxQpYop45hVEhWuzJvRPS27OjvzIz0bAZs32N8fP9bBMipiivbGRKaCFTMiP/GwEbNZsf53Bb31pYtKb26aw6Yci1opQxN/5ECigUcRs0MiP/FIjYKsor/znOkORIqaIZ15BVLjG4TAtNIpECuTmquDzYUNJfnP8XLefoogp2hsbmQIaRcIGjfzILzUCtoryyn9DpfFlJ+C13AmYIqaIZ15BVLjGX8JaaBSJFMixJ5YGROaXeYouMxQpYopWx0amgEaRsEEjP/JLjYCtojzzn8v2UxQxRTzzDKLCPb6T0ECjSBipzZvz+bChJL95fhtK4zt9eNeFiD4K4KIwYYqYor2xkSmgUSRs0MiP/FIjYKsoz/y3fsvEZs/HXeKxD9y3sH/RxhPT05PhzYEpYop45hlEhXvsiWmgUSSM1NgTSwsg88s8yeoMRQ/+1/ZURmeP86qfek8RU7Q8NjIFNIqEDRr5kV9qBGwV5Zn/hsZ2Lzk5Pb2tKmCBiNWc/EwRU8QzzyAq3GNPTAONImGkxp5YWgCZX1qTDM9azFLEXgngxbmhzJrPmcH3R+Nc5aGYrYPYrAQfAvKzEbBZs/2Rn41Aa+vwvopZiNg5AN4C4F4AKwD8OuTSBQB+AuByAD+giLUOlqYEk4iGGnsSNmrkR35pEWhdz2BpYhuAm6RkFiL2fgDvAHAzgFeHROx0ALsALAfwUYpY60BpS1DEtOTm7MiP/GwEbNZsf635hQ/NzELEqh7IMGJYxO4E8ACAGwHcRhFrHShtCT4EWnIUMRs58iO/NAi0rkMmfJyYPvpcWj0xmfZ4CYDnAXw8dPmwiEnvTLbU/yCA74ZFrFwuj3met7Xe7eHh4dZ3whIkQAIkQAI9SeCz9/4UTzz7ErZvWt1w/wMDA179lw1fhAq8B8AbAbwE4EsxIvZDAPKu7FkAcsWDAK4F8KMo+pzYYWuT7ImRn42AzZrtj/xsBNysq7t55DWc+FoA/YFrXwXwRQDfDoSvwWOKmFsQ40oxiZCfjYDNmu2P/GwE3Kw3lMY3+vB2ZC1i0vt6us6lKQC3852YW6A0pZhENNTmbciP/GwEbNZsf278qke1ZClibp5ElGJPTI1u1pAPAfnZCNis2f7Iz0bA3XqwNHF4qjKyrGrh+7732GOPzSR9J+Z+RceSFDFHUDHFmETIz0bAZs32R342Au7W60sTk3srI0MUMXdm7OkkZBVVnEnOBpH8yM9GwGZdpPYnu9zvLY/IwufZD3tijrEtUhApEo5BS1CM8U0AK6Io+ZGfjYC79RW37Fp5/+1XH6CIuTNjTywhK4psCsDqqqBI2JiSX/fyY0/MMbZ8CBxBxRQjP/KzEbBZs/11Lz+KmGNs+RA4gqKI2UCRH/llQsBWaZHzH0XMMbZFDqLcAv1zDCRFwgaK/MgvEwL6SilijuwoEo6gmORsoMiP/DIhYKu0yPmPIuYY2yIHkT0xxyA2Kcb42hiSH/nZCOitKWKO7PiQOoJiT8IGivzILxMCtkqLnP8oYo6xLXIQ2RNzDCJ7YnZQFNlMGDK/6LFSxBzZsZE5gmKSs4EiP/LLhICt0iLnP4qYY2yLHET2xByDyJ6YHRRFNhOGzC96rBQxR3ZsZI6gmORsoMiP/DIhYKu0yPmPIuYY2yIHkT0xxyCyJ2YHRZHNhCHzix4rRcyRHRuZIygmORso8iO/TAjYKi1y/ktbxF4J4EXZHT+E7BUA+gC80AwjzxPr3kbGnqIttuRHfnYCthp6QcTOAfAWAPcCWAHg1wD6AXwVwKsAzAB4BMDWOJQUse5tZEzCttiSH/nZCdhq6AURez+AdwC4GcCrAxHbCGANgD8D4AG4CsB9AE5G4aSIdW8jYxK2xZb8yM9OwFZDL4hYlZAMI1ZF7DYAbwPwVgD/DOBWAN9hT8zWmOKsi9zImITtMWd8bQzJr3v5ad+JSS/rEgDPA/h4CE9YxHYAeCeAKwCsAvA5AK+T92XlcnnM87yaocWFCxfi+PHjNtK0JgESIAES6DkCZ599Nj784Q/LiF/Np+GL0F/fA+CNAF4C8KUYEbsTwFEAW4K/PxUMOf6iE4cTiz7cSf9szy35kZ+NgM2a7S8bfs1ELO6K4Z7YnwLYBODdAH4XwA8BnNep78TYyLJpZLZa07NmfG0syY/8bARs1nHtTytiMlPxaQCLAHwhGE6UHpsMH07EucqHIJsg2mpNz5rxtbEkP/KzEbBZd2r704hYFKmlwbuzyFmJVYNOhWRrGulZk5+NJfmRn42AzZrtLxt+aYmYk3cy2WPLli1jToXbUIj+2aCTH/nZCNis2f56k1+uImZDTGsSIAESIAESqCVAEWOLIAESIAES6FgC7RIx2WdxcbAHY7vhLQBwerCUoOpLkfyLet9YNP+eqwtikfwT184M2posB5FP0fyrfwaK5F/UvqhF8i8qfxTJvzMA/KZur9le90+2K5T5E+FFw3FMpP29HGxrGKkV7RCx6wFsBvAEABGQa4OZjnmL2WkA3gTgwwFQ2U5LPkXxTxaN3xOwOQHgxwA+UyD//gDANwH8EsBvAfivwczUovCrtqcLAPwEwOUAflAgfjKzV2b4fjdw9P8A+I8F8i9uX9SixPffB2tSqz9KNgC4GMDKguQX+fH55WBT9LMBfAvAzgLF9/UAPhWIgzwjfx08w1nGVwTpzQA+C+AuALub5FxZynU3AMl94p9spCH8Gj55i5iIlqjvEgD/GkzPfxJAOW8FAyC78Ve3zfrHYE/IIvknW3gtDJYtSEKRXyMSzMcLwk92cZHYjQfrBD8fbD9WlPhKk5Ie9i4AywF8FMDDBWp/8iNA2t8HggdV/C1S+4vaF3UvgOmCtL9wyrgDwL8A+KsCxVf4yU5GVwP4YwCyu5FsHlGU50NE6yCA/wTg94P/F5GRE0qyys8XAbgOwJUA/iIQsbg2LyImvdi/BPCaINeIf7KUq+aTt4hJMvkegIHAixuDX07SG2rX58+DXfmlJ1Yk/2S4VQIpSUOCLrujXAbg7wrGTzZ//ncAvgHgvxUsvsLsAQDSzkQwRHSL0v4Gg1+a8qD+A4BPAjhcIP+i9kX9WYH8q+YLOVlDftG/AcD5BfLvXAAHAHw/2L5vW3ACSFHan/TCRFClA/Fvgo0q/igYXck6P0uvVEZxJG5xOVdyn7CSdceiU3JKivj1WLtFTBrc3wCQrqx8ZMePtQBuaJeCAQiLWNH8k56EbOn1CQBDAJ4pID8RfznhQH4hya+rosRXfBLx/2AwZCdJWd5NFMW/dwXDX/8ZwDVBnOVXu/Qci/B8RO2LKsJbFP+qKeMrQQKWI6GK9PzKtn3yw056PG8HcAzALQVqf38I4H8FwiridSEA+e/Xcmh/YRGLi9lvB21NyspHtjQUjvJDr609MeldSLKTl3iitNX3UDI+2q5PWMSK5J8MIUrCkMYvPQnpRRTJPxFVGZ77VTD8IJM75JeSvCMrQnxlCzTZWeZZAKuD4ZIPAfj7gvgnP1Dk5bb8k/ezMvYvwzo/L4h/UfuiivDK+8UixFfyxe8EP+zk/dORgj0f8iNAeq4y1Cm9bdlIvfo6oCj85BxI+WEiz6z8uBMhyyM/h0UsLqdVmUkPVp4PyS8yzCk9sraKmFz80eD8MXkY/jZ45/Pf26VgdT2xIvn3kaCBva+OTVH4VYLNnz8NQH7VybCd7JspE1BkiLHd8X1tcGir4JNf6V8E8O3gV3sR/BNu8sJffJF3JvKrXX4EFCW+cfuiFiW+Elfpbcs7lvAzUhR+Mirxe0F+EfF6KBjulPfvRWh/8uNd/JNRHnmdIyNiMmqRB7+wiMXlXPkR/zEA0qMdDk5SkZ5iwyfvd2LigDQ4mckmH3lRLC+2pVfWro8EU5JH9biZovgnv+Tk5XD4I7+UZOy/CPxEuGSoRHoP1aESScRF4RfmNgXg9mB2YlH8k3cmMuYvPTD5J/uOip9F8S9uX9Si+Cfxld6iDDNJb6f6KYp/cubiHgASZ/nIcLbMViyKfyKs9wc9RNm8XYbqZFQlD/9ExCSHTQZsoq4pIib+SZ6R3prMB5AfAoUQMXFCpmRLV1aGyIr4oX/uUZGHVBJJuJtPfu78ZOaVzKwLf4rEL2qdYpH8iyJdJP9kdEKWUoTXRBXJPxmxkAONwx2JdvgXd03xT56P2IMo29ETc3+8WZIEW/pTDAAAAEBJREFUSIAESIAEmhCgiLF5kAAJkAAJdCwBiljHho6OkwAJkAAJUMTYBkiABEiABDqWAEWsY0NHx0mABEiABP4/qesQ/pPZMQYAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<VegaLite 3 object>\n",
+       "\n",
+       "If you see this message, it means the renderer has not been properly enabled\n",
+       "for the frontend that you are using. For more information, see\n",
+       "https://altair-viz.github.io/user_guide/troubleshooting.html\n"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data.plot(kind='area')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DataFrame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame(np.random.randn(100,3).cumsum(0), columns=['x','y','z'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.vegalite.v3+json": {
+       "$schema": "https://vega.github.io/schema/vega-lite/v3.4.0.json",
+       "config": {
+        "mark": {
+         "tooltip": null
+        },
+        "view": {
+         "height": 300,
+         "width": 400
+        }
+       },
+       "data": {
+        "name": "data-13099b60e16e19b1dfc8ec8ad5449064"
+       },
+       "datasets": {
+        "data-13099b60e16e19b1dfc8ec8ad5449064": [
+         {
+          "index": 0,
+          "x": 0.10174192426040822,
+          "y": 0.31973437326889537,
+          "z": -0.24087925640418273
+         },
+         {
+          "index": 1,
+          "x": 0.46377109678002576,
+          "y": 0.39284953965450403,
+          "z": -0.8470307992657274
+         },
+         {
+          "index": 2,
+          "x": 0.5427920704495576,
+          "y": 2.0215438525479135,
+          "z": -0.5041337657185385
+         },
+         {
+          "index": 3,
+          "x": 0.691790393493323,
+          "y": 1.4080784951558476,
+          "z": -1.5530227427069885
+         },
+         {
+          "index": 4,
+          "x": 0.5438454859014044,
+          "y": 2.282289197786082,
+          "z": -2.47969679801141
+         },
+         {
+          "index": 5,
+          "x": 0.8412672776574759,
+          "y": 0.9336365164416933,
+          "z": 0.11586844310132616
+         },
+         {
+          "index": 6,
+          "x": 0.4440696728540403,
+          "y": 0.5846040675015804,
+          "z": 1.198605562039081
+         },
+         {
+          "index": 7,
+          "x": 0.37689265681375916,
+          "y": 1.8445078498152159,
+          "z": 2.1971366928099076
+         },
+         {
+          "index": 8,
+          "x": 1.7088994296520779,
+          "y": -0.2965165131611587,
+          "z": 2.4854050834183345
+         },
+         {
+          "index": 9,
+          "x": 0.7594255157953386,
+          "y": -0.7840081732519648,
+          "z": 2.530393125472639
+         },
+         {
+          "index": 10,
+          "x": -1.4872055561564141,
+          "y": 0.3599911702784182,
+          "z": 4.835100132883255
+         },
+         {
+          "index": 11,
+          "x": 0.2150577809319032,
+          "y": 0.11582875972667908,
+          "z": 5.208579582224949
+         },
+         {
+          "index": 12,
+          "x": 1.5744840005341858,
+          "y": -0.372546574433127,
+          "z": 5.51545982910521
+         },
+         {
+          "index": 13,
+          "x": 0.3679772618606698,
+          "y": -2.878238152804081,
+          "z": 4.186569493581132
+         },
+         {
+          "index": 14,
+          "x": -0.11537830312732728,
+          "y": -1.9506804820892456,
+          "z": 3.339122687346829
+         },
+         {
+          "index": 15,
+          "x": 0.268552495967064,
+          "y": -2.3876264052815257,
+          "z": 3.7811188858038514
+         },
+         {
+          "index": 16,
+          "x": 2.226832215019299,
+          "y": -2.126093605804431,
+          "z": 2.0328388792460435
+         },
+         {
+          "index": 17,
+          "x": 3.8506435691911456,
+          "y": -1.3191840891125446,
+          "z": 0.6586872458863735
+         },
+         {
+          "index": 18,
+          "x": 3.176396308806726,
+          "y": 0.5053296955453654,
+          "z": 0.584394876179876
+         },
+         {
+          "index": 19,
+          "x": 3.6109830595525274,
+          "y": 0.24878768452561512,
+          "z": 2.154914558728954
+         },
+         {
+          "index": 20,
+          "x": 4.268315558606928,
+          "y": 0.28702041547905166,
+          "z": 2.1925933269587845
+         },
+         {
+          "index": 21,
+          "x": 5.051792703926308,
+          "y": 0.8084957713851727,
+          "z": 2.726933416131036
+         },
+         {
+          "index": 22,
+          "x": 3.960653857760024,
+          "y": -1.0602674336345799,
+          "z": 1.6993094433335816
+         },
+         {
+          "index": 23,
+          "x": 4.0584745148057975,
+          "y": -1.6941204224418502,
+          "z": 1.6515505886605286
+         },
+         {
+          "index": 24,
+          "x": 3.786081117290783,
+          "y": -0.46754429414988685,
+          "z": 2.4685878205488523
+         },
+         {
+          "index": 25,
+          "x": 2.741724342276396,
+          "y": 0.1523948677505672,
+          "z": 4.58321713054731
+         },
+         {
+          "index": 26,
+          "x": 2.8013085128398605,
+          "y": 0.7990974820535526,
+          "z": 4.892019651329498
+         },
+         {
+          "index": 27,
+          "x": 0.2069234183914137,
+          "y": 1.24699471682072,
+          "z": 4.654423098801681
+         },
+         {
+          "index": 28,
+          "x": 2.1655806809093194,
+          "y": 0.4687251097775069,
+          "z": 5.912860340821911
+         },
+         {
+          "index": 29,
+          "x": 1.9829943803653802,
+          "y": -0.05890571295352498,
+          "z": 5.893990033926627
+         },
+         {
+          "index": 30,
+          "x": 4.248989972799317,
+          "y": -0.254524993710882,
+          "z": 4.507886736419069
+         },
+         {
+          "index": 31,
+          "x": 5.934371725729361,
+          "y": -0.8869058278485157,
+          "z": 4.571610341559309
+         },
+         {
+          "index": 32,
+          "x": 5.4140845862818425,
+          "y": -0.5044805179694067,
+          "z": 5.62977884584074
+         },
+         {
+          "index": 33,
+          "x": 5.4501816431594925,
+          "y": 0.3429631069122123,
+          "z": 6.02974958340587
+         },
+         {
+          "index": 34,
+          "x": 5.399664441419694,
+          "y": 1.703967924986447,
+          "z": 5.61243990526056
+         },
+         {
+          "index": 35,
+          "x": 5.172968470830933,
+          "y": 2.397689255319875,
+          "z": 3.692298753317647
+         },
+         {
+          "index": 36,
+          "x": 5.750154694482398,
+          "y": 3.1886569430215896,
+          "z": 4.344349548933432
+         },
+         {
+          "index": 37,
+          "x": 5.092582320162698,
+          "y": 3.1067826056283856,
+          "z": 4.917785581801794
+         },
+         {
+          "index": 38,
+          "x": 5.254272059482469,
+          "y": 4.141413004966657,
+          "z": 5.620976316751887
+         },
+         {
+          "index": 39,
+          "x": 6.357545531371504,
+          "y": 4.097757647686296,
+          "z": 6.18646564919352
+         },
+         {
+          "index": 40,
+          "x": 5.57987671819632,
+          "y": 3.514169061914425,
+          "z": 5.664795621912372
+         },
+         {
+          "index": 41,
+          "x": 6.868678223733693,
+          "y": 4.438871989278683,
+          "z": 4.971151710223277
+         },
+         {
+          "index": 42,
+          "x": 5.978478595171977,
+          "y": 4.256481510544367,
+          "z": 4.290192930843104
+         },
+         {
+          "index": 43,
+          "x": 7.27385413218568,
+          "y": 4.4418126528036,
+          "z": 4.195896001192871
+         },
+         {
+          "index": 44,
+          "x": 7.60085135587176,
+          "y": 4.162472682994865,
+          "z": 2.032617349280593
+         },
+         {
+          "index": 45,
+          "x": 7.948721752538825,
+          "y": 2.81277416046235,
+          "z": 2.694012623718799
+         },
+         {
+          "index": 46,
+          "x": 8.364290165030434,
+          "y": 4.0841944872584115,
+          "z": 2.759878490550716
+         },
+         {
+          "index": 47,
+          "x": 9.359794630240813,
+          "y": 3.482878122855636,
+          "z": 2.927735045609092
+         },
+         {
+          "index": 48,
+          "x": 8.104774336021741,
+          "y": 4.190030140622708,
+          "z": 3.614185846205572
+         },
+         {
+          "index": 49,
+          "x": 9.715417613466196,
+          "y": 4.623986629439741,
+          "z": 4.015269442644731
+         },
+         {
+          "index": 50,
+          "x": 9.370471485459165,
+          "y": 5.504467326189326,
+          "z": 3.041052583158115
+         },
+         {
+          "index": 51,
+          "x": 9.065885308371291,
+          "y": 5.4206861985537556,
+          "z": 1.394615266131908
+         },
+         {
+          "index": 52,
+          "x": 9.218321631226758,
+          "y": 3.739325038071642,
+          "z": 2.40901501723681
+         },
+         {
+          "index": 53,
+          "x": 10.198316200824136,
+          "y": 4.573143244874159,
+          "z": 0.8947416224225218
+         },
+         {
+          "index": 54,
+          "x": 9.35226463525669,
+          "y": 4.335863561983189,
+          "z": -0.13679849716142778
+         },
+         {
+          "index": 55,
+          "x": 8.762788860077656,
+          "y": 5.119003366159331,
+          "z": -0.4334589388760052
+         },
+         {
+          "index": 56,
+          "x": 9.117564250500054,
+          "y": 5.418976864353279,
+          "z": -0.18891403242086383
+         },
+         {
+          "index": 57,
+          "x": 9.602651859227619,
+          "y": 5.086966380253811,
+          "z": -0.6121778154020331
+         },
+         {
+          "index": 58,
+          "x": 10.879607109217254,
+          "y": 4.311484927031843,
+          "z": -1.425664934927123
+         },
+         {
+          "index": 59,
+          "x": 10.537410942379033,
+          "y": 4.387162376655904,
+          "z": -0.5399290309997808
+         },
+         {
+          "index": 60,
+          "x": 11.225578975297841,
+          "y": 3.5183673813659633,
+          "z": 0.832419083266073
+         },
+         {
+          "index": 61,
+          "x": 10.359691864727573,
+          "y": 2.7040074025101597,
+          "z": 0.44964576655079536
+         },
+         {
+          "index": 62,
+          "x": 12.26761043202559,
+          "y": 1.0648754608317819,
+          "z": -1.5795325927036103
+         },
+         {
+          "index": 63,
+          "x": 11.022252084971917,
+          "y": 2.865679137865471,
+          "z": -2.1572375190414115
+         },
+         {
+          "index": 64,
+          "x": 11.452264641911409,
+          "y": 3.3518049587910395,
+          "z": -2.096341110341587
+         },
+         {
+          "index": 65,
+          "x": 12.158060551893351,
+          "y": 2.321521136777985,
+          "z": -2.0022892663135545
+         },
+         {
+          "index": 66,
+          "x": 13.177127890975944,
+          "y": 3.6645282775200165,
+          "z": -2.4389101160888402
+         },
+         {
+          "index": 67,
+          "x": 15.522945188865691,
+          "y": 2.361464107419462,
+          "z": -3.568480388365322
+         },
+         {
+          "index": 68,
+          "x": 15.81688552955633,
+          "y": 2.5220984282537025,
+          "z": -3.7165067259278377
+         },
+         {
+          "index": 69,
+          "x": 16.129729433656294,
+          "y": 2.4937185572111527,
+          "z": -4.2466357168853275
+         },
+         {
+          "index": 70,
+          "x": 17.06784855711916,
+          "y": 3.93583270540669,
+          "z": -2.493002296789477
+         },
+         {
+          "index": 71,
+          "x": 16.70326660367303,
+          "y": 5.5249944902113155,
+          "z": -2.121319801745191
+         },
+         {
+          "index": 72,
+          "x": 16.950199127276772,
+          "y": 7.159967308032584,
+          "z": -2.7152283810749513
+         },
+         {
+          "index": 73,
+          "x": 15.248282457364098,
+          "y": 8.210170853853088,
+          "z": -1.9355365448498585
+         },
+         {
+          "index": 74,
+          "x": 16.054992388109284,
+          "y": 8.250469654794461,
+          "z": -3.107166689002126
+         },
+         {
+          "index": 75,
+          "x": 14.164541809906131,
+          "y": 8.916046264798378,
+          "z": -2.7773149839259865
+         },
+         {
+          "index": 76,
+          "x": 12.298760173518286,
+          "y": 7.155427687411402,
+          "z": -1.605128707862652
+         },
+         {
+          "index": 77,
+          "x": 11.8800503728053,
+          "y": 7.481289338966637,
+          "z": -2.065024272465417
+         },
+         {
+          "index": 78,
+          "x": 11.643534036485335,
+          "y": 6.424359008166599,
+          "z": -3.0244706955932585
+         },
+         {
+          "index": 79,
+          "x": 11.869846216582067,
+          "y": 6.834063197344662,
+          "z": -2.5672367692080074
+         },
+         {
+          "index": 80,
+          "x": 12.120206533204701,
+          "y": 7.066807418005693,
+          "z": -3.424208815445228
+         },
+         {
+          "index": 81,
+          "x": 10.594880908570588,
+          "y": 7.4382606295506015,
+          "z": -3.239480823160873
+         },
+         {
+          "index": 82,
+          "x": 10.458719301874376,
+          "y": 5.9438633998527735,
+          "z": -3.4561830287704414
+         },
+         {
+          "index": 83,
+          "x": 11.455597611962888,
+          "y": 6.077430806863743,
+          "z": -1.8707027699876657
+         },
+         {
+          "index": 84,
+          "x": 12.754059866940093,
+          "y": 7.177908821156228,
+          "z": -1.209913816481841
+         },
+         {
+          "index": 85,
+          "x": 14.708054346196757,
+          "y": 6.939716516222237,
+          "z": -1.6791085690526817
+         },
+         {
+          "index": 86,
+          "x": 15.281672532246994,
+          "y": 7.147083287222761,
+          "z": -2.2179803046948017
+         },
+         {
+          "index": 87,
+          "x": 15.52144984592544,
+          "y": 5.812799723614566,
+          "z": -2.8043770783954693
+         },
+         {
+          "index": 88,
+          "x": 15.117744315987167,
+          "y": 5.444030417678696,
+          "z": -2.280572102090161
+         },
+         {
+          "index": 89,
+          "x": 13.927728756982127,
+          "y": 3.220712999501728,
+          "z": -3.5345034995471702
+         },
+         {
+          "index": 90,
+          "x": 15.193044682415191,
+          "y": 2.4866111100918293,
+          "z": -3.937726991578081
+         },
+         {
+          "index": 91,
+          "x": 15.071570219335568,
+          "y": 2.9177719361150682,
+          "z": -1.6453903467106312
+         },
+         {
+          "index": 92,
+          "x": 14.202344173379267,
+          "y": 2.364584729551816,
+          "z": -2.172403692590777
+         },
+         {
+          "index": 93,
+          "x": 15.887154022596365,
+          "y": 1.0427051146283275,
+          "z": -3.492515229576884
+         },
+         {
+          "index": 94,
+          "x": 16.68478992256872,
+          "y": -0.6943145021549451,
+          "z": -3.228226032811297
+         },
+         {
+          "index": 95,
+          "x": 18.131774750904352,
+          "y": -1.6764272841025862,
+          "z": -1.1351491559933211
+         },
+         {
+          "index": 96,
+          "x": 17.814194344521113,
+          "y": -2.8151228157108497,
+          "z": 0.2388957166555099
+         },
+         {
+          "index": 97,
+          "x": 17.305576906316734,
+          "y": -2.7856877507761673,
+          "z": -0.09130337260940496
+         },
+         {
+          "index": 98,
+          "x": 16.804003476374817,
+          "y": -3.385818957044541,
+          "z": -0.7751946313592928
+         },
+         {
+          "index": 99,
+          "x": 16.013016105881928,
+          "y": -3.569795812183962,
+          "z": 0.018632786890970587
+         }
+        ]
+       },
+       "encoding": {
+        "color": {
+         "field": "column",
+         "title": null,
+         "type": "nominal"
+        },
+        "tooltip": [
+         {
+          "field": "index",
+          "type": "quantitative"
+         },
+         {
+          "field": "x",
+          "type": "quantitative"
+         },
+         {
+          "field": "y",
+          "type": "quantitative"
+         },
+         {
+          "field": "z",
+          "type": "quantitative"
+         }
+        ],
+        "x": {
+         "field": "index",
+         "type": "quantitative"
+        },
+        "y": {
+         "field": "value",
+         "title": null,
+         "type": "quantitative"
+        }
+       },
+       "mark": "line",
+       "selection": {
+        "selector004": {
+         "bind": "scales",
+         "encodings": [
+          "x",
+          "y"
+         ],
+         "type": "interval"
+        }
+       },
+       "transform": [
+        {
+         "as": [
+          "column",
+          "value"
+         ],
+         "fold": [
+          "x",
+          "y",
+          "z"
+         ]
+        }
+       ]
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAdQAAAFbCAYAAABswX9hAAAgAElEQVR4Xuy9C3gdV3Uv/ttHT1tyIicBK0SJZUx5N5FDCaWk2Ia2PKI0TsGWHMqNTUl76U2wDRciRwHLFNsn8AfbFG5pE2ob2lhSUqzcyBBaqGUI5SZpEzkNUMrDcuJgmTwsJ3as59n/b805+5x9RvPYM3vmnJG09X18gM/ee9b89pr5zVp7PRjMn0HAIGAQMAgYBAwC2ggw7RXMAgYBg4BBwCBgEDAIwBCqUQKDgEHAIGAQMAhEgIAh1AhANEsYBAwCBgGDgEHAEKrRAYOAQcAgYBAwCESAgCHUCEA0SxgEDAIGAYOAQUCFUCsB1AMYscFVB+AcgIyB0SBgEDAIGAQMAnMdAT9C/RiAvwDwEIDzANwK4DkAdwOYBLAYwOcB7J3rQJr7NwgYBAwCBoG5jYAXoVYDGMtZp2cB3A5gEYCnASwA0AmgEcAJAGStvjS3oTR3bxAwCBgEDAJzGQE/C3UhgFMA5gP4HoDdAP4AwHcBdANW2g25fJcC+NVcBtLcu0HAIGAQMAjMbQT8CJXQuRLAHgBPAPgzAF8H0Avg3hx0JwG8BcDQjh07uhhjW2RIX/ayl2HFihVzG2Vz9wYBg4BBwCAQBgG+dOnSVJiJ5ZjjR6jvzJ2XfhRAT07ATwN4AcAuABU5C7bBLTgpnU7zjo4Ov+uU496ta/7yl7+kDTPyhdwBg19I4HLTDH4GPz0E9GYb/dPDzz7bi0jot9M5F+/D0sQ/BnAzgD8CsBoABS691U0sQ6h6G2YU3uCnh4DebKN/Bj89BPRmJ13/ghDqqwD83DZhH4CPAPgWgNcDmAfgD3NRwI7IGUKd3QqVdIU38hn900NAb7bRv1mDH8UPUUDu5wBsBlAF4DNBCNUPiUsBDAOY8BpoCNUPRu/fzQNp8NNDQG+20T+Dnx4CerMTpH+vBfBTAOSh/UcAr8sRbNENxn52aAh11iiU440kSOGNfHqqZvAz+MWAgN6SUb5fWju6D6lI059uX+kyjgJuu3Je2q86jTGEaoKSVHTMdUyUCq8liMtkI58eqgY/g58eAnqzo9S/1o79AyrS9KfXuqWlUGGjNIAbc9ku05YzhGoIVUXHDKFqoeQ+OcoXRhwiGvn0UDX4zRr8KKbo0VxA7pdztReesd+dIVRDqFoab14YWvCZtC09+Ax+Bj9NBJSn/zOA7wP4LIC/ywUlrTeEakPAEIKyQjkONPgZ/PQQ0Jtt9M/gp4dAtLONhWosVC2NMi80LfiMhaUHn8HP4KeJQLTTDaEaQtXSKEOoWvAZQtCDz+Bn8NNEINrphlANoWpplCFULfgMIejBZ/Az+GkiEO10Q6iGULU0yhCqFnyGEPTgM/gZ/DQRiHa6IVRDqFoaZQhVCz5DCHrwGfwMfpoIRDvdEKohVC2NMoSqBZ8hBD34DH4GP00Eop1uCNUQqpZGGULVgs8Qgh58Bj+DnyYCytO/mauSRJ3XfgfAJwGssc82hGoIVVmjnAYaQtWCzxCCHnwGP4OfJgLK07flRnbmusxwAFTbt+jPEKohVGWNMoSqBZXjZPNBooepwc/gp4rAme2NSsXx628bdiqO/yYAdwN4DYAfA/hTAI8ZQrUhYB5IVXV0HmfwM/jpIaA32+hfcvBb1bG/uS+9dkhPouLZUe7vmW2NSsXx6zuHnYrjk/H5JIA/A/A1AJcBICvVWKgyAlFuWJSKJNYy8umhavAz+OkhoDd7LukfdXNhwN7702v36qFWmJ0w/KjTzGoA3QDI9Tvtz7h8jctXS/cTpvDT7sXIp7W95oxSD745hV9rR7dlsTHw9VGRasKe36sAPASgBcARQ6gOCCRswwwhaL7A7NPN/uoBavAz+Kkg0NqxfwXApDNK1tWfbtuqMtdrTML070oA1FiciNXxz1ioxkLV0vmEKbz5INHazemTzf7qATpX8Gvt2N8FMIp6JcvtCkKNA3sPptuntTgLgmiC8PsAgE8DuAUAtXIzhOqEQII2zHGDjHxBHj9DCHpoGfwMfuEQoPNTgC1njF0PnmnIgO1iwPm6pJqg9189gAyAl7wQMhaqsVDDPUG5WQlSePNBorWTzpPN/uqBOlfwE+enlbU1C/u6rh957229LSyToSCl8znDpoM72neFQTLp+NnvyRCqIdQwep6fk3SFN/Jpbe+cCqrRQ2rufpBI56dH+tPtFLBj/V27uWcV5/wAOEYqGV8WJqUm6c+vIVQbAknfMCOf3mvO4Gfw00NAb/Zc0L9rNndvZBw7Gfi++9Nr18mIXdPR3ceA6wAM9KfbnQomeAKcdPwMoRpC1XtDGPwMfpEioLdY0l+4c0E+QZpO6TKrug40TIyODYV1/SYdP0OohhD03mAGP4NfpAjoLZb0F+5ckK/11u5TYGioBF/i5NaVXb+ZitTKb21fM6i66wnC72MAbpTk/kcAnzOEaghBVZeVxiVI4R3lNfIpbaPrIIOfwc8LAQo+SmUyVNP2WH+6vdltbGtHNwUlbQDHYP8d7ctUUU2Q/l0IoAHApQAo3/Yduf8uuhUTlGSCklR12xCWFlLOkxP0wjD7a/Y3MAJe56fyYuT6nRwdI8t0McC39qfXdqlcLMrn43jbaqXi+E0997id9VbSWTCA7wD4Kyf5DaEaQlXRa2PBaKHkPjnKF0YcIiZZPrJ6Pvknb9jw9qt+O/b3WFhsk4wf3ZOufNd27N/LwW5UKTcoV1PKpFLLVFy/uvLJ+3Z8zRql4vhNvb1OxfFpqe25XqjvATBlCNUBgSg3LOxD5zXPyKeHqsFv9uJHZ3fzaioazk5y15czvcT702uVXqR6SM1ND8Q1Hd1HGdCsSpCy67dyXs1KylmdIe8/IlEq+k9VoIbdZI79yy6dTvOOjo7YrxP2YTAv3LDIZecZ/Ax+egiEm50PdKHpDnmOlovx3NgeztByMN2+JNxV9GfN5ueD2rVNgh3lwOmD6XY6X1T6a+3oJtcvEdPu/nT7xhlCqA8CeBuAF3Py9gL4sF322InOEKqSjrkOms0PpB4yarMNfmo4uY1KKn4iVWNedQXOjU8RqQ4Ki8dyLXJ2gCJP6b5E9R49JMLNTip+4m505Lu2Y/86DraHA/cdTLevUkVICmSir6GVXh4EHflU5YlynCFUc4aqpU9JV3gjn9b2JtIDkQtwOUV3tqX9cmztfjxbkJ1jkAEDnMFm9Xi/tPUQ8p49m/VPnJ+GKS0oiulzYMjLg5B0/IyFakMg6Rtm5NN73Rn8Zh9+IrKULKMv3fTm6z7+jccXTo6O0Tmp1eUk+8e3Aows1A1Bokr10Jo+ezbrX9DzUzs6rR3dQxT16xXQlHT8DKEaQo30nZF0hTfy6W13EvFrvbX7MTC00It4101X7Vm6dCnLWa1Eqg2ZVGoVRZCKc9agLkk9xIpnJxE/WcKw8gm3bdDzU/nawmXslZsaVr4o9zDIWsbla1y+QfRl2tikK7yRT2t7E+fytQfCyPtLpEp3KyJHpbGebkU9hOamy1e4e1UCi7wQuqaje4TKErqdpSb9+TUWqrFQI31/JF3hjXx62500/ETahSjE7iefeGGXKzDJTz693dGfHUY+8aFCV3crN6gqmThLdSqsT2uEkU/12nGMMxaqsVC19CrpCm/k09rexL3Q7Od2fvsrN76+f0dbnx4awWf7yRd8xWhnhJHPjwSDSOhHzmHkC3L9qMcaQjWEqqVTSVd4I5/W9iaKUKXc03zdWL/9FS9/t8AkWjNOovWTT2939GeHkU8Uw/dLeVGVzst9HEY+1evGMc4QqiFULb1KusIb+bS2N1mEmitzJ5Oj3/4WSJgf7k+vLSopR/mqDFhn7+Gph1jxbD/5orxWmLWCypcPJAKKmomHubaYk89LpQId82qWyNWTgsqnI0cUcw2hGkLV0qOkK7yRT2t7E0Oo0ou86NzOb3/zLkWOkf472hfKaFiWEWdXBOl+EhRNP/mCrhf1+KDyyRHW96fXUim+SP7yrnnw9fK6QeWLRBiNRQyhGkLVUJ/kBw0k/YE08vmrn0ym9uAVFfzygUlSv0757K4/3R7be1BFPn8E4hsRRD5R3F4nVcbtToQnIcz+xodO8JVjUyQhiik9GHxT5BlBFF7vSuFmG/nC4SZmGfy88bv21u6dovKRUwEAFfycApMKZ6t0/fgqKanIp6dBerODyFc461RvvxZEOqdGBkHkC3KtuMYaQjUWqpZuJV3hjXxa21tWl+81Hd176IyT7sCtmo7K/joFJhUCa9zX1kMuO1tFviiuE3aNIPK1dnRzuk4pU5CCyBcWgyjnGUI1hKqlT0lXeCOf1vaWhRBynWIOUTUkci8y8FVuBdRV9tcemCS7kHPo+HY9CYuiinxh145inqp8Ui/TyIKRVORXlU9lrVKMMYRqCFVLz5Ku8EY+re0tOaFaEZ9TmT2CTHkqtcKrEbXK/toDk6TAmn3UHBuYHgGsh1phtop8UV0rzDqq8on6ybqVkYLKqCpf0HXjGm8I1RCqlm4lXeGNfFrbW1JCtbVdO1JZW7MiqgbUIjCJXMe5lmOnq8BbqJ8n9VO1RwDroVYeQqWPkYrMVEuQ6FvV50Ocn3oVso8KM3kdVfniuHaYNQ2hGkINozf5OUlXeCOf1vaWmFCzZ3QU6VlRW7vRj0xprOr+iv6p1C6MAc0il9UpAlgPseLZqvLpXrO1o2cLwLvo4yBTkVrpZdWHISzdzjJh769U+IWVzz7PEKohVC1dSrrCG/m0tleZsPSuAkhpLPkqSCprqu5vcVRvoQatiACOK9JXVT6Ve3UaI7vI879TgQTGl/Wl11J7NM8/Ffnk/rNxphg5Caoin989lvJ3VUKtB3CW4suDCmfSZoIiVp4v3LBSJl3hjXxhdzY7r1T4FYJegp1nqsonBdVYFrCojuRXmlAPvXjxs4KrONsJBuqycwzgFBHdBbDl1BKtcl7NSj8rXwW/sHuji10p9S8KWWkNP0J9OYDLAXwTwKsA/AZADYBnADyQE+JnAD7lJpAhVL2tUlF4vSvozTbyGfz0EMjOlizIQBG3qvonW1myNSoifuPqmaoqX1AM5Q8EChSqrK3pIvKU+sJSs/WB/nT7Sre1KS3pfW+9bN3/fezkQi/iDbs3Qe9pLlio7wPwNgCbACzKEeprAXwGwA0AJv1AM4Tqh5D373E9kHpSFWYb+fSQNPgJQu3eBWCDWxF7N5SD4Nfa0U0u0JH+dHuLWE+qIzsYRwnCIPIF0SQRqeyEF7nPJ8AGqc8oB/YeTLevt69d/IFh+R77eIr1VdVU32cnV3H+XOqApNlooYp9IFevINRWAHcDWADgEQC3AjhkLNQgj4P62LgeSHUJDOFHhdVM/AIvlf6FPcsMIh8RQwq8zx4FKwoWxHE+GEQ+VT2TUliOVdbWtDhZl/kPBZdCDCI3d151Bc6NTxUu7RDxXK6ApLlCqO8EcCWALwNoA7AZAFmtjuerxkJVfUycx8XxQOpJVDzbyKeHpsEvi1/Yl3YQ/IiIDu5oJ0u46K+1o3sQwBVxBCYFkU9Fk3JFL47SuSlj7Hqv1nNelqVIg7n+rZfh/sdOLpwaHV3FwboALJYtUWHJxlG/V+V+o8ZP5Zo6Y/zOUJ0s1GoA9ElD/6nIuX0vBXB8x44dXYyxLXaBVq9erSOjmWsQMAjMcgQ23EnOLmD3TW8u+Z3+4+GjePi/n8UNy5fgLa++qOTXD3JBIeurLl6AW1rJjnH/G3jiJA786En89uIGfPiPfqto4Nbux/H8i2P45J+8AZdcON/6zWn8L068iL/u/y+oXC/IfQQZu3TpUlWeCrJsLGNVBZVdvlsBvAzAXwL4PQDfALDUTTpjoertW9K/0Ix8Zn/1EAAk92TgsnZR6F+cQTdRyCfwlQORKqXOOW74u7WuE/9OVueXbnrz+YKw5HNVsX7cUdB+uhMlfn7XiuL3IIRKEb8U3XsxgO/mLFMKSiKLtN8QahTbMX2NpCuUkU9v3w1+gFcTcD90o8AvzrSQKOTLE+qt3Y9RScYggVtO7mxxBkvpQ7tuuupG2QK0d5Rx6tTjtydR/h4lflHK5baWKqE6zW8EMOwnpLFQ/RDy/j3pCmXkM/urh4CcMhO8LVgU+hdn4YIo5CN85bPMqtqaZr/80oJVK6KnkU9Hks9Wd9101R6ZUKWep0MH0+1LRFceFYtYVw+c5keFXxyyOa2pQ6hKMhpCVYLJdVDSFcrIZ/ZXDwFAWEWcYZNT0JDX+lHpX1wlCKOSL6wVnZ/HkU8LkknyCzddddR+RplLL1pM+8E4dpYrIIn2PSr8dHVUdb4hVFN6UFVXHMclXeGNfFrbW5IXWtiUmShfuHG5NqPSP51zXvljYdKqY8wozdE6r3aSL5+WwzGSrcIUrHqVnsYVz44Kvyhl8lrLEKohVC1dS7rCG/m0trc0hHpr9yl6cYdxK0a1v3EF30Qln44Vn28MYFmcvAGwMjEsF7CTfNOKPiC4K15P6wqzo8IvKnn81jGEagjVT0c8f0+6whv5tLa3NITake0yE6awQlT7G1cJwqjk07Hi5XtjHIspsEnksLrJVwhOAvzyXfU0zHt2VPjFKaO8tiFUQ6haupZ0hTfyaW1v7IQa9mxQ3FVU+ytSd6i9GwXj6KEWvYWlU81pusVZ+Hhxw68oRae2xrPWb1RYOa0T1f7GKaMhVAmBpG+YkU/vUTD4JRs/Xcswyv3VIS03lKOQT8rTDdTaTpapkD5D/1o4E/WSLxecRJ6DZj0tCj87CvzCXz34TGOhGgs1uNaYDxItzOTJSX9hxC2f7tlllPLpuFXjJFSdPF0hl9wPVo6m9sKPgpPAseJgun1VZAofcKEo9zfgpUMNN4RqCDWU4kTtctMSwmNy0h/IuS6fbieTKPHTCfyJk1B1PzpINrlYfiaVWvat7WuofrGnSz/rKh7d2J9eSzV+y/IX5f6W4gYMoRpC1dKzpCu8kU9re0txhjpgNcQGX9mfXjsQVNoo91fq4hKoJ6uXzFHIF1VKD6XPkKwH0+3UkNz6i0K+oHsWZHzS5bPfiyFUQ6hB9Hva2KQrvJFPa3tjf+GKc8vKkIEvUe6vboCUE9JRyBe2E49dHrLA6d/uT69dZwhV77lwm20I1RCqlmZF8cLQEsBnspFPD9048YuiNViU8sVRgjAK+aIKlqKzWPBMg9wPNgr59DTMe3bS5TMWqg2BpG+YkU/vcTX4JRe/KCzCqPdXlN2Tzxl1ENSVLwqMhPz0wUD/W64DrCufDjYqc5MunyFUQ6gqeqw8JukKb+RT3krHgXHiJ1JmqOuJ7IYMInHU8uWDpHyad6vKqCuf3BkmLEZesurKp4pD2HFJl88QqiHUsLpd8hduFIIm/YGcy/JFEb0aNX5RyCTrra58rR2iW0w85f905YviGZ3JhG8I1RBqpM+AeSD14JzL+EURvRo1flHkfEZLqPu1oqD9tDNq/PyuF/T3pMtnCNUQalCd9hyfdIU38ultd5z4tRYaZodKmaE7i1q+VR37myfBjoJjpP+O9oV66OnLl2+1FjIK2k/+qPHzu17Q35MunyFUQ6hBddoQaqSIFS+W9BdGnPJFEb0ah3y6qTxRWaiC3OPsRxoHflE+LkmXzxCqIdQo9T1yCyFS4WKwYIx80SBQcK1m+3KGXTWOF26UJQh15IsywtcNXx35wu5ZkHlJl88QqiHUIPrsOzbpCm/k893CsnggoirzF8f+RhkIpCOfTlNx1V3XkU/1Gjrjki6fIVRDqDr6PW1u0hXeyKe33XHgJxdQCNNUPCqXqhsyUaTziLV18BMfHQx8vVyMQW9HzZFDlPgZQjWEGqk+6bwwIhXEZTEjnx7KceAnCAvQc/fSncUhX97VyjHYf0f7Mh0EdeSLImjLT3Yd+fzWjuL3pMtnCNUQahR6nl8j6Qpv5NPb7jjwE8UT5DZiYaWMQz6SJYqAKV3Cj0oGL2zjwi/sftrnJV0+Q6iGUKPSdWudpCu8kU9vu6PGL0p3b5z6V2jIHa4LjkA9LH5RBW357X5Y+fzWjer3pMtnCNUQalS6bgg1AiST/sLwko9e+vfvaOsLAoNw93LgvigaV8eFX1Tnl2HlKwRGIbJWck77FFa+IHuuMzbp8hlCNYSqo9/T5iZd4Y18etvthR9FoTKWGgxCqroNxUvlEowqwjas/pXi/DROC19P6wqzw+IX1fWDrmPat5n2bUF1pmh80hXeyKe1vZ4u/Vy+5mB/un2jylWK3L0RVf6Ja3+jygENI18cbeTc9ieMfCp7HdWYpMtnLFRjoUal68blGwGSSX9heMlnNb7OluhTioSN2t0bp4UVFfmH2d9CFDQ/3J9euyICNXNdIox8ccpTKg9EXPdgLFRjoWrplnkgteCbsUFdYYKLonb3xkmotHa+YhLHYOW8mpVyH1GVXSeMrl226NSfXfd7gd6zURW9UJHRPL8qKKmPCbTR6ssWRqbTad7R0RH7dcLIFvcDGVYmeZ5ReD0UDX7x4FdwiQIqhQfyRecBVEbk7o37+c19NAwCWMyBvQfT7etV0SR8ONie+dUVzfd8ZnWg959l+QPNUTU595LZPB+qO6o2LtBGqy1ZPMoQahjUCnOMwhv89BDQm+2mf6LxNa2uErErRc2GbibudCdxPx/vva23hWUyAww4H1DrSdra0bMF4F1C3iDVoEpREN98sOs9E16zDaEal6+WdsX9QtMSzuTJ6sLn6pIWBGldwKfVWZF1Cr6kL712SFuw3AKl0D8pJxSMsevdopqt++TsABhEsf9jZN2qWPACD/GhwsAj/fBww7sU+OnsddLls9+bIVRDqDr6PmPPALVuOsLJSX9huMlX6MiSBcPLPRmXdUrXLRV+skUOsK7+dNtWWQ1ab+3eAKALDA0AjgF8HWeshXHsDEKOcZwze6lrqfAL+8gkXT5DqDYEkr5hRr6wj2J2nsEvHvxEWTwAuwFscHOHxmmdlnp/pWILZJUPZipS66szUyOTYHsAWNG45P6uqq1ZRwFMYWoC5xuKR2zJGwtV7zlQnW0sVGOhquqK4zhDWFrwzUjCp3PFVCbzGFlijLGNnPMDRDBO6TNxWqelJlS6Xo4k95Irl1zd1u4zNFAT8BRj6+zu4CDNymVc+9PtzXqapTbbPL9qOKmOMoRqCFVVVwyhaiHlPHkmvtDEmaIIRnIjjbit03IQKl0zF/1LQUfk5i2ySu27vHH3Qf6LEy/SqJX96bUDXioUVXWmIGo6E/UvyP2VeqwhVEOoWjpnHkgt+GakhVp48WejXsV5qj1gJ27rtFyEKnY8+2GRGfEiyi/3fp8/8OiviVAtrHwIdQBgy70Cn/S0bfps8/xGi6ghVEOoWhplHkgt+BJPqE/89L/5G1/36qL3hJ1AnSJTJfclgqSNBEUz6frX971/53f9yy+IUD2rHkVVmWm24Zf0/bXjbQjVEGrQZ7BofNIV3sgXfnvpvPCG5a88dMN73lL0nhCFBwRRCvLkwNDBdPsSixzOjR3NRbzO6W4p9EHSse9RaxP60+2u79s4yjKq7Lx5PlRQUh9jCNUQqrq2OIw0D6QWfIm2UFs7ug9dcuH8FX/7iT/OvyfcCre3dnRTbuliSp9JTWX2ZHMxTS1aej423PmIlY/qlVpU6nQZobXm+dV7fo2FakPAKJSeQhn8Zid+cmlBmQjcurDk688CQ1Q2jyKAK2trWoLWvw2K5kzQv413PryPg93IGTYd3NG+y36P5XL3lvsMWmWvk76/hlANoarosfKYpCu8kU95K4sGknUqcivlwgRSgYMiV26hQ4oV9Xqap1IrvrV9DdXBjfVvJuzvxjsfXk91fd0KPAhMVUo4Rg3mTMBv6dKlsXtSo8I1dkFNLV+9rTIKb/DTQ8B9NlmbThGqwgolYrRq2HKMVM6rWULWplsnFNnKClJqT/feZsLzccvX/mMZ5e2KM2b7PYtm4qXEzbh8dTXPeb4hVHOGqqVZM+GFluQv3HLiRy9yzjBo76JSsE751ksurNvy9HMv5TvKFEoOTs+rbO3oJot0QLXhuJbi5SaXEz8V+YV813R0j9DHiT3iWS6GX1Vb0xy3i9wu80zBTwXrJIwxhGoIVUsPzQOpBV/ZgpLkogtyazLZOqUX/Jq3vOLU3YePWqX2qBKSKOLgFLHqZvHqIeQ9e6bon1uubqmL4RtCjVMbqWhWzH/G5asH8Ex5YejdZXyzDX7O2MpnnjRCkKpsnVIhAsLvo3c+Yrl+ySVJZ4EUcFSq0nh+mjFT9tetClLe3evRxcYPA53fZwp+OvdYyrmGUI2FqqVv5oHUgq9sFqpcxSgDtirb7xNUGm8FnZ0K92Mu7cMqgE9ngBTBW47gGTeUZ4r+ORXKL3XvUycMZwp+ek9Z6WYbQjWEqqVt5oHUgq9shCp3NRlPVTQUmmhb9mq+TB7t78fvfHjJJNjRwp36l9HTQ0V99kzSv3yHHg46T92bYWhgwLog7d3UkVEbOZPwU7uj8o4yhGoIVUsDzQOpBV9ZCNWpqwn9G5Eq3Y0cHCP2V+5/Wspas37oziT9y7nZNwK4Qr6vcuI5k/Dz04Uk/G4I1RCqlh6aB1ILvkCESi5C1NaO6EaCugXCWKTKMyvk4gNif+Uz1zhr8wZFcybqH+FckZnamHO1j5TzPHom4hdUR0o5XpVQ6wGczcYu5P/qAJwDkPES2AQl6W2nUXiDn0CAAlsYMHR/ei314wz95xZx6rSgrH8i9cOrJm1ooUJOnOnPB5FrKQpguME70/ELqTaxTfMj1JcDuBzANwG8CsBvAFwE4G4Ak1aTXeDzAFwfcEOoentnFN7gJxCgovT0v6kAvQ4qQZpey/rX2tG9C+At/em1K3SuH+Vc83zooWnw08PPPtuPUN8H4G0ANgFYlCPUDgALAHQCaARwAgBZqy85iWYIVW/DjMIb/AgBuR2aSrNqN9REc3AAR/rT7S1+6Mr6l4tK3VjKwg1B5PMbW47fzfOrh3rS8Vu1NWYAACAASURBVAtKqGI8uXoFod4F4LsAupHNYyWX71IAvzKEqqc8fi636FfXXzHpCj9b5Mtah9hAO6YTFVpYRy1S145fOYo3eGnpbNlf/Scx3AoGv3C4uc3ys1CdCLUXAP3n3tyPJwG8BcDQjh07uhhjW+wXW716dbRSm9UMAnMMga3dj+P5F8fyd52+8UrMq64IjMLnvvljUCnBW1pfi1ddTI4m82cQSDYCSS4dGoWF+mkALwCgL2Z6ok8BaHALTjIuXz1lNV+Qswc/KiBvj9BV2V/JTXuMA4MMuE7OFVVFSC43qBpYpCKf6vXjGGfk00PV4KeHXxSE+scAbgbwRwDI9PwYgLe6iWUIVW/DjMLPHvyoiTRPpbrkqE6V/RVVjYhEGUsNcs4PuHUu8UJLpL4EqXSkIp/eDunNNvIZ/PQQiHZ2EJcvRfw+A2AegG8BeH3uf/8hgIcMoUa7MWI188LQwzVJ+FnRtRwjmYrUSkGqKvLJVY360muHWju6hyjCPmhBALfWa14Iq8int0N6s418Bj89BKKdrUqoTle9FMAwgAkvkYyFqrdh5oUxs/AjtyqRnl3qfC1X+oFKzzG+ifJJ/fbXKSo3TENqq1/pubGjYGjIpFLLVHMf/eTT2x392UY+PQwNfnr4hXX5hr6qIdTQ0FkTjcLPHPyI/MAzDU6FFyQSzDbtzkbrrt9101V7vIIuyE1MZ6acYZOoYCQ381atWnRNR/ceqhurmi5jPCR6emfwmxv4GUK1IWAIS0/xDX4F/MilmgFrOJhuX2VHVXa3pjhv4WA30pgbli/BDe95i6OnyIs45XNVarPmtYvCyqUuMjyVWqFqnZoPOr1nw+A3+/EzhGoIVV/LpRUMoRbAsM46AfTf0b7QDjJVOaLWZ8LdWiDErKXqZNV6BRFJ7cBGKufVLHGr72tF9nL2GLl6ZStXVQnM/qoi5TzO4De78TOEaghVT8MNfo74SWeddEi6sj+91urcQn+ypSmnq8jFGsCxsf+Oduo7Ks85QP1J3Qi30AHGvUiDaBgeJLJXvkFDCHqPi8FvduNnCNUQgp6GG/ycCbVj/17hxrXniBYCkvhhex3cu7/9EL/7cLbVKAf2VoFvnQDbwjhWkVVJ/15ZW7PQyQKVyxE6naVSMX2AbZEbhgfdfEMIQRErHm/wm934GUI1hKCn4Qa/afjJFmiOGQf772hfJgYKYgOw214Hl164G+98eH0GbJcIVipcgB8G0CVbu/aLS67jgf50+0rxu9xuTaf271wjhDPbGtfVdw5rdfMxFn50r5ik658hVEMI0Wm7iUK2sCyQFxEgW263Kr3apYkXhtzgOwXeVwF0OaXf2DePyHxidGwoS8ZZV7NMpm7uYlUlSPoLLUr5iEwBEKFG1k0nSvlU9yzIOCNfELT8x+rkofqvDsCkzSjB5DrIKHzy8ROpLURe3EpNYcvlogv2wgxuFkzYBuJSSs5QCnwrB9uTu8Y0izgomnNJ/85uazwK8Ia6zpPTgsqC4ibGzyX8wmLkNS/p+BkL1Viokep90hU+bvmKUltqaxZOjI2tYxw7RUcYUT+XzjEPptutM9E4XIKtHd2DAK4Qa+t0pIlDvkiVTlosqv09u62RUo+sxh6pFJbM2zw8rThHmHuISr4w11aZY+RTQUl9jLFQf/lLnuRuBkbh1ZXZaWTc+NlTW0SgkKi161c/Nyr55EpMUZEp4RmVfHq76D47CvlOdTU3VFedOwqw7AcPS11fd9uv+6KQOQr5opDDbQ0jX7ToGkI1hKqlUXP9gRRpKfJZpai1SzmnqUyGzuU2uHWHiRI/cj2nwEfuT6+la0byF6V8kQgUg4UvW6e55bfWdQ57FstQvZe5gJ8qFmHGJR0/+z0ZQjWEGkbP83OSrvBxyie3Q5NTW+SqSIzzVdlApeLcVAFglPI5tYfT2tw5YKHK1ikH283AN3DgcFSBSVHur+5elsODoytz0vEzhBrDF66u0njNT7pCzWX5RDCQ3cUqu3mzvUsBt/6jcxm/KJ4bXfyEdUokWpHCukwGFJg0ElVgkq58UWBk3i9xo1hY31ioxkLV0ra5/MJovbWbSvq12NuoTctLBY70p9tbjIWgpWqOk3X0T7ZOMxmsXPCp4YEz2xpHKAUpqsAkHfmiR2v6ika+aFE2hGoIVUuj5uoDKVchcorelaNuvYKE5ip+WkonTQ6D35ltl7RUsKnzM5xvBNgqcOyru33YOnc+s61xgAHLowpMCiNfVNiorGPkU0FJfYwhVEOo6triMHIuPpAqVYjkOr1exRXmIn5aCqdxZJPNM0Wz/fqyNSoFKEUSmGT2V2+3k46fOUPVeCD1VCPc7KQr1FyTz0qLmcocojq7XkQpp7F4NfSea/iFewrcZ6niR1Ypw9RjuZWOUVoT4xjiDANyqcGz219BPW0PRBWYpCpf1LiormfkU0VKbZyxUI2FqqYpLqPm0gNpnY2eGzuaI9N9fukp13R0W+dxbgFJBOlcwk9L0TT178y2i3dlI3jZ7vrOExvdZDm3o7E5ysAks796u550/IyFaixUPQ2fo/jlyJQs0xZgetcYJ1CzJQl5g73DjDw26S+M2SKfcPdyVCyr73yaqkq5/kUZmDRb8Iv0pRFgsaTjZwh1jhJCAB0ONDTpCh+FfMVkiiOVtTUr3Bp6y+Bl02osQnUtEhCFfIE2LODg2SCf5O49Vtc5PO0M1Q5JlIFJswG/gCoT6fCk42cI1RDqnFJ43QcyLJkSyFT4YYqlWu7f0eZaxk5Xvkg302Gx2SCfqrtX3H6UgUmzAb+4dcxr/aTjZwjVEGqkz0fSFV5HPh0yFSATqXq1YdORL9KNdFlsNsgXxN1LMIjAJIDdV9d5YpUOzrMBP537152bdPwMoRpC1dXxovlJV/iw8kVBpipAh5VPZe0oxsx0+YK6ewmzQmAShuo6h5fIOFIxiIVdQyOq2M50/FTvM65xScfPEKoh1Eh1P+kKH0a+UpEpbUQY+SLdQJ/FZrp8wt0rF29QwU8EJo1P1C4UBEoNyBnYqiBWq4yfRe58aqMoIqEiR9xjZvr+xo1P0PVN2oxJmwmqM7PaQrUK3nN2IBvNqx6AFBZE80ILi1x2nh9++WIOAVuyicCkfEnC7Yt2Ms6sdBuZZP2kF/LlyhweosISUdUJ9ru2yu9++KmsEeeYpMtnLFRjoUaq/0lX+CDyyUUbSkGmKoQQ6WaFWCwIfiGW157iJZ9w91Jz9/rO4WnN3b0unrdsga0AFgPIt8TjwHq5GITXOiTfBd9458LqqnOHAGbVc46qTrA2eAofJFFcQ2eNpOufIVRDqDr6PW1u0hU+iHytt3afoqINpSJTQ6j6quhNqNliDkHdvSRV1r2LPdR5hhqPEykzsAGAXxckWOnoT4/wl3/zjwYFmdLaqoRMwVHj49UDXme2Qc907YgHeT70dyv4CkmXzxCqIdTgWu0xI+kKryqfZZ1mMlSa7lhlbU2LSp5pFECqyhfFtcKsMZPlC+vuzRJqoVQhkSlQsWJiomqoumr0FP2u6vY9/X9+n1ee+jlNOQZgL4AtqgSfkx+ZDNZTJxx5/4hIq6rPbWEcK+o6Ty4Ls7fmgy4sau7zzBmqOUPV0qqZ9ML1SmER3WMA7O5Pt7uWptMCy2HyTMIv6nuPYj03/ESkbhh3r5Dr7LZGLshUVFc6u+3iPrJS/azM3JnpHupmI9agdXP1hKdFD9uxsNUeBmd8V/1tJzdZZL+98UbG+S6ynIOQuxPeRv+i0MLCGoZQDaFqadRMeiCJNBlLDToVWmjt2D8AsOX23qZa4ChMnkn4KdxOyYe44RdFkXsiT45Ul1yqsOAKds9RzV57isi0gVfVAxPn8uUOiaRVSLAQncyOgPErssDyQc7YCFmlRUAHDLiS5xr9i1ZlDaEaQtXSqJn0QBJpcrCRg+n2acn6rR3d1ouusrZmYancvcblpqV61mRXQt3WSOUetwAI3YbN6Xwya3k6u31lq9SiP+Dws9feu7z58qvz71nVsoZyMQrLsuWZvYJYsxYvNqY4a+CM71R1IRsLVV/f/FYwhGoI1U9HPH+fKYRq5ZaOjlnnX3bSvHZzzyrO+QEKRupPt1uRmKX6myn4lQqPoNdxw0+VuIJej8Y7uX1zREtn8M1EeCnOuubffmKXXT5R1tCr641TdLJ1Zlo1ZtWEnpio6aJAJckt7OtCdrtPo39hNMB9jiFUQ6haGjVTHkiJNMEZNh3c0b5L3HihGTjf6lXIXgsol8kzBb847j2KNd0t1EWnyOWqGjwURJaXPnvxRssyzJUmLOSYshZwdiRVwVfN2zw85GRBv/hXjStSKRzy6reaX59jn18RCN3OOEb/guy8/1hDqIZQ/bXEY8RMeSALpGm54oYOptvzJeVab+1+LNeWbWV/em1RNKUWOAqTZwp+CrdSliFO+IUpNxhEeKk0oRXtW101ujOXp3psfKK2RU5zscsnu4zrOocd379nty16zEqzUTgbVQ2SMhZqkB0OP9YQqiHU8NqTsMRwcuvazz/FC+2aju6jDJBad3GLPGVXsFcjcC2QZsEHSVz3r7uuM6GKHFL94vZu8p397MWD2TNNbuWY2qOBxTwn+cRcUYVJvkbQ6OQg1qzTvZgPOl0NLJ5vCNUQqpZGJemBzPUfHZStTJLv43c+vGQS7Gg2Od/KBdzAwPfdn1677tqO/es42B4O3OcUrKQFjsLkJOE3W164cpWjus5h1160CtvjOqTg9s0NcbEmnQk/V3DCIWDK7k72k1H3HNXonx/CwX43hGoINZjG2EYn6YEk1y1nOCYTI8m38c6H1wvSrALfSOQKjpHKeTVLpkZHd3GwG+3nqlqgBJicJPxmD6E2DjBguZMFGGBrPIfKbl+vnNSgFrQIpvLLc5WF0zlHNfoXlUZk1zGEaghVS6OS8kCS67b6pTPZKjapyiWiB2mOUPfJpJnPOQVfnwHbQq7gTCq17Fvb1wxqgRFiclLwcxN9Jsoncj3dzihDbJPjFMt1Cz7oFTjkhF+BjPmIXCjfKyXHS+azn23cC4YbGWebKLI4yP3NxP0Ncn+lHmsI1RCqls4l5YEk1+3/eObRPedSVbjnwt+23Ll0YyTfhr97ZIRq9FaCW0Qr3LxkpdK/kyv4YLo9UPF0LdCkyUnBb7YQqoiipWjbuttPxJoCRdeylwS04+gehdxIUcCLOSryRR9UikY47VPYeeL5WLp0aew8EPZ5SfrzYb+v2IFMp9O8o6Mj9uvM1g1LukIFke/oqlUWaS3p61Nu0Ky6r5+65QsP/sVvHnobjd/ZePWZXy689FIKUPr+w//JP/fNH9M/H+tPt+eDkq7p6B5hwPlZN032PFX1WlGOC4JflNdVXWumyacbpKOKi+o4V0LNWZWyazdsxK6bxasi40zbX5V7KueY2InOEKre9s4khb+2Y//eitrajW6Vhp5qW0PFE3BpT+/1eqgUzyZ379af33fqwsmXrB+eq5yPL1z89ju+/v99qONr9/0bP/CjJ6eRJslKbuAcoa6/P72WgpVK/jeT9rfk4Chc0I6fjvtT4XKBh7jtbyH4iPcxgCp4Uf1o64MvTHu3s9umW7wqwhr9U0FJfYwhVOPyddWW4+2r1/EMW8yAIc65lajOgNNN99yTP2uUH0grNYVjsP+O9mmEebytjVph5axAtruppyeyAvT/su6WvtedO3nd6Yra8erM5FPz+OTS75/3yhduuDN9/sbdB/kvTrxIhFpEmlJ3GQhXsPpjE91I80LTw3IaoW5rPJqtVlRwpepdQW+22/7ai9/nrmJ1pAkTmRz2Q8Lon97+2mcbQjWE6qhR5J6tqqm2gnyK/jhGmnp7F4p/Ew+knM9pLzB/vK1tI0CVZawapJabFYyvb+q+x9MqpDUxOtogAoycBD3R3t58Duxn1XyquueiK77S9pvBu5BiVAIOfRe84Y4Hzn/NrfS/nWr0tnZ004dBg+wKjvbx8l/NvND8MfIaIeOnUjRB72rBZ3vtr4jOpYpLYGxv3W2/7gt+heyMsOeoRv/CIu48zxCqIVRHzXhyzZpVKYYDADsGxgeQQXO2mhDOR4YvE1aqeCBbO/avANgha7FcSgq5fsnKBWd7BIlmf8/9f2kdJyHILUv/7nW+SW5kBqw6Mv9i3Lnod62gI2Gxkut32yXvxEupKscavbngpJZStmuz36d5oem90GT8VMr66V0t+Gyv/VVpIK56RfljIoh1bvRPFWG1cYZQDaE6asrxtrZdAN/AGbZe2t1rJccfb1+zFxw3AmxTU0+PFZ4vEWoXwKi7R/aPo++rv/qnrWDsEEXSynPE2kS8FanUsou7uy13svwnE7SbS1aQPkX23t70rid6Pv8/flus8dAHPzx5yfgLFf963qvQe+Hljj1Os1b1aEupyw3K92leaGovKrdRMn4qhef1rhZ8din3V7h9AT7CUblSbjungl/wu4t/Rinxi+JuDKH6ECq9tC/r7Q3titHdpHIp1PG2NdZZlGyNCmuTg993ac89Vgs0Id81Hd0UXHEdwLdSgAVF0H5lqO9sBc/UgWFfU3dvURTtU22r+xjYdQAGm3p6l00j1Hx9XeuXgf50+0r7GCHjPRdcju+dv7SosP3tt3zhq//zNw/9Bc35+4vevPbTX/lEt+5exDG/XPurei8zST4RJatSA1f1/nXHlRq/oKRaavmC4pl0+ez3YwjVhVBzZ4jkwmxo6unNF1IPqhC648uhUHQuOcUzRKinm3p68/mZ+X+XzlElQrVq5VKBBMYzK5ad/fXO/3ny/yED9sRlPT15y1HgkcOXLNPzJ8bGF8qpNNkSgqAz12McaMimt2Rr74r5gtxPVdRObr7svZX2wgxkfX7gqX879dYzxyiSahqh6+5LFPPPblt04NySa1bNP3pwYwaVh1UsiiiuG2SNcuhfWPnObst2mAkTJRvkmkHGlgO//IcF+Mj4xLwlcrF+u+zlkC/p+AWRzxCqDQEnhZLI1EoMr2CpJU5uSR3gVeeWQ+GdLNE8kbW1DQF8sbBcSb6Pf+PxhdRrVC6Q0L9+w3DLSycWHVj4hucfaHjNC0WF6bMFFQY//fR3X/uK8RcaOUutvLS72yJLyw17buwouYkpuInzTEvOlVxkpQrrdN/L3oQf1S8uyjEVsn5k09/e2/nr772v3HvotNfOUZ6c8nMH6jpPRpJWdHZbo3V2Xdc5vF5V32bqCzdoUfmweASdV47n1zpPrRwbEMX76zpPTvMAifsoh3xBMEy6fIZQfQj1+OrVLYVzv9xghYjUIEoSZGw5FCrvjnW4b/s5Ksm38a5/vz7boJsf7k+vXUH392Rb2+kU+HkUFPRUdTaw1/635rnH8Y4XfoGB85YO3Xvh5StzVYxy+aHZtYhgJ0bHhmQrVRD+mYrqF//3Za0LADifkXbsb97Mfnb0kl/9JHFWqijgPv7yZag++dg+MBBuiwkj3R6eRf05s6BTKkYoUi2H/oV5PsJGuQa5Vpix5cIv25B81HpuvPSpXPKpYpl0+QyhehCqjUyPcIY+xrGlnC5Du0I5tShTVU7VccfXrDlFFqKTZW63Xkm+DXc+vDVrRWYbdItgoUmWOnFz83U3ZFIVI3Kd3FUd+5sngea25x7/85Uv/HLtj+oXY99Fb6LKRXs5g5WfKgcitXbsFwFPlpUqrNO7L1z27PfPW3KR3R0s3+dPfvQQP2/XF6x/KqenwY69cE8+9669uOx33m0dvYjC6DpF3bOW7+SeQksxK3eYXOZ94xPz1nu5/5z0I+kvNCFfKTrMqD4/8rhy4qeiT+WUTwXPpMsXBaHWAHgGwAO5xX4G4FNu4MyUSklFZJo7c5POEofKdY4qKxRFvnLGWg7uaA9UAFtFccWYp9rbVzCeOUTpMk09PVL/0OwI+zlqjlAPA2y5yD+VrFjPAg7iWs9U1p/+1KV/JJmxWWIWMuVyXClndPF7T//Xg3/8/E+uppSYzkvfTc3CPevwknw1nZv3WdHJCTlLzVtTnB0ZXvvgFaKWqi4p5MiU9q6BatmOT9asqKqaaAamqPsKkerg+MS8lUFINekvtAKhxt9hJshzJMaWEz+VYg/llE8Fz6TLFwWhvhbAZwDcAGDSD5SZQKg1HR3L8m5e20v3uO3M0O9+o/5dVijKy8yANcTZt/Op9jVdllUO92pGMiZj6fRj9uLzwsKVI4TdcDnetobTbx955fvIbWx9KFTW1rTYyxeKgvbbnnoAVGLwGxddee6HCxZ/rrK2dpdbqUNai/Cb39m5JBdklQgr9cz2xkOMYwXVcT3Z/sM9glApLxE8Q7m/99V1nrCiqFX/cm7eoxaZgt03PlGzThAnEa1Mql5navbrJf2FJuQrVYcZ1f1IBKFua6SPUkpl2+pWfWmm7G9Q3Ms1PkyUbyuAuwHQ2dUjAKgSTTah3+Ev6YT6qwcf5NVf+pLVdcTJgnHKvSzlZgmFz7pJGUXeOlb9iUqm421rqMpQS4bjerd0IRmTE5u37Nza/XjeUrQsfatSkbOFa5fzeJvVMu0KIt+b33DD0Pj4RLNbG7XP/eWOZ2947rELR1OVz71q/90XqdyzwC8vc5mtVDl4ZmKitvn5D37vlCBUqcfmUF3ncKDIclEblgOH6zuHrXNs+S8XBEXpX4uDuJRnwgv35Xe/bWUqhUOl6DCjonPymHLip1LoopzyqWCZdPns9xCGUN8J4EoAXwbQBmAzALJa+Y4dO7oYk5L7c1dbvXq1CnalHzM6iprP3QGMjiLz+tdj4k8/OE2Gikf/A5X33uv6e6mE/uaPnsThJ05al7th+RK85dVKfOIpXuU/3QvU1mLyGvpGgoVDzWe2Wv9zbPsO17kyJo9e3Yq7/uUXeNXFC3BL62tR2d+Pin/7IaZ+722YbM2t6yFF1T98A6mf/AST738/pq58k7e8d9yBitMjSmOnKfqpU6j+/Oesfx7/xCfBF+arJ5ZqC63rnPfobsz/716cW/IenH7L7dOuveif3gU2cQbPXHsvpuouVpbtZfe/HxVnT+DU1Tsw1vR2x3n1T3wN9U/8PcZffiWef8dfK6+d9IF1P+vBgse+5Ipp0uWPS76qUz/Hhd9ZZ+kR6dNM/Utye7koCLUawFTuPxU5t++lVEjHacOSbKEKawzAkYmx8RVObcWcci9LqZj0hWalpeRSSejaHLhPx+2bTQuq2VkoVo9BZPj6DGPNVrlBjsNNvb3TrBxx3zImfe+/ueGBR39NUlnnnk4FIbzwEi5muSKT03jJFe14tut2DfkLNwlWqghGEuXh7F/gIpAkSHGCQoQrjtV1Dk879xbYyJGfqrmaSbcQSL7G7qvvA/h1ciu0Uj6jXtcqN35+rvByy+e3T0mXLwpCJRPmZQD+EsDvAfgGgKVuwCSVUPPF32trMXH6haLCAvZ7Kec5KinUR+96ZFOu0MERyz0KoD/dHsa7AFuOLRWrp+IK1ppUtYjcvXKZQLd9FZh8/Ypr8W8vVIECkv7mF/cOBXH30tr5ICgPErcIPJN5zGoGLuWs+j2M9Lv8QOY+BOgei+oRq6wTxZjCGWmB+OwvDFE+z+vcyy6LfCZb3zns2XAgH/jEsa/u9mHfHrBJf6FlCfVtpMOJ6TAj70+58Tv72YsHKR/Vzc1fbvn8nqukyxcFoZIf6rs5y5SCkujQu3+mEap4kWeWLMFl6Ts8ySlfe1aqYeunCFH9bhHqnY9QPllzttABp0CDK+wdXVSulyMU6klKBStOI8NXTExMDFXV1HRR3d78Gj5F62mcsPb6Xt6CB+peaZ3rfvmn3bl11NuzqXgARAF8ueShyv3aCTVL4CLoig809dwzrZyh6rphxokKNoyzTfNvP1FUC1msJ0jX6SyUzkHt1ZSkc7LTdCbrF8ErndMq9d1M+gvt6E+P8Jd/813WGX5953C+qleY/YljTrnx8yvHWG75/DBPunxREKpYoxHAsB8gSbVQRT7l1JVXYvGtHZ6Emu+84uMK9cMizO93f/shfvdhKxbJqgYkyvIx8H1eXVicrpWPvnVwcWc/MPhegFOpRd8Xk8CPijb8ZF7jyLtO/9cgOGuxgrsUCFmWT0T62ksQFlmwwOkKlmoJWrHK/kDKJQ+DWrth9k/MkdyyRYUb7PIVCI+P1HWeLDroPWv1+rQKn68XxFqo3eoeyWmXO8icpL/Qjh/ewxc+uJkI1TEYS2fPophbbvz8PB7lls8P46TLFyWh+mFh/Z5UQhWWyuQ734nmP/8LT0KVe4M29fSGcrUqgeUwyN4gOx/tyzHSf0e7cmSNXJ93Ymy82em8mO6zorp6hUozAGk9m9Rq0b1FhLpmzQAYljsRnDiT9TtjdcNXfiAtdydjA88/fnVLNjWo2Eo9s73xRnAwP7dp0L2U80Pt53xOLwzRJ1M+55TcxeLyXakU9mUysL62VM9EaaywaomcZ3qt15P33cYp0CqIizzo/umMLzch+FWQKrd8ftgmXT5DqDkEjude4hTZu+Taa31JUqR3lNKqee9tvS2pTOYxcmdV1dY0i3zLXGPsQG5flbNKP+W2//7vf/qh4yerFlwyyVKHl515eldVKjUY1IKkNZ1axWWt03xObKBAJFlO8UDK/SIzk1UPnv7p7y4DZ3W0nw1vGEAqRQ3QmVW7mTO+q/62k5uC4uE0PnddSkVqhsO5pdMLw8lNl/83zo5ka7RKf4rnofKUfPAT0AXOB3mKSh+yFsZ5g5ynmvQX2qk738Orf0NZWqnrdRp0R7HXTmuUGz+/1Jlyy+eHe9LlM4QqCDWXbzl+y0fxyquvViDU6f1B/ZRB93cq5MDBbhQRtGI9UYoviNtXpWBDUHlbO/YPUIUkr9J/Kmseb2vbCPCdch6wTiCSE6GKPE3x27mTizF6cjEqqs+dqV30ZH3Vec+BVUweE/V0OcPAxHjt9X5nkn73JwKG3HIknQm1OCFfPvekuqyVFaMtNRX2mgAAIABJREFUqRQo+Miq/RukobSQV3ZB2+9BXi/pLzQRxapb/9hvH8P+ngT8vCJ9kyCfF7ZJl88QaoFQrQo9lG+pkudU6nPUokIO4EuocLzYPMlyHTqYblcqABBHgYrWjm4LQwpI8qpW5PcyKpQ7LPRGjSrFRTyQZ7ctIjOmhQKCOOMNmamqTS/815vP41OVsniDqerRH5/32odbs6X6MMRRcb1bWzVyw46PVw+4ka6IqCUPg1vAkNMLw25VOEXmZlNgxigIrMWpkIMf5vT72W2NQ9Qej6K7GTAAjmYwkNs7HwGc5Bea1LHHM11IBYu4xiQBP6cjBHG/SZDPEGoA7UviGapczWds+/bFKoQqn6OWosi6sE6vevVF+PSH/mCaBd3a0U0Eu9ipD6gTuQkXd1Qua0H4F9RX4+u3/4mvhe+nMiIwic6o5fNZL6yzQTpophq1nLER+m+yBOUzUHphLOp++zKGKct1LiJBiZDYufr0+AsLm8dHGqeQYe8VMta97uGFUvuracFBkpVHNXIHnMq6yValbPGR7jXdcw+l7lh/Ti802T1d1znM7LmrMpY0VteKzlvtOxqbs2eyhbPVJL9w816HEC5vP32M6vck4OdVJD8J8hlCDaBtSSRU+TxxbMeO5SqESrcsrKawATJEQrKl6QajsEDp9y3tl+PNLa93IlRKu9jAgb1gbIBlONV+XcEZRngqdb29fJ9XJG2A7cwPpUL9ADtEFZJ2bbgmAkIt9FlFBdvoV8zeuZ9oVjy7y3JR99W7GaUF+bx47efkfjl8WVcaH0ml2LJ5m4fzHgTL+vts4167tUdnxRyZ5kt77snX6XV7oZH1SB9MHCwnOztSd/sJ64w3zj/x8hXBU0l+4aoUf48TK5W1k4Cf8HDI6VpeH3Qq91WqMUnAL8i9ar8I/S6WTEItFIAf2759gyqhSq7JUN1nyOqsALr8SLW1o5tqI6+gs9PdN121xUk+mXSn7QHHCGN80/3ptVaSv2Rdn1ZJifHbU/pdnOMuf+MifOJPV2rrkejBSh8r2Qhc73ZrBXcq280znGrUIpVidBZ7HZ1/1t82bOWY0gPZ2P17I1Q03u+sUcgg6hh7dX8pirq1EbVTrqdIMyKZ5PQgd0K9uI/uRexFqaoAFc5W+SAFJyX5hSbc+H77qqLPcY1JAn4idYY+zuo7T1jtEQ2hxrPj2i9CP7GSSKhyoYax7dt3qhIq3auoEORUPN4irtrqXU3dvY4VaK7p6D7KgCHq6emGm7D8RGTvFz54eb54un0OuX1zZ2ADKfC+CmBgCujKBjIBjGPX/Xe0b4ojwre1o9uykN995Stw85q3a+tRIWgqe5d+XgDh7pVfpnJpPUFAIk+R8ni9yvLRNe1lEL2LLFy8y7J6c39yJRq7dSp9iOVGs01NPT2OhR3EelL+YMmLFogzN8L2ZPv3HwvyfPi9D+Tf6ayY/v+CTw0PBJlHY+1u8aDzSzU+CYTqFembBPm89iLp8tll134R+ilmIglVynsc37btUJAXRj4i1ZbDmCXb1dSLstmpd2qup+epHF2s7E+vdXyJyNYp1cb1UiiyUp06s4hWZ1lmwuBXhw7ss6JoPVqy+e3jdDLPRvhSQfx3Xd2irUf5oK/shU675crSj17BKJKFZeVY8uY3n6p5+gdwcnfZ70nIICoyeb20C9YRDjNQDm3WKrZbp889+vsN+daAgCgdOdjU07uMru+2v4VcUdrC6ZZF0P0KMl4Oghpe+8MbgzwfQa6T+2iAW2sxr7XEx874y5dh4U3f1ta/IHIHGZsEQvAqFpIE+QyhBtCohBLqKaroQwEvL23bdjTIC0OutCMHzBSs3mKXnoBKWJ65/z/gZKXarVMKLgqr8ES2LJOxGktve+qBuy+cfOkGlRq9qlvbemu3haHbGa/qOmKcHIjkZ53K7l67CytLuNlm0/nzR8XCB07Rxk7nqPY0luqqUav5OVnF1OdUnJ3+5t9/d2NVTXU2BzXXNu5425oRqiUsdMdtf2UyD1K0ISjuTuPlF/Bv/uSfG5a87opYCIs+SjgYBYq5NmJwux+hA2fe+CEsum57LPJFgWXY5zeKa8truKXOJEU+t/tNunx2uWNXxEQSaq6pNUWUhtkwKQVld1NPz0b5fMwyCh0KuIszx8IG8GlWauut3VQAvkXOOw0jn7iGiBTuOv7PTzdOnLkkqghfWl+kzOy+6c1KaUcqL4hc4JSndUrrOLl75fWnByypN+yWo42z5Jx37eabNNurz8hWcbbBd7Zy0XODbxd1k/PdjOyBbV77myVzDAVtNq6Ctd8Y8VFy+i2deMUf3BL5e0L+YAiTQyo8BM+/48u49K3vj1w+P3xUf9d5flWvoTLOLdI3KfIZQlXZxQSWHpSskCNNPb0tYRQqn3bDMQLOV9pdek4W1jUd3X0MuA7gh7PFEFBkpV7T0b2HAXT2atXsFfCGkS9PqJt7VnHOD+w6dn+mNjORcqqVq7iNRcMka/vI7pvefEUQC9/relZqT4rvbeq+x7VjimruoUSEdAa5XrWcoL2zkNM5qlN0qVR5iHy0+0498fsD4GwPNVqfGBtrEaUeJde2FdjmTaiNe5FK9ZWjApD4SJhc+Fs4/y9/EDlhFQV1hahyJCyu4fYfRvZBF+ZZ8Juj8/z6rR3kd1FpS6X0ZZB14x6bFPxU7zPyB8V+4aRZqPZzsrAbJlIsQKRKBeEZ6JzSeok6dUURLlLKGxWuWFFhSJx5UiAST6VWyOeiYeUT+7DmE18//cUn+8+j/x9VHWJJ3vu+dNObr4uMUNvaNopgHTcF9nP3inkiQAlV9efXf/IXynpuz9d1Okd1yguVzzxz1ilFajeD8fX2DwSZtMfSadegHyKdcpCpwFAEJ7m1/vJ7yeRcx+uczkiLP3iCnRHnsebsyPDaByP7oPO7nzC/6z6/Ya7pNMetSH5S5DMWquJOJ41Q7ZGcYRXK5ua1XHpVVVXN2X6gKEqrEUUQiDAPptsbJPfvQCaV2kT1eglOBr5epLpEYaHSGltv/vwDf/bMI+8arqp/+nf+4e+bFLfNc1hBfve0niiu4/JisIo5qKRKUOL/S698986LbiDjX+3PqeG5fI7KUhUjVCTCKWrYslwpAlWyTpt6eqY1/JaizHcHSdtSu4PoRuVfwiELJ+Tcsg11ncPTqnkJl21W2myKjqrkchrIyfYHldPeVNePclzY90uUMtBaBY9A8fFHUuQzhKq444kj1LbVfQzsOmE5hFUoKTgJclsxpwIK1+Zcrxy472C6fRVF/E6MjlGP0/PzFi6wuz/dXpQjRhCHlU9sz3fW3/K1N7x08kP/Xt90ZtXXvrhAcds8hwn3NX0A7Lrpqj1RWaj2i9qrAKm6e+V1hh5/kDdf7l+rWczJfyjlgojo32WrOMUxxBnf6VQkguStrRlteG7w7a7WKa0nHxmM7djREBd+unsdtHeqfL3itJ+KZXL5Rtnqp49Meg6CBF7l3essdf1w2w8OJBW/KJ5f3T0U86UOQ0UfL7rvl6jkM4SqiGTSCNXu0tNRKLI0MpwPyO3OnEr8iZxNOdioOEiJH+5Pr3WMdNSRz3p5t2WL+vc3vA7/98I3LHNKs1HcyvwwuSj+7puuCpR2FORauf6fFORjlfjj2W4w64KkkQTFzylnV34ZUVRqNoLY+Vy24LnwbmMn3L6q3Y6C4Bbl2GfvXs/nHf02LZkPyvJbX3Z/01j7fsnn0gxWycjrgpxzywXxn//g91zztP3kLMXvQfUvTpmcGgkkST6ne0+6fHaZlV1hYTc6cYSai/AVATpRb5hTKzK3riy5erxUXL7Frbi8rnyC4L948e/jv2tf5mgFB91bEeHbn24PFSWtcj3Vbih+awXFz633rXgZieu5RaaK/q1OZ6eyrCKfWaXBvd89xvn7Uz+6l1/wrzfTJYacXLf2axe1qwO7L1ftqWiuHDnNOBtxs/id7ks+P6VSjEH3N06skk4I+RaA0seRwS9ajZhThOpUgi9qhRIWihyY5NaVhVzBU4wNeVmNuvIdX7PGyhftvPTdeLZyvnJ3Gjc1s58H68rndp182zNgKweGsp1iKMeT+nUOTzuXjNJlZM8VpbWLo3id6+qqWqe0Xj7vtrYWTfu+HvtzGPa1QfvbuP9qqwerihV5dtuiAwBbJdrVFWoSF9y+ctoTyZU7k1YibHsZvbj0Lyxe9nlJks+psbwsXzaQb6LZrbtSVJgEWSdJ+KnIHfuDnCQL1cmdF/WGFTrZZAOTpJq7RekwKptDY3Tkk62tv1jyJ9ZZlb07jaocYlwhZSbrptaRz5VMt13SIrrDuLU9U5U7jHxObvviM8HpUanH16yhco+7shHf0yN7neS1p+io3lMpxxF+i7rftp4Be+QayU4yCK8CnYtWpNBCDQPsUdniXFbu/ONEum73aE//CLO/pcYvSWe80oeh5cKX8csGigFBAsTixjLp+2u//zlFqE6NrOPYMDkw6ebXta9jHDuDNAOXN0mWL1sruGqVV56mPFf+gPjIK68fytX43V0JvmuKsys4Yy0cvPlgun296oNxzebujXQ/yAVRxYGfyPMMclYarYWaPXeWK0vJ54IijcTaj+rq68DQlW0jZ/1Z+c0qeBZ6vqoRsMqaUY+h/b3gG+9cWFU1agXReUVXF9KJCufLUiCZZYHai2KQvEG6xohriCCmOPQvSgyTJp9spdZ1nlwo5Du7rXEPxSfQvauU6YwSI6+1koaf333PKUJ1SomIY8NkC+cvm6+jIJobOcOmgzvarYLoQf5k+Z5qW3OAAVQrWCnFQP6A+MiS9/VRkQena9NZqKpM9gCrqPHTiSx1uocw8hXqNTOrEpZY94XbX8Unz56Pl379qr3U2Bugqlbijx0Dy3SpfuzQLKcPPNV9KNU4gZ9Tk3NZBq8IbNkCZXxqI5VmlF/aTiTrdH9O1wizv6XCjq6TRPnkFn0n23+4J++ByEVcu7UkLCVu4lpJxM8LB+UXaVgwk+TyFUQnd4qJY8PkwKSPLP4TsmConKBrQXyVLzS5eLxqg3P7B8Q1Hd0jVqoOcAzgdC5JVtW0JuVe8tgDrKLGTzf30S57GPmcjgbIGq2eV/EMz1RUFl2D4zBPpbou7e4O3DHFqXawXX46a72422omX5Y/gZ/8oUNNz+3CeJGi7PZl2ZZ0RXnEXsXb5es4NRQPs7+lBDKJ8kkBf0PPvWtv84XfyTbHsmpR0/m3tUe8r67z5PWlxCqqD+JyyjwnCJVeSpNTU4tZipGF2IIMX9Z0zz1U0DyWL0gRnDKZqvjWzYuvey9dJ4gVKCsEPZCpj398YVV19VHrfM76K7T/8lIe+1mgvTuNW/Sx15q5FnTNleBLqK9r1C8M4dILW50nCkLNBwxxjDT19i6kNcVHEqsc/zWfrPk8Z2wwDIna5bPXDpZ/z57Hp1b4VY+K8wVSdMZm1RbmVzjtjVfvWNntmyVTUEH8nC5npXdqQkDzKtgUfQBS5NKxTIae3+IUm6j1L2oskyqf8BqI+xXHK/RxM5XBoPXhHaIk5FzBz+0+E0+otMEU3BB0o7IBOVUUcTgtv1MuwReHwovApAmWGr6leVUj1e91yzP1uy+Sr6Zz8z5wUNDLaepUAiDf/suTUNvWWFWF3Cxa4b4N4o6WU2ai/iCRgloOh+lAEuUXrnwOXltb2zDFM4Ql5l/yq2su+OK/f8tv31R/f2rjBs5OnHBsqEAkzpFpvrTnnlWq60U9rphQG/fa3bXiem7F18XvxS/w6c0KZELOZDDAKrDFiup2+JOLQMTx/EaJYVLlk9PSOFD0vOU9AcDQ+ETtsoVdQ9QhqSx/ScVvRhIqJYBzzlc4tejyJBLry57ReaEIFDlNfUE54yOwLIteCiKx/uLaMPFC/tjia/FSqip0/ufRf/kXXnXXnSTqaarINMUzZFnn23+54SBFG59u6uktsgbEHLmEIPVe9Xti5KL4/el26/wwSvwK6RTqxez9ZA4rn2zdM2TWWR80UvUkv+uq/n5s925e8W8/dPQ6WDmtHA3CSlZdM8pxMn5OLtcCYS46RZ123PJz5dq9TkEvRcXyc4uSJUsfj/R/KXaAjifsJR/D7m+UGHmtlWT56CNnqq5x8dTIyEI7aQqPQRSBgTpYJxk/p/tKtIWaDZHPLA4Sxm2dNQJ7cu7RfNsst02Na8Pkggo/r71oWo1eFSUjK7uycdEpduoURAcbqXXcJi9XoL3FnNP1RElEVQvaXkIxSkKVvpiPBckz9cMx7P7K+GUjfkElJpdEfZ45dE8vr7z3XtgbKkgfRLFc1w83pw9Oe8SuGCOdr7rundxSz6nMoFyOMHvGj73jE7W7/KyjsPurev+645IsHz1zz79r757LfufdDmfi2dQ1uv8w7fV0cXPSv6jWjHOdshKqvVarfKP2Js5+DxbNLSpYr2hNxKXwcsm/Bxa+1jpvVNlIepFy4HzGWDNnWMUAcvflUzGk4CRXt28uncM6c/UiAXtOqV0+SpGp4rxPyO5k0UaFXxzWqQ7hi4CuPCaK+qSyx/KYXz34IK/+6y/RPxU1VCgQupXHMK1jTdDrhB1v31+n8nVOLe6crpdz+8Ltg4k+oDl4n2qrPZ39DYtH0HlRPR9Br6s63ks+uWZyuboeJR0/O85lJVRyA01M1HQ5kaWcSK9yOJ4PJLHuUC1oJ84H8icf+B9/ed7k6Ff+c37jxHv2fKlaRcFFVaNpY6UgKuvDoW0NnWm4un3z6Rgch5t6ex3PocQ17Gei8rXFb4xjV8W8mq0To2N7qaer3BUnCoWPyzrV2V8pAteCJA7rVMhXc9tm6xpyv9oiXYiJzFV00r6/Tmelbq3B7Otbbl/OG+puH86GlUbwF4X+RSCG6xIzWT57Vao4cXJbO+n4JYpQrcocnMq4TX/AhMVCAqv48QWJpOad+dkr9n7rtaqbH9eGffkjXR9e9fxP7nyhonb09Xd/fZ6fPPKZJ533IoUhKrk3+YEPblly7bVFHz5+bl9RT1ZOD3K7vltZRFFiMD+P+r5a3yoUaVxIAYoCv7isUx1ClV2uTg3j/fZT9Xcr6Gzz5sNgWM5ZaiVFDsspUrl1lILQVK8ZZNx0Qr14F8u6wPPF8lUtGXL7AlMtQSxQP1mj0D+/a+j8PpPlc+tQo4NH0LlJxy9hhNrIs4RZ3N5peoCCf7/E421ryN/fMr/pZz++4AtH3kjrUps0t6LzAoi4Nozco189emALXUe2PNwUyqkGsBsheLl9C795dzsRcrilzhTOV3GEEr0BtlzMkVOAdPGL0zrVIVSamwssOz0xNt68pK8vlkhHwq+6c/NWxrHF4Zx8tzi/VdGhoC8rlfEOFuo6KkMIFCJ17dWLvNYNG7Xvtqau/qlgoDNmpsvn5OLXwSPo3KTjlxhClUu52WuEinqdFA1odaLwORgX7l6WmppseOODT4ggpms79q+rAAa8zi/j2rBrO/bv3XTiBze+evRZqFiKblanm3xubt/jbasPZVOF1Nze+d6mjF1//462PolouwC2RbScy563ootaqFGT9Kg+SOK0TiMg1EHO0CdHhQd9IfiNp/2t2rz5+hTDAeRc9MLdS27mqUyGUlXy1qvfelH/btc/exEGEUzklFsatSxO68X1/EYl+0yXz147OSpcVNdJOn6JIdSiM1KSKpdEbA9Gqqoa7aP+k17nqMLdW73wJOou/RkFPVguUiI1cpt6pYR4bRiRSCUwpBpQJINLll/rqf9a3jryU7q5ohJ2TsokLGzh9vMjLCcCls6Rla0qt9QZuYn4/em1e4U85AqW8dBR+LitU21CbV+zd2J0fGNc1qmQb35n5xIrz5VjJAOst8g1F4jmVC5T9WUUxTin/T2zrdGquEXRupOTaE6lcMieyxjFtVXW0NE/lfV1x8x0+bxSpXSxUZmfdPwSRKiUEmNVPTlsEWau36K99JzKwbggo/rmH6PqvOfyLmSq6kM3fDDdvsRt83wItYszNhKmBi+dTb569Bl87MQP6NK+Z2BuFXPc5Mu7djlGyMKnc1fGOFmmK4LkS4pi9/bi/aIikl93Gh2Fj9s61SVUipaOk0xl+YTHgaxUskiFh0HaZ98AM5UXVNAxLoRKDd+tj1zwDOUj09GGcgPyoDJ4jdfRvyjlCPN+KcX1/a7hh59bqpTfulH97idfVNeJap2yRfnKPREZpsjVuDjn4qWAh2ZR3sxvQ0XwCEtlxhve+GA2mpalrv/AC18YnASzCNWLFHwIdYCDjRxMtweqVCO3bPvq0W9SMrrnOapT7VixwV7y5V/CNm0IEpHqljrjFf0rXy6swju18YpKqaOQLw5ZnNYU+D3VtrqPgVGdW+tP7KFbw/NSyydfT47qpT619nKApZJN/iAp5TWDXCvs8xHkGjpjVeSTPRJhqtbFLZ/O+lHPLQuh2l+m8nlq7gaLEsS9NlTke1Y3PHOm7rKf1ufmb11zZtdIrs0YvFqneRNqtxU0FbQOr1ww4au/ouqHWO51jlrIeZzuGvaSzyr8UFtLCdjNnArdc97CGBtp6u5VTkuQGobnm487VURyUzyVB9JprmqHEV2FDyuf7nVV5+cJtX1NFwUm5eYVtYArZ99UJ/zE85rzLtEHY1Gxe9V7j2LcTNnfKO41jjVU8CvnOaqKfHHgEnbNshCqUyK41Ph2Wj8+rw0VKSILXvk4KutFICa7b82LO6lcWfaLn2Ok/452q8i5/c9twyRSAbMF7PiBLZ9L/s3QAWRflO7nqMI6cSLdUiiU3RqlYC4OtocD9/lZ52HlC9ID0w9vr9/DyqdzzSBzC4TavoLxzKHs3OKAMr80qSDXCzrWCT9bVSNrSacONEGvFWb8TNnfMPdWijkq+JXzHFVFvlLgpHqN8hDqtkaqG1t07uJVmsxtQ/O5gqnJUwvf+G9EmFSybDHAB9te2N2cKz9o/ZsbKXoQai7K1YIyUC1eOXL2/xw9MJJ7Ubqeo8pRnfbSdqVQqNYOqz2Y1catt24T2l/8Alm4G0SEbxyEJbv86zuftuq1xvFXCvx05Bbyya5du8veLaVK57qqc93wk4vdlysgie5hpuyvKt6lHqeCn2p7vThkV5EvjuuGXbMshOqWCJ61WlhDXeeJojNLt3NU4e6tanjmV/WX/fSV2X5+lCMHtL1o9fI+xhl2kevXzdryINQBkXtJkcJegU128O0BPeKs0ymXsBCZ65w3WgqFErmof133Vw+8PPX8WNuLX2zI3rt/D9cw8pXq/HSmvXBzrt2Rpp5eqXE5IBWZKCpPGPahDzLPnVCzQYW0lkrhlSDXDDI2jP4FWV937GyRT24SH+cHsB3vpONnl7cshOqWLEyupMqK0ZYFnxqe1qzZ6RxVuHvP+61HX6yYd2YBhfFT6yeytm4++2k8m1m4rwLoEsFJlbU1C+2FHpw2jApCTI6Oncq+LHCaUgRE/0+VB8zuQs0HnDjUZPWzPkqhUNTGbUXVwxs+Unu3dXu3nL39hd9kLjpP5Z7DyFdKF1IY+VT2OKoxsnxZ1y4bdGp64FduMip5VF9oUosvqzF1lNWPgtzLTNrfIPdVqrGq+JXqiEZV/0qFT9DrlJxQJWszUFcR+zlqPrqXZU42/PaDi7IlDE+0COt360s346dTS60uL245lW4WjFwliIEPcrAbVXuGOgX05GvrOtRkFVa2W3k7VYUPuvHy+K233/bVj9Tu/4s6ds7658MTV+Erozeclgs4uK0fRr5SBjmEkU8Hy6Bziwi1rW1jBWN9Th1tvD7Kgl4zyHg3/ORAwqiawQeRS4ydSfsb5v7inqOKX6mCCA2h+ux4Op3mHR0deeIOuzF2q0YQUWX9qYcWvPI/3yLcTiKk/97xd+MAu86ySEWQDeVq9t/RvkwW2UmhRONtOkNkoJq6bI9yi7NcQI8cWezlsnMr6FCqFwZ5BcYr2aP17NySn0z91rOvr/j5RWf5PGw82/nDu3d8+Gq/B1r1gZTXCVKqzu/6fr+Hkc9vzSh/V5XPKxI8SnmCvNCEp6lcAUluH8Rx4hF0bdX9DbpuVONV5SvXOaqqfFHhobtOGSzUbHFtpybDXjcjLFsO9uTERM0VZ396FdXubV7wqsGfVc5/4TWiktIjW9/25ddX/vJ/PTR5xfPv2PKdC8Wa13R0W9Vd7G5MR0K9tfsxMFB+3crK2tpB4f51chnbZZbJWK7Q5F4qcI2VmtPU0+u4F7J8RH5VVWNdQRuue+F6dtsiyutZdSxzCT770kd+ePu8v7loccXTr/nB5JseeveWg7/rp2BBFT6sh8JPDrffg8oX9jph56nKJ3W/8S0SElYW+zzyrIx9+tM7l77hDY66aTWhpgjf208UnflGdX2VdVTxU1krjjGzSb5ynKMmHT+7zpScUK0OM2AtQd1EdK75+YquX78idXLexEsNPz/zi8t/C8BTCy///qXWQ50rN7jz9o/u/fN5vTc+nVn09Ks/daRJ3HC2DCG70R65at8w+fxU5J+2dnTTi+MKlfQZt2LzTi476SVZlHcob5Isn9X+CpnlQRque70khNVP58S3nP30+c9kLsDvVT36nQ21X3/XS7z2+ZfdPpT/IImKsEp5fjrbLBhRTatUhfIpRiHzylc2X7Yj7UKojVZJyijbsQUltaS/cGeTfKU8qhF6kHT8EkCo2Q4zTm4iKjJAv9lr51LlIZbJHKhn55q3zP8yXjZci7FnL0HFvBcfOe+3Hnuz3Pnihs13PXhn/e1vs19DnG3aI3btGyYXZehPr7V6iYq8Uq8CEQLY1lu7T1G6jt0SdjpHVXHjCfnkM6soXGxyzWSy7tte+CLVj6UorMHP1X++ZXHqaaVgk6AKX+qHMqh8QV/ouuODyFfKc1Rbf+G9TT096+33Ssc3Kc4a5t9+wgqpL8dfEPyMfNMRCIKfShnYqDEOIl/U1w6zXkkt1Dwp5AKI8iTUsX8FWY8MsCr8cGDwW0KJAAAgAElEQVQvkVd/eu2ARYScHcjllB6pY+eWfO7XfedVjNZA1O6V3ccUYbunfjPms3OgqF+5VJZT70/7hjm5bEUpQb/0Ganq0LSAnvw5KtXeBXalGBvkyGzM1t7l65u678kXoLdbqBd8450Lq6tGLRc3/RbUundSDBG1B459ZGEULGtgRdXDyEb8+rfNC6rwpTw/nXUWavvqdeBUcIPfd2nPPYHKYQZ9OYjo88I8No1UyX3PM1MNTlH5Qa8XdnxQ/Qt7nbDzZpN8coWs+s5hy9iI+y/p+Nnvv6SEKrv7Vr/0pV2pqQwVxV+XPa90+KNG27nfhHX4hf+1/b1tzw4e5BUZXPCGB61Jop+qsEK3z995ZmnFsXo78Ti5Y6cRqnR+SoQupBJnsF51gd3q4oo1wtTeJfkWdV+9O9fUOXe/emkKTkU0RCR0TtZjPQs20v9c7EfeQRS+1Oens41Q5eIPcbt9RXWmqSuvRMWjj2bVwuPDL+4Xq9v6QfSvHDLOJvnkCllReMlU9iPp+JWVUH/xV7/96MWpZ5b97WjbS/868db5QphsriffVQlYVtokQKXvNlIQUW5MvlKRcJ0+suASvGbx9/Fy9tzzH57cuZSieYV1+Yl5dw3+TuUTRNJFHTDEOSoDt9Jp7C9cp/NTIaOY65U+Uyg56FxZiV6IFdXVK1gKLSyDFaxi8u1gjJ//hv/3Jrdk6ad+dC+/4F9vzonB7ssWIme7dQKTzmxvPMQ46Aszj48kO32iHO5ZsIk+Jqjp9UD9bcMro3ihlfr8dLYRKt1Pqdy+Isd7/JaPovrLu9eTZZxEUk36C3e2yVfqwKSk41cWQt2Q2bXiyORrNzay36x6Wep53Hr2ExjKXHKMgdNLe0DutykLSOku9P/l30WaycGFr/v7f13Y/KHlVQ/jW+PLyU08xDgayDW8Zd5ff4Uife3EY+/9SUE+p97x1xsufev7s/1TN/es4pwfcEqR8fotCOmKseIMMzNei1T1KBXw3zi/8+Ru+f7pi7CiYeGpirMn6J+3UtEK3d6Tktvm9MREbfPCriGrALJo45a9Pt/6jdrNu6qqRofoo8bLSg2i8KU+P52NhFpwxfKBpp57XD90VL7+3cbIfXXHtu84f+nSpUx2AbtFpOtcM+zcIPoX9ho682abfKV+hpOOX5SEWgeAKgFkvBSO8lBvmSqOWfjAizuXhGnaLT/oTT29DVmCJEuLyuQV/vbXbVzpRDwyKX6jdvOq6qrRbDUkxnfV33Zyk1vKC42RrVc3t2+ri7vYCR+pQYBViSlHZH0pxiywpoBmxvkqSmkRRSuicLk4Wad0PadmAFI1nKHxidplgnzl+wmi8KU+P52NhOpV81fnxS/Plat3jW9PX0eESr+Xs+uN270F0b+o8AmyzmyTL0hgEnkTJ8bG9ur0FE46flEQ6kUAKGJlMluIHp9HzlXrpGhEqO8c78fQ1CWYx8597Z01D382bE89r4pDFBA0xVIt4JmGr9du7suSJR+p6zyZ7zIjBxf1nvexTeCZbGSr9ccHb39p07yfTzW/xq2GrbBwyRquqq1ZJpcxlHqgKrV7K+opyVKDnGf2Si7uIijFGTH9o3C52AOuVB7yQlENHBufqG2RCVIEVNE68geDlWvI+BVubmZVhc9f2xaQpiK3zhhV+XSuoTM3jHyF3qnFXWl05CgmVCqBiBup683Y9u0784S6Zs2AXyvCqGRQXScMfqprRzFutskXJDApd2wwMjE2vjIsqSYdvygItQPAAgCdABoBkD+SrNWX3Aj1wRFq/FI4twyrqMLdqxIc4VYvWET69tRv3AeGG88teQ/mHf12rksN8DejN+B//9UXXYO1RE4qOPr672i/nu7FItOpzCFyN6uk1tAce4MAcgFPZbCXcdbAGaderkNgGDp19Y4tTcup5n/2z62xgAqmhQ4vzkFNTk3F5QAmJ9evqsILy7jUdV9V5VPBL44xYeST3K+xFHkQ56fI8GVj6fRjglBFmpdbmcw48PFbMwx+fmtG+ftsk0/VSyZVhyM4B8OSatLxi4JQ7wLwXQDdFPeXc/kuBfArN0L94cjifBCQjrIGSWwXxDM90jfbquzuBR97sQKZBc+9ay8W9P/Phc+kzr/rkoqT77MstAxWuqUCkCU3ATZI1iR9JFTU1vZNnhs7GoRM6RqC3PwsTbtCyZZtXecwubyV/iT3rWsN5Vwbt5H+dHtR1LV0zWmuXxWFL1S5QtG5rZLgmoNU5NO8hNb0MPLF6fa1H6vI8j25Zs2qFMOBUqTtqIIaBj/VtaMYNxvlUwlMynsTCyAOIcOvb7rnnkCtGpOOXxSE2guA/nNvbrGTAN4CgIhq2p+9lm9YJS188Ti3ObOv69YdgVJnmlO/Xn5HHXmqcWy4/YeL6Quc3Lmra76z5f3VD5D7d2R8Yt4SpzNDmiTVBqaAHrIkiYCOVNbWrLB3s3G6X9WvPJo7jVC3v2IVuaqD9KDMXu/cUYA1iBKNTnIRNlS7+P70WisYTP4Trl9y79d1DueT/FUUXuyFbnRyGN1RkS/MulHNCStfXG5fe/cjWT7J6ojFMg6DaVj8wlwrzJzZKJ9KYJKsnwCn98kV4BgB5yudSDX7kVizkzO279Lu7ny6YtLxi4JQPw3gBQAUPFMBgAJ7Gsiw27FjRxdjjBqHF/2tXr06jC4WzUn96leouutOZJYswcRNf+67Xv0TX0P9E3+Pl169Bi9cuSE//tv/8TQW/fgreG/14aLf7vrnn+M/j43gKxffhYvOPIHRprdj5OodrtcR42nAJRfOxy2tr8W8aoLD/6/6N4+BUmHGX74Mz7/jy/4TpBFVp36OC7+zDlN1F+OZa8U3jfcSAgu/633zR09a9/CeN10ybUFxXfqBrn36LZ2W/H5/qfEzeFn/+8DGz1jy0lzzp49AxaP/gcp77wW/+GJQaovj3+go2Llz4AvzYQS+F6689x4r73TymlZMvc0qOFb0V3PbZuv/j213fzZ8L2IGzGgE3N6t8k3VfGYrMDqK8U98EnzePFTf+XdgJ04AtbUY++St1n/LfxXf+y4qv/c9UN7z5PuL+UIcOcwE0MIUdvhjAJQY+UcA6M4/BuCtbjcbmYXa1rYR4DsBtrupp8eqOuD153Z4Tukhn5v/+Z3Nqact1+5vbvjhIdow0RT83bU/uGZd1T/dbbl0OdvkVlYtF/VruS8qa2taVCxTIW+QSDmnLzS382EnPOQSg3Jwk9PYXNT0gFzQQh6Xi0ymDykKRgPlqD7beu+K5suvdtUjEYwUxKL229sgvyf9CzesfLLbF2B7J8bGNsmBH7k60ZQ7GigoRD4/JUvCLt/xtjVWXWvOUitlSyLInkQ5Nix+UcrgtdZslM8vMMnJm2jpa3V1HwW1OZ3BH1+zxirZaterpONn3/swhDoPwLcAvB4A/e8/BPCQF6HeODi4xKnHYxClDhoQ4dZuKP2p/91+S+0/7B/j1ZMX3P5kFW3Yx7/x+ELRUYYK4ouUFnL9clSudCu6QKkmmVTFyLe2Wy8Z5T8Vl4lYzEmh3M6HnQSwlxj0EpLSiip4ZtAvpYnOYzOMd9FHB6+ux8TZyYVu7nHRDKHUwUhe+ClvVAkG6rwwcqTZh2zaVT7w46k1a7YwBul8XS1n1X5+Srdvl69UhSVUodfBT/UaOuNmo3x+R1Zu2Rj5ZiAcIxPj40vEB6AUZDetSUjS8YuCUMUa1OVlGMCEl8KRhfqBxx7tu7Sn14qItf/Rl4tKSPXxECH7Z7Y1Wi3bZEtzeNurNi/Ame3URPu9Xf+X0YZtuPPhlQA7JBd0yBORQj3boA9cgWQqlrmRtTehqrXAk4s4VKTQ4peuRNHKqh8H2VZyo30MWO52Nipfv75zmI4FSv6X9AdSV76sNZDqAzh5DSiOgc71c0FlbHfu/Op8Fc+O/fzUkVDb13QxblXQ2nppd69yUFxcG6+LX1xyzfYPOq/AJK+PLvEel/XHK3sj6fsbJaEq6SIR6p8+9iicXET0AHOOVSqFvgsboe5qKliahXq/wrqj9JgHK35/4Rc+ePmpDXc+vBWgs1++VfQw9fsKU7p5l0FBGjM7KZRqCT+3Ig46sstzZXeyU7Ry4aOkuARkVNdXWSfpD2QU8uXcvxTIcUUWE3aMM7aOXLJF6Qs+tXidXoR2+USkLzgON/X2lqRAutc+R4Gfih6FHTNb5fPysgn3bQVLTfNM2q3UytraFsYzh0hnm3p6rOYf8l/S8SsboZJLqqmnNx/FIpcyUyn0LVJmgpY9y/YQ5RuocEMqxa7PZHCUQPjQmR04y2tX7r7pqkMfvfOR+xhwnb3faRDXquoD59Zxx22+k0IVWrm5d4MRZEd1kuUSg6pyqo579u71fN7Rb9OJal9d58m8F0L+mPFLDVK9VphxSX8go5LPItXaaqvK1sTo+EbZ61PUOSbDl7mlLji9CKedoVoWMaPOR0NNPb1LwuxJlHOiwi9KmWYSIYTFzy0ORCUbQ7ZSwXkLA7vOzeMRVr649tNv3TBnqH5rFv2etVAfO2a5pHJfyNNaQ/l8OcsBGEEJ1bI0K8cGqNoPkSo1N38y03jyE2c7FlGh+y99+M07N/zdIyNOPUzFV5hXqkkgMKj6xWcv3sgZ3ynapvnNd1MoPys36HX85HD7fejxB/lF97/fKp8o8nezeaeT9NXZUI5UmbnwQgu6X8fb2naBPiw5Rpp6e6eF/eYtT5ul4KR/YT9ug8qsMj7pL9zZKp9bYJJXNTuxn7KVmmvLCTejKun4lcVCveHRR6+nhHArD4mxrdloXavv2mEr6sunv6O0AaHcTHK1H7rsv0787nf+drT9XeTi3dJ+xZat3Y9Tcf1pPUzDFlHwehEIi9krgliFEPySq4MEPqm8uLws6Mbut20VnWnAKzb9/+1dDbBdV1X+zn1JE0hKUqA/gbR5NFABgSalgGKhiVABW2yqJimoNK0ggiBBcfqS19oEyA8oNinoDD+apihtUrWtFgcttelMrShCUx0UlLYvWMirqH2VtuT93eN85+59777nnZ99zj7nvn3fW2emM528s/dd51tr77XX2utHK1PbQ4PL7+eN9X1B9pI+HaGbVGlMt2uLWwopCtWbSN9e4pcna0l/n6v0pV2J2QataSs1wizAwZW3HJ6R+84/+Y7frCjUoaGhoAvACMTwygEMHJkOm5ELNsvtW0WFFqNSED554hffdt/k+TczCOmdF73ows/d9e2oZdmde9/WdSdUh5VX1I2cbqGuYCDKpWnRs9qCrdvdSvrYAF13pmFkdFRAQjUuL7MJVTnG9wXZS/rSShZmVV5KVKiXq1q/HvRH7SV+ZeRyLtPXLvYSNC5bsv17jDZH1v2piV/bSGIxg4S7Vv2u7/jNnkLt3L10NSrOOjV3XATVRBZGyiwMlm98ev+WRrP5AIvcv+W85w1+6evfi1qW6YAk/bt5+VZlFliRHNKsE1qW9dy+v+xBIXot8EbhfSaoPjgxtWhdWipNGdzKjvF9QfaaPt3k3gwS1G66JE9REn1FU9jK8s5mXK/xs6HJxsNUdJ663nfBL25w2Nyfmt8RGVkAsoLbXOirC7OseXtyh0oLNTq98GSL8MjKW26NmntH/6YKNmS5fbU7yqYoftbHKjfFVtbA1YXgX7jiZHz7+A8QD0jiPGm5rGUZZbieU+vpxudOE6gsZa/dyr24vzTpi9zQYTDmizLNOpCU5WHV43q9YWhlaLrZdDGHZojLzjp8OLI09JOsUC9fF0VmehDp22v8ivJ/LtNnRvlPTC4+5al/e82W6Dovw4Vr4kcrNWw2l8dlLk/+ivKgl+/3VKEmfZiRTJ7q9i2TMpMHou4aw1J7P5yYxgKEiT1a84J/8n7H/HvHigvuWDJ8fIPN2LQFmaXsdZ5rVpF/m9+2ecekj0p+anrxUR8s0yyFYPNdvXqn1xuuud7oapuK+u4WS1toz5ES4NQr7OTA5I60q/zpKyxePT3+z6/bwIhdV8NHFGoGX21KD+a5ffUJOsvXXlS0WAheNyZPCkjS83X6geYXYcijoUyQU5bAdwKTOu3YzHSZXhRTcF2QeZi5/l3om4mgGYAUAIOq92liSc80/Ip0fnLlYdb4ucxfehPCJo5mWXCu2LriZxoJjz/4ugsZtVvlPu1Knys+RcfPuoVKgvPcvnWE6etm4S3AZgYkaSCLBhFlMaDMXJkKVXWeMbvjlLGCiwpNP50gfV+Qs0GfERAyghDLszbBVIWqKpfNdk3f2cCvyHopS5+qfRsFbA40GmtdS7em0VyWPj2fjvZtTizGE998Nf/5iZWHDldWFc2VviK8quJdLxRqlgvJqPQyo86jCwDtFmwthTojIKltoe46g+XV2EFnZ5H+o0m0PbXr9McZAVsk8jZPoNoNxxV9vUqX0d+XR58Lj6oYK/Qlo/jo5s0jqlxhlL6WFhiSqlB1pC+CD648dCgqKDEbz1zlb/uuuwVqbe3yqsCPe87Uk8su/cHDr8iUpTLyUQV9ZX637BgvFCqJ127feGCEaw5qGjAsbN+q34vEgKS4QnUN8DEqB1kHJJGGPIEyqiZFPVx139MiSrus8NjQ5zJ3FWPz8KviN1zmmC36uoqrZKS/pNHX2fDtuj+5YJQ1drbws/2eMvRFBkaz+YAqevBEq/lBPTiXoS/+7fSKnXhs1YETj7GcdLV0VkGfLa+qeM8jharas8UixDqd36tllGq/xl6uqQFJ/FtVqTO6rq5tQQfNXBuBald0ahVHH2TaypJrjqsC6VWISfocNvTVS0H27EJfMj4q95TygiwXXbpC9SPSt07+8tAxeWLydpvmHWlSWIa+TlYDDmI63KdKPSIpCtt1bZn0ca8t6234/rvXj4+PnXpSY9HTH3neTXeyZ3YlTxn8KvnhkpN4o1BNt6/Z2qfOnLeLh24Ze87Sk5bddM3PZvTzZBm96ah26ZLh0VK1S13q6toIlBm+TjlwtaaLyJINfUXmq/pdoS8d0VY5QirU9P7Cafj5EulbJ39bXVCCoysPHbqyrFwWpS8ehc2707ZREWt7VpYmc1y3Qt30QDPEzjJBUMevuHh0+sSS05+54uHff/a+f2K/7EqeovhV8qMOk3ijUPkNSdG+daTMaLwY6fvyVadcuOc9b87EwTV1pkhP0jgvbQXK6OwSNU4/+drRKGm67seWvrrpqNJC6CWts4lftHlPTy9PK5ZPHLLo0/ews9nKrS78TMXmkgZSlD7TOjXL8XUqzdn1trWV4ZhCDVke1jRobOfRgaPLX3r/d5Ze9yh9v5U8RfGr5EcdJvFLoV6+cQvC4EBU/OHQreuVkqV1uKaOaMK3Dt1845vOe/4V79v0+jyFStfYqjL3kq0ouB8+UjQYSfPUVqBUf9IRFqlfMjxaO1+L0ucgo05DbfFz+hGHwf1Mn1nkvM5I1Cx4i+JHmtnWLo9lMxp4ZHTpqYq+JOtUz2246HmfWlkgmMbP/O0QSO1fnfStemzQmAqXv+z+oMw+2a8H4jjdtW+8NnmoMaGJ7jV1LlMdKTP695g68/5LXnLdmy5Yk4lDWrqLTSEDXZ4rBO5dOjxauH9kkQ2jlecarLEtGpG3qdj8vQh9NvNV/Y7Q54ZoHn66GHrRTdiNqs7oPPrM32kpycaaLBe3fr9d5B14UPWZHZkcn1hb9D61CH3/uXnTbQGwIa3SkNGLdqyqA4ymz6ytSwyK3NfqsQOLn3rsWed87fSicSJVHUiqkimXebxSqJFFqsLx6UaaOjGxb+Gik6hgK81tMhTqur1XvPKel73knByF2uqpGhcUVZHo6JLh0dQ7lqd2ncFcssGyLeCKLEhlpW5YOjzaLu3oIhw2Y4vQZzNf1e8IfW6I5uGnrBN2n1mW50WilbV48eLlVeZU5tHXpVA3b4ryOm36uJqFKxYuOilq3l7m0GBLn9mgIKtRSNUHGE2fEfzZarVZwPWr41wGFj9557PO+folbJO5ZPixdu9rFwm0xc/lN6oc651C7fRlxEgYNK6ss2bohqGbBz/xrlc/snr16jyX74xcVDMQKO1EVjZVxmSw7wIl9Lktx7mAn5EzOaPpOPPIwyC4NAhCpqmtK7JR2yAbx4+KKcmKtO1uwt809qAo9908NBR1t9ry1zY90HT9FrEi07A0FGrUL5eGTNDEulZbTTvXrzaCGgumti976f27+Vus7VtFCVJb/GxkpRfveKdQIytVJ50HOMiyaHn9Ul2AsmFYUuqMLkCvfzspEEinyqS1WLOh24Y+m3nqekfoc0N2ruDXDlACbg8QjAHNwUiBJj7VBdaY+D26efMB/q6Ov+i2Tjey4b2iJ/sOUjdjN4OtDCWb2Woy/rm2/C2S11sk6jftgKHpbCtUo/LVAmBkOmxGXgcbpW0Gjj775fduzWorWXS12OJXdN663vdVoUanJf3RdUYR2jDMKJ7QdmW0XbkI7qAAsfxfoxGsfca20ZGW9RrexvtM1gmenFw8WPa0ZkNfXcJhM6/QZ4NS+jtzBb/4HVzni4NjAG5vhuGRhY3GUb1RV1UAwLCwGMwYNamOK4GuiF2+kNMlR9cORywQybZ5dhkPk1ZKNgosMjqUAszq7BJVmRsItqY17+Y8Hfwid/hgJ3ZF1QWwaIBgusdPfdVXNgTAAcC+AUjWCvJ9fcRp91KhzlgANTYytmWYmToTd+V2CiuER5kDGrCFEZtsA8dCDGxYOvxdnvZKPbb0lZq8gkFCnxuIcwk/ndfKnO0wCI4mRdMapUS7+iKXRZH4Ldq+nW0hI2Wqni7XczsuA+EdUTcUIL2zVbtvc3Bs5aFDgyZdnchfewvblr+2jbk1PTZ31608WizPujM2FGrIuVceOtzWCW1PYUaEs7FXR3EuVbe8tMWvrPxUPc5LhRqdwDZvohI6NzpQBo31NqHuZcCxZdiTu84YY0oKQ8Kb09iBAFfo+r6qQDTpNfKvgjsmJhdtKWuZ6m+xpa/Mt1cxRuhzQ3E+4tdWTCHGEIbrs/Jg89AduemmcMEX74xeo3XXCAJ6t1Zpr5YZ7EPra7rZvJH3g2m5pW13akJPz/hcNsFVNvwt2phbY2LcXc+o9WvWAs7q/kL6ThoeXt9q4YeueuntnNiMNJ2ku1/doatsIKbJcxv88mSkl3/3V6G2c1I7KTR1AGPLsHYR+qBxGcLmbaTFzLdi83Bg+giV7nwKG7fFrw7e2cwp9NmglP5OXfh1NmvMCGSypTipHnE8N3YKzS1BiOt0HEaWwlQH+SjvPc31mqdkqBzNA4INfvo7ysSKdJocdO6Fu7wAEZjpd8akb+G2bZc1AtwWd4UbaTqpzROS7n7bbSpDHFxyzajpObBlbfs9G/wKT1rjAG8VqnkaNN0QVWNhyzBdiYj5pAGiCLgZeaUsEg0MHHVx8ca/z5a+qnGxnU/os0Uq+b35jJ+NSzELXX13F7c2O3edOIgmLmWRee3lyiqZaJO6YmYhxF2pdHmHaA6eeejWDUU8TElBULZSZeam6gpHytXLWt5RDm2Wom5ZqNt2RoeOADvPvOUwMxqix2YPTjpg0LhwLddaBD9brHrxnrcKNTottnJS1zB0vS4wbDc0ozl4RIpL5G6Rb7Glr8icVb4r9LmhOZ/x04qkTICStkTDFStw5r79XfvYjBiMuCtTZxHE7gZtLcVHN28aizrAGOPNKGDTxWrDX60Ay15tmQFKITBC5QgEx9BsbogK62cEFkV30MPbomyKJDe4vnpLoy2tNOxTu86IqsuFGFjrYmDY4Oe2Aqsd7bVCjYQU2JrWq7EKKGwZZgQiUZk6Re4WoduWviJzVvmu0OeG5nzGz2x0blNswURau26nzzsPq64emrGPdfUTjQU1pinyPHeu/v34+MjFGgT3qHZrMC09G/66VoNLOEC0407yFGKkULdtuzfKO02IVcmzns0IXzP/10gr7OojzXiTInElNvi5rcBqR3utUCMr1aGlkA1UtgzrpM5E5qnz3YANbXzHlj7b+ap+T+hzQ3S+46etvazAmSSEtfKbuvgSDL7jHTP2sZa7clEUXR+P1jUUeTuYx1SKebQYd5RROcKFi05iQM8a3kFGAU+GRZjHX4OWroCgolLV3ZC80+oyzwsQKdTt26KfS6rQZFjeMwKf4hG+Js0dAyQcQ5SXDB0xPTIxuXitrVLNw68oTnW/771CzUtMdgXIlmEqkjeqMyzdXDqo2+Lnyqey44W+ssi1xtWNn61VGP8K7SadfOe78IKLLkrcx+jCDREMmveCHSuz5baNIn+np5e3LcyE6N5Eha7dxgCVdnRfOTk+sa6lxMNV2n2ah1+Rgg5ZnDQPEJPj42u0tZh0eDDneegb3wgXfXgn/ym1vGuaFZpX3UlnRiTQ3WW1Zn1XHn5u0l39aO8VavWf3D1jEYapXNRjS4ZHu/LT6qSxCH110pE2t9Dnhvp8x88mkjRZoW2K8ibHd+9BVunQ1FKEmzeyotOlQHAjwpAF6ZdnFUmYqdBV4YPWH55AM1zH6N54rmoef8sUi0iTuNYBYmAknmKYphA5zyN33RUu/NxnM4tdpBWdMOr/7k9qOMDgpLA5vXzBAoyw4I1RIKddBCdv9eThlze+138XhfrQQ2FeLV/NFJU6c2TJ8Gg7Eq5uhvkuUEKfmwTMd/xsImvjCJtu0vHde861Xb/mPDPas1lapnqOtH6pZq1dWr9P79qVWSu8aEGHMtKWpbTbebwZ359mRRvuZOt2cu0iOJbXZr6vjzg/RKEWUKgUhkYj3MrTVhnBLjPGd4ES+spwtTNG8AOKWmlmLun4rj1XlFGopiIvYpl2KWUWnwlwNF7az3Bj7x/fvfsDafRl3UG6SVX36Kzc25HPfDpccPfdXYFUGQeYrnvUtAjfLNpZSWm6iaPM17e5OvN9fYhCjSFQhGF0WZx87Whuc+IqF0MR+qr8Xdu5hD5bpJLfE/yYHsc+pcEB28IGpmU0vrjGi9YAAA+ISURBVHv39WUUKrkRRcAmKERbjtJSnjpx4mi8u007aCnE2PiePctJX+vfcD3nHggGrmSVpbLublv69HsmPSsPHz7FHP+doavDxiOP5PY/jbuNzSCurHZzSbTqFMQwwJGl20fXZ32P7+tDFKqDQi0qyFW877tACX1uXBb8gKxiC0nompbRxK5d95RVqHUGPOp0lak3vBEL7r67u9ZwiLEQ2BcEwSm6ZVpS4JSbZM2wUkeiYKl4wf+tHwiD48dZt3FtVglI04sQzdwMrldpQoWjk81SrXn5/L6vD1GoolCrXKe1R4G6Euv7ghT6WhzWCsim24qZt+krfjPuaKOa5NgZMH2ERRSMp2xBhyJrIy2a2jYHthOABF53tYIyAxycPDGxNan/bB5trCrX6koTpdXsm5hcvD8plcZX/qZ9n9yhFrhDzROSOv7uu0AJfW5cF/xa+LUDX3KCg4wc0Mgy8hU/MziJimcAjR26mH4rqCqk1Ro10yjqMi0jcUnu5SJF+YvUB7alr9OliyNCNh/Z8czhx/ab433lryjUFAR8Z5jQZ7s8k98T/PoDP/Oej+7QBY3GwaRuLvH7Vp/5S1onPnT1gbPPPz/RcFGHiA11llbV3DeDsLQXIC+PNC45rSIcwRhLGrp0CDLnZVxK0MAO1kfnv8cDlXzmb9LKEgtVLFSnHdd3gRf6nNjbU5d+uyZtm+TgxjAIDpp5lfFSeP3O3zrvceOcb3sBVNu8cCDYkFQUP01i6PadHB+/sYyLN08KoxzVAFvi3Wl852/8u0ShikLNk/XMv/su8EKfE3t7qlBbrt/L1wVobmnfM4YYG2g01mprNZ6qIfwtxt/2XSqVagN3tHBOb+9WbPbq3/adv6JQYwj4zjChz22RCn79iR8jf6fC6X2takbhkZWHbo3SK+LpG8Lf4vzVAWB6ZC+CoopT2RrhO39FoYpCLSvbieN8F3ihz43ds4lfV2APgg+i2TwStSNDcEwXvJ9N+myQ9ZE+hSvz6c/lN+Q1A7D5zrre8RG/rG8Vl6+4fJ3Wgu8CL/Q5sXfWLQSzgXbYwP7ozg/hHbqJt/C3HH9VEBiV6rKVhw7XrgfKUSkW6gzc9u7dGw4NzexXWBbgqsfJgnRDVPAT/NwQyB/dLiqgXi3abzT/F+p7w+f1QaXaXH32A2ft/Zgo1IpEoHYgRaG6ccrnBdkPdxyCX//LX7frlwUSGut15K/w142/D993X3j2BRfUrgfKUuk7f+UOVe5Qy8q23KFWilxrMt83DF/oMysPmYUQfKEvTTSEPrdF4zt+olBFobpJuOAn+FWKgP1krZSZYFAHJMmBxB47UfjuWNnMULupLy5fGzakv+P7CU3oE/66IWA/Oiqij+YOs12ayJ89fklvCn5u+ImFKhZWpRIkC9INTsGvGH7xykKCXzH84m8Lfm74iUIVhVqpBMmCdINT8BP83BBwGy3y54afKFRRqJVKkCxINzgFP8HPDQG30SJ/bvhVoVAXAfg+gC+pyb4F4No0suQO1Y1hIvCCnxsCbqNF/gQ/NwTcRvsuf1Uo1BcD+DCAtwOYyoNLFGoeQtl/912ghD7hrxsCbqNF/gQ/NwSqHV0myvcSAF8AcDKArwK4GsA9YqFWyxg9m2wYbrgKfoKfGwJuo0X+5jZ+ZSzU5wLYqwbeBGAhgPMAfArAZgDbANBqDffs2bMjCILr4j+yceNGN1RltCAgCAgCgsC8RGD16tVlDL9ZwcqG0GUArlLU3Q3gmwCm1X8Dyu17JjsrJX2BuHzd+ConXMHPDQG30SJ/gp8bAm6jfZe/MhZqfMxOAKcCeC+A1wL4PIDV4vJ1E5y00b4LlNDnxnfBT/BzQ8BttMifG35VKNQVAL6sLFMGJdHFe6co1GoZo2cTgXfDVfAT/NwQcBst8je38atCoeo5zgAwmgeXuHzzEMr+uyxIwc8NAbfRIn+CnxsCbqN9l78qFaoVUqJQrWBKfcl3gRL6hL9uCLiNFvkT/NwQqHa0TVCS0y+KQnWCT9p7ucEn+Al+jgi4DReFP7fxEws1hoAI/NwWeOGv8NcNAbfRIn9zGz9RqKJQ3SRc8BP8KkXAbTJRWIKfGwLVjhaX70MPhT4nDsuG4Sbwgp/g54aA22iRv7mNn1ioYmG5SbjgJ/hVioDbZKKwBD83BKodLRaqWKhOEiUbmhN8EjTlBp/gJ/g5IlDt8NoV6g033BA+/fTT1VItswkCgoAgIAjMeQROO+00XHXVVbXrqaqArJ1Q39NmhD43URL8BD83BNxGi/wJfm4IVDtaFOreveHQ0FDtOJRlm2wYZZFrjRP8BD83BNxGi/zNbfziX1e7IhGBmtsCJfwV/roh4DZa5E/wc0Og2tGiUMVCdZIo2dCc4BML2g0+wU/wc0Sg2uG1K1Q2Hd+2bduOasmubjahzw1LwU/wc0PAbbTIn+DnhkC1o2tXqNWSK7MJAoKAICAICAJ+IiAK1U++CFWCgCAgCAgCfYZALxVqA8AzADzlAUYLAJwEwEyQ9Ym+UwD8H4BpAyvf6Hs8xkef6CNpz1ayNq7o9I2++DLwib4lAEjPDzyVv6QtxCf8TgbwJIDQU/xmg77Faj+btMCE8vdDAE0PdEUhEnqlUK8EsBXAdwFQmf0CgO8XorSalwcAvAzALyvmflBN6wt9ZwE4pLCZAvB1AB8F4At9LwbwJwAeAvBMAH8M4BaP6NNSsgrAvwB4M4D7PaJvkeLtlxSh3wJwrUf0cdP7QwDL1Gb2AIDrPKLvtwD8hHFAeiuA8wCs8WR/4UH4s+ogciqAPwVwo0f4/QiA31a85Rr5jFrDde4vVI4vB/BxANcDuC1jz+UB5AsAuPeRvt9R+FWz+/dgll4oVCpQnkqWA3gCwA0AjgPY04Pvi//EUgAfBnA+gK8BoEL1ib5rACxUmxg3N57SKFjHPMHvNxTvbgbwRgCfAPBKj/hLftPzcBjACwC8B8A/ekQfDySUv7erTYP0+iR/WwC8GsB7AXBvuAzAFwGc8ET+zPX8MQCjAD7pEX+J308D2ATgtQAOAPhRj+ijAv13AL8L4EXq/6nw6DWsa38+F8AVAC4F8CGlUNNkngqV1vMwgDPUXkP6+qbUXi8UKje2LwNYrVbD+9WJklbibD2/BuCFSqH6RB9d4hQqbmAUwN8DcBGAuzzDjxvuuwF8HsCfecZfYnY3AMoZlRcPb77I3yXqBM5N46sArgYw4hF9+rDJQ9KjAHjA+6ZH9On94hVqY34JgOd7RN8KAEcB/C2ACwDsA/DnHtFH65TGDY2ZHwPw9wB+XHmd6t6faa3Tu0ULNW3P5d7HtUqvF3UTXb6k6+HZUhRFf7cXCpXCfysAuhv4/BKACwG8syixFb5vKlTf6KOFtQ3AbwLYAOC/PcSPlv3PqZMjT52+8Jc08SDyDgB0q1JB8C7LF/reoFyUnwKwWfGZ1gwtah/WBy2q1ysra61yufEQ4At9egv4nFIGdE/7tH5/Sh0yaQm+BsAEgO0eyd9LAXxFKXkq0nOUQj3YA/kzFWoaz56lZI3v8nlM4chDZ188vVCotLposjNogCcQfW9Jf/psPaZC9Yk+unm5eXEh0sKideUTfVTwdKF+T7mIGJjEEyTvVH3gL0/cpwH4HwCvUi6tqwDc5wl9PCwx0Iz/8T6fd0V0vf2HJ/TRumcQFw90ekPjIYD30T7wlzQ9Rx0yeV855tn64IGEFj3d0fRCMLBQX9n4gh/vx3lI4prlQZNKtRf7s6lQ0/Y0jRkte64P7i90RfdNcFIvFCoXwYPqXoYL86/VHeHfzJY2BWAqVJ/o+xUl7D8Tw8YX/PaqDXcnAJ526Vp9ngqeoht4tvl7JgAeSvjQevkDAH+hrBkf6CNuDFYhLbxjo8ucBxJf+Evv0bvU/fhKhZtP/CVf6YXgnZy5RnzBj96as9X+QkX6D8olzXgNH+SP+x7po/eLV270FNKb0wv8TIWatudy7b4PAC39jQAYs0FLum+eXilUCj8jQvkwyIFBGWZIea8Bo2BxIyPD+PhCH0+4DGwwH54geVfkA35UonRn0arS7iwqBV/wM3G7E8BuFeXrC328Y+MdES1T/scIWtLpC32MQmbQIANraLWQPt5n+UIf+Usrmq5AWoH68YW+0wH8JQDymQ+vHBj16wt9VPJ/pSxnHpjolqa3qRf0UaFyD7s9Y8+lQiV93GdoxTJ+hIeSvnl6pVAJCNMs6G6gG9PHR+iz5wo3DG5qpitG8LPHjxGMjFA1H5/wS8qD9om+JKR9oo9WPdMCzZxLn+ijJ4dBZ6ZRMxv0pf0m6eP6MPGzX12z+GYvFeosfqb8tCAgCAgCgoAgUC8ColDrxVdmFwQEAUFAEJgnCIhCnSeMls8UBAQBQUAQqBcBUaj14iuzCwKCgCAgCMwTBEShzhNGy2cKAoKAICAI1IuAKNR68ZXZ5xcCjFpkOgxTiuQRBASBeYaAKNR5xnD53NoQYKrJ/6o8zg8U+BXWVR1SxcCZiiSPICAI9CkColD7lHFCtncIMBGdxcdZ/pDVmWwfVp9ikXzm9sZzU23nkPcEAUHAAwREoXrABCFhTiDAOqQsxchazKyOww5BrPLCqi+sSsMqWFSeXHMsmP6rqsgJm3j/pFKorKPLphH8jx2H2A+SrfL4H5PdWUifbfPYlo6t89g7Vx5BQBDwBAFRqJ4wQsjoewRMly9LzrFLEB/WE16nFCtLvz1X9eL9VwBHVI1XvkcLlXV0OXaHaqTN0mtsqM2i+veoOtisAcxi+my/1XeVZPqey/IBgkAGAqJQRTwEgWoQSFKotFTZ8OBtqg8qa6auUUqT/XjZ8YOdcKg0qVDvVd01Pg1gULU65B0rLVrWsNWdmljbmV1N5BEEBAGPEBCF6hEzhJS+RiBJodLFy1ZoP69aZVGhsnUWlSwLqf+XcgWzIcJZAL6j/o0NCPTDRuS8k2WhelqufLQy7mvAhHhBYK4hIAp1rnFUvme2ELBVqEyrYUeNP1LW6X7VO5MW6m3KlfsW5SK+XAU6MXqY97FsDk1X79+p1lvsqyqPICAIeIKAKFRPGCFk9D0CWqGyOfJH1R2qdteyhyfbV9FCZT9gWpxvUl+slSQ70LB59scBXKz+xgAnWrNs6s42fryD/XXVz5KtB6/ve9TkAwSBOYSAKNQ5xEz5lL5CgJG/tDzZdzT+sAk5rU/+XR5BQBDoEwREofYJo4RMQUAQEAQEAb8REIXqN3+EOkFAEBAEBIE+QUAUap8wSsgUBAQBQUAQ8BsBUah+80eoEwQEAUFAEOgTBESh9gmjhExBQBAQBAQBvxH4f/ocHzeeUj6IAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<VegaLite 3 object>\n",
+       "\n",
+       "If you see this message, it means the renderer has not been properly enabled\n",
+       "for the frontend that you are using. For more information, see\n",
+       "https://altair-viz.github.io/user_guide/troubleshooting.html\n"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.plot(kind='line')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.vegalite.v3+json": {
+       "$schema": "https://vega.github.io/schema/vega-lite/v3.4.0.json",
+       "config": {
+        "mark": {
+         "tooltip": null
+        },
+        "view": {
+         "height": 300,
+         "width": 400
+        }
+       },
+       "data": {
+        "name": "data-13099b60e16e19b1dfc8ec8ad5449064"
+       },
+       "datasets": {
+        "data-13099b60e16e19b1dfc8ec8ad5449064": [
+         {
+          "index": 0,
+          "x": 0.10174192426040822,
+          "y": 0.31973437326889537,
+          "z": -0.24087925640418273
+         },
+         {
+          "index": 1,
+          "x": 0.46377109678002576,
+          "y": 0.39284953965450403,
+          "z": -0.8470307992657274
+         },
+         {
+          "index": 2,
+          "x": 0.5427920704495576,
+          "y": 2.0215438525479135,
+          "z": -0.5041337657185385
+         },
+         {
+          "index": 3,
+          "x": 0.691790393493323,
+          "y": 1.4080784951558476,
+          "z": -1.5530227427069885
+         },
+         {
+          "index": 4,
+          "x": 0.5438454859014044,
+          "y": 2.282289197786082,
+          "z": -2.47969679801141
+         },
+         {
+          "index": 5,
+          "x": 0.8412672776574759,
+          "y": 0.9336365164416933,
+          "z": 0.11586844310132616
+         },
+         {
+          "index": 6,
+          "x": 0.4440696728540403,
+          "y": 0.5846040675015804,
+          "z": 1.198605562039081
+         },
+         {
+          "index": 7,
+          "x": 0.37689265681375916,
+          "y": 1.8445078498152159,
+          "z": 2.1971366928099076
+         },
+         {
+          "index": 8,
+          "x": 1.7088994296520779,
+          "y": -0.2965165131611587,
+          "z": 2.4854050834183345
+         },
+         {
+          "index": 9,
+          "x": 0.7594255157953386,
+          "y": -0.7840081732519648,
+          "z": 2.530393125472639
+         },
+         {
+          "index": 10,
+          "x": -1.4872055561564141,
+          "y": 0.3599911702784182,
+          "z": 4.835100132883255
+         },
+         {
+          "index": 11,
+          "x": 0.2150577809319032,
+          "y": 0.11582875972667908,
+          "z": 5.208579582224949
+         },
+         {
+          "index": 12,
+          "x": 1.5744840005341858,
+          "y": -0.372546574433127,
+          "z": 5.51545982910521
+         },
+         {
+          "index": 13,
+          "x": 0.3679772618606698,
+          "y": -2.878238152804081,
+          "z": 4.186569493581132
+         },
+         {
+          "index": 14,
+          "x": -0.11537830312732728,
+          "y": -1.9506804820892456,
+          "z": 3.339122687346829
+         },
+         {
+          "index": 15,
+          "x": 0.268552495967064,
+          "y": -2.3876264052815257,
+          "z": 3.7811188858038514
+         },
+         {
+          "index": 16,
+          "x": 2.226832215019299,
+          "y": -2.126093605804431,
+          "z": 2.0328388792460435
+         },
+         {
+          "index": 17,
+          "x": 3.8506435691911456,
+          "y": -1.3191840891125446,
+          "z": 0.6586872458863735
+         },
+         {
+          "index": 18,
+          "x": 3.176396308806726,
+          "y": 0.5053296955453654,
+          "z": 0.584394876179876
+         },
+         {
+          "index": 19,
+          "x": 3.6109830595525274,
+          "y": 0.24878768452561512,
+          "z": 2.154914558728954
+         },
+         {
+          "index": 20,
+          "x": 4.268315558606928,
+          "y": 0.28702041547905166,
+          "z": 2.1925933269587845
+         },
+         {
+          "index": 21,
+          "x": 5.051792703926308,
+          "y": 0.8084957713851727,
+          "z": 2.726933416131036
+         },
+         {
+          "index": 22,
+          "x": 3.960653857760024,
+          "y": -1.0602674336345799,
+          "z": 1.6993094433335816
+         },
+         {
+          "index": 23,
+          "x": 4.0584745148057975,
+          "y": -1.6941204224418502,
+          "z": 1.6515505886605286
+         },
+         {
+          "index": 24,
+          "x": 3.786081117290783,
+          "y": -0.46754429414988685,
+          "z": 2.4685878205488523
+         },
+         {
+          "index": 25,
+          "x": 2.741724342276396,
+          "y": 0.1523948677505672,
+          "z": 4.58321713054731
+         },
+         {
+          "index": 26,
+          "x": 2.8013085128398605,
+          "y": 0.7990974820535526,
+          "z": 4.892019651329498
+         },
+         {
+          "index": 27,
+          "x": 0.2069234183914137,
+          "y": 1.24699471682072,
+          "z": 4.654423098801681
+         },
+         {
+          "index": 28,
+          "x": 2.1655806809093194,
+          "y": 0.4687251097775069,
+          "z": 5.912860340821911
+         },
+         {
+          "index": 29,
+          "x": 1.9829943803653802,
+          "y": -0.05890571295352498,
+          "z": 5.893990033926627
+         },
+         {
+          "index": 30,
+          "x": 4.248989972799317,
+          "y": -0.254524993710882,
+          "z": 4.507886736419069
+         },
+         {
+          "index": 31,
+          "x": 5.934371725729361,
+          "y": -0.8869058278485157,
+          "z": 4.571610341559309
+         },
+         {
+          "index": 32,
+          "x": 5.4140845862818425,
+          "y": -0.5044805179694067,
+          "z": 5.62977884584074
+         },
+         {
+          "index": 33,
+          "x": 5.4501816431594925,
+          "y": 0.3429631069122123,
+          "z": 6.02974958340587
+         },
+         {
+          "index": 34,
+          "x": 5.399664441419694,
+          "y": 1.703967924986447,
+          "z": 5.61243990526056
+         },
+         {
+          "index": 35,
+          "x": 5.172968470830933,
+          "y": 2.397689255319875,
+          "z": 3.692298753317647
+         },
+         {
+          "index": 36,
+          "x": 5.750154694482398,
+          "y": 3.1886569430215896,
+          "z": 4.344349548933432
+         },
+         {
+          "index": 37,
+          "x": 5.092582320162698,
+          "y": 3.1067826056283856,
+          "z": 4.917785581801794
+         },
+         {
+          "index": 38,
+          "x": 5.254272059482469,
+          "y": 4.141413004966657,
+          "z": 5.620976316751887
+         },
+         {
+          "index": 39,
+          "x": 6.357545531371504,
+          "y": 4.097757647686296,
+          "z": 6.18646564919352
+         },
+         {
+          "index": 40,
+          "x": 5.57987671819632,
+          "y": 3.514169061914425,
+          "z": 5.664795621912372
+         },
+         {
+          "index": 41,
+          "x": 6.868678223733693,
+          "y": 4.438871989278683,
+          "z": 4.971151710223277
+         },
+         {
+          "index": 42,
+          "x": 5.978478595171977,
+          "y": 4.256481510544367,
+          "z": 4.290192930843104
+         },
+         {
+          "index": 43,
+          "x": 7.27385413218568,
+          "y": 4.4418126528036,
+          "z": 4.195896001192871
+         },
+         {
+          "index": 44,
+          "x": 7.60085135587176,
+          "y": 4.162472682994865,
+          "z": 2.032617349280593
+         },
+         {
+          "index": 45,
+          "x": 7.948721752538825,
+          "y": 2.81277416046235,
+          "z": 2.694012623718799
+         },
+         {
+          "index": 46,
+          "x": 8.364290165030434,
+          "y": 4.0841944872584115,
+          "z": 2.759878490550716
+         },
+         {
+          "index": 47,
+          "x": 9.359794630240813,
+          "y": 3.482878122855636,
+          "z": 2.927735045609092
+         },
+         {
+          "index": 48,
+          "x": 8.104774336021741,
+          "y": 4.190030140622708,
+          "z": 3.614185846205572
+         },
+         {
+          "index": 49,
+          "x": 9.715417613466196,
+          "y": 4.623986629439741,
+          "z": 4.015269442644731
+         },
+         {
+          "index": 50,
+          "x": 9.370471485459165,
+          "y": 5.504467326189326,
+          "z": 3.041052583158115
+         },
+         {
+          "index": 51,
+          "x": 9.065885308371291,
+          "y": 5.4206861985537556,
+          "z": 1.394615266131908
+         },
+         {
+          "index": 52,
+          "x": 9.218321631226758,
+          "y": 3.739325038071642,
+          "z": 2.40901501723681
+         },
+         {
+          "index": 53,
+          "x": 10.198316200824136,
+          "y": 4.573143244874159,
+          "z": 0.8947416224225218
+         },
+         {
+          "index": 54,
+          "x": 9.35226463525669,
+          "y": 4.335863561983189,
+          "z": -0.13679849716142778
+         },
+         {
+          "index": 55,
+          "x": 8.762788860077656,
+          "y": 5.119003366159331,
+          "z": -0.4334589388760052
+         },
+         {
+          "index": 56,
+          "x": 9.117564250500054,
+          "y": 5.418976864353279,
+          "z": -0.18891403242086383
+         },
+         {
+          "index": 57,
+          "x": 9.602651859227619,
+          "y": 5.086966380253811,
+          "z": -0.6121778154020331
+         },
+         {
+          "index": 58,
+          "x": 10.879607109217254,
+          "y": 4.311484927031843,
+          "z": -1.425664934927123
+         },
+         {
+          "index": 59,
+          "x": 10.537410942379033,
+          "y": 4.387162376655904,
+          "z": -0.5399290309997808
+         },
+         {
+          "index": 60,
+          "x": 11.225578975297841,
+          "y": 3.5183673813659633,
+          "z": 0.832419083266073
+         },
+         {
+          "index": 61,
+          "x": 10.359691864727573,
+          "y": 2.7040074025101597,
+          "z": 0.44964576655079536
+         },
+         {
+          "index": 62,
+          "x": 12.26761043202559,
+          "y": 1.0648754608317819,
+          "z": -1.5795325927036103
+         },
+         {
+          "index": 63,
+          "x": 11.022252084971917,
+          "y": 2.865679137865471,
+          "z": -2.1572375190414115
+         },
+         {
+          "index": 64,
+          "x": 11.452264641911409,
+          "y": 3.3518049587910395,
+          "z": -2.096341110341587
+         },
+         {
+          "index": 65,
+          "x": 12.158060551893351,
+          "y": 2.321521136777985,
+          "z": -2.0022892663135545
+         },
+         {
+          "index": 66,
+          "x": 13.177127890975944,
+          "y": 3.6645282775200165,
+          "z": -2.4389101160888402
+         },
+         {
+          "index": 67,
+          "x": 15.522945188865691,
+          "y": 2.361464107419462,
+          "z": -3.568480388365322
+         },
+         {
+          "index": 68,
+          "x": 15.81688552955633,
+          "y": 2.5220984282537025,
+          "z": -3.7165067259278377
+         },
+         {
+          "index": 69,
+          "x": 16.129729433656294,
+          "y": 2.4937185572111527,
+          "z": -4.2466357168853275
+         },
+         {
+          "index": 70,
+          "x": 17.06784855711916,
+          "y": 3.93583270540669,
+          "z": -2.493002296789477
+         },
+         {
+          "index": 71,
+          "x": 16.70326660367303,
+          "y": 5.5249944902113155,
+          "z": -2.121319801745191
+         },
+         {
+          "index": 72,
+          "x": 16.950199127276772,
+          "y": 7.159967308032584,
+          "z": -2.7152283810749513
+         },
+         {
+          "index": 73,
+          "x": 15.248282457364098,
+          "y": 8.210170853853088,
+          "z": -1.9355365448498585
+         },
+         {
+          "index": 74,
+          "x": 16.054992388109284,
+          "y": 8.250469654794461,
+          "z": -3.107166689002126
+         },
+         {
+          "index": 75,
+          "x": 14.164541809906131,
+          "y": 8.916046264798378,
+          "z": -2.7773149839259865
+         },
+         {
+          "index": 76,
+          "x": 12.298760173518286,
+          "y": 7.155427687411402,
+          "z": -1.605128707862652
+         },
+         {
+          "index": 77,
+          "x": 11.8800503728053,
+          "y": 7.481289338966637,
+          "z": -2.065024272465417
+         },
+         {
+          "index": 78,
+          "x": 11.643534036485335,
+          "y": 6.424359008166599,
+          "z": -3.0244706955932585
+         },
+         {
+          "index": 79,
+          "x": 11.869846216582067,
+          "y": 6.834063197344662,
+          "z": -2.5672367692080074
+         },
+         {
+          "index": 80,
+          "x": 12.120206533204701,
+          "y": 7.066807418005693,
+          "z": -3.424208815445228
+         },
+         {
+          "index": 81,
+          "x": 10.594880908570588,
+          "y": 7.4382606295506015,
+          "z": -3.239480823160873
+         },
+         {
+          "index": 82,
+          "x": 10.458719301874376,
+          "y": 5.9438633998527735,
+          "z": -3.4561830287704414
+         },
+         {
+          "index": 83,
+          "x": 11.455597611962888,
+          "y": 6.077430806863743,
+          "z": -1.8707027699876657
+         },
+         {
+          "index": 84,
+          "x": 12.754059866940093,
+          "y": 7.177908821156228,
+          "z": -1.209913816481841
+         },
+         {
+          "index": 85,
+          "x": 14.708054346196757,
+          "y": 6.939716516222237,
+          "z": -1.6791085690526817
+         },
+         {
+          "index": 86,
+          "x": 15.281672532246994,
+          "y": 7.147083287222761,
+          "z": -2.2179803046948017
+         },
+         {
+          "index": 87,
+          "x": 15.52144984592544,
+          "y": 5.812799723614566,
+          "z": -2.8043770783954693
+         },
+         {
+          "index": 88,
+          "x": 15.117744315987167,
+          "y": 5.444030417678696,
+          "z": -2.280572102090161
+         },
+         {
+          "index": 89,
+          "x": 13.927728756982127,
+          "y": 3.220712999501728,
+          "z": -3.5345034995471702
+         },
+         {
+          "index": 90,
+          "x": 15.193044682415191,
+          "y": 2.4866111100918293,
+          "z": -3.937726991578081
+         },
+         {
+          "index": 91,
+          "x": 15.071570219335568,
+          "y": 2.9177719361150682,
+          "z": -1.6453903467106312
+         },
+         {
+          "index": 92,
+          "x": 14.202344173379267,
+          "y": 2.364584729551816,
+          "z": -2.172403692590777
+         },
+         {
+          "index": 93,
+          "x": 15.887154022596365,
+          "y": 1.0427051146283275,
+          "z": -3.492515229576884
+         },
+         {
+          "index": 94,
+          "x": 16.68478992256872,
+          "y": -0.6943145021549451,
+          "z": -3.228226032811297
+         },
+         {
+          "index": 95,
+          "x": 18.131774750904352,
+          "y": -1.6764272841025862,
+          "z": -1.1351491559933211
+         },
+         {
+          "index": 96,
+          "x": 17.814194344521113,
+          "y": -2.8151228157108497,
+          "z": 0.2388957166555099
+         },
+         {
+          "index": 97,
+          "x": 17.305576906316734,
+          "y": -2.7856877507761673,
+          "z": -0.09130337260940496
+         },
+         {
+          "index": 98,
+          "x": 16.804003476374817,
+          "y": -3.385818957044541,
+          "z": -0.7751946313592928
+         },
+         {
+          "index": 99,
+          "x": 16.013016105881928,
+          "y": -3.569795812183962,
+          "z": 0.018632786890970587
+         }
+        ]
+       },
+       "encoding": {
+        "color": {
+         "field": "column",
+         "title": null,
+         "type": "nominal"
+        },
+        "opacity": {
+         "value": 0.4
+        },
+        "tooltip": [
+         {
+          "field": "index",
+          "type": "quantitative"
+         },
+         {
+          "field": "x",
+          "type": "quantitative"
+         },
+         {
+          "field": "y",
+          "type": "quantitative"
+         },
+         {
+          "field": "z",
+          "type": "quantitative"
+         }
+        ],
+        "x": {
+         "field": "index",
+         "type": "quantitative"
+        },
+        "y": {
+         "field": "value",
+         "title": null,
+         "type": "quantitative"
+        }
+       },
+       "mark": "area",
+       "selection": {
+        "selector005": {
+         "bind": "scales",
+         "encodings": [
+          "x",
+          "y"
+         ],
+         "type": "interval"
+        }
+       },
+       "transform": [
+        {
+         "as": [
+          "column",
+          "value"
+         ],
+         "fold": [
+          "x",
+          "y",
+          "z"
+         ]
+        }
+       ]
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAdQAAAFbCAYAAABswX9hAAAgAElEQVR4Xuy9C5QV1ZU/vKvus98NDUI3T0FbJUKiaAwmJuRlZhBIFHk0MYl5LDP/ZDIzmf/3aZMY42SMtM6sbx7fZL4h84j/GQcaEJ0AMgmTjGaYyBiCRkBUDNi8ummhm6bf9/a9db51Ll1NdfWpqvOoul19775ruUDu3ufs+p1d53f3OfvsowF+EAFEABFABBABREAZAU25BWwAEUAEEAFEABFABAAJFZ0AEUAEEAFEABHwAQEkVB9AxCYQAUQAEUAEEAEkVPQBRAARQAQQAUTABwSQUH0AEZtABBABRAARQAR4CDUKAOUA0GWDqwwABgDAQBgRAUQAEUAEEIFiR8CLUP8YAL4KAC8DQCUAPAQAHQCwGQAyADAHAP4MAJ4qdiDx+REBRAARQASKGwE3Qo0DQGo4Ou0DgIcBYBoAnAWACgD4NgBMB4A2AKDRan9xQ4lPjwggAogAIlDMCHhFqJMA4CIAlALAzwHgrwDgEwDwMwBoBsgdu6FLvvMB4EQxA4nPjgggAogAIlDcCHgRKkXnZgD4EQAcAYAvA8A/A8A2AHhmGLp2ALgNAFo2btz4qKZp37VCOnXqVFi6dGlxo4xPjwggAogAIiCDAJk/f74uozgeOl6E+vHh/dI/AICtwwY+AgDdAPCXABAZjmCrnZKTmpqaSGNjo1c/4/HsuT6PHz9OBwztkxwBxE8SuGE1xA/xU0NATbsY/W/5w89cawxlFmhabgsTCIF2PZY9uvuxz76thublJVunD/3u0vAS768sQisB4PcB4E4AWA0ANHFpiVMjSKhqQ1SMDq+G2GhtxE8NTcQP8VNDQE3bb/9b8e3mDxhZWMSyyjDg0L8/ue5/VCx2I9RrAMDO2P8HAP4XAOwBgAUAUAIAnxzOAmbagYSqMjwYQauhh/ghfqoIqOn7TQhq1ozVLib7aGRKMpmPumGoRbMvOESqNH+IJuQ+CQAbACAGAN+zt6Wy1DkLAM4BwJCbgUioaq9AMTm8GlJsbcRPDVXED/FTQ0BN20//W/ZQ86fNZV4nq+jy754n1v2Y8f31APAGANAV2n8FgBuGCXaUqAqhciGFhMoFk6OQnw6lZgkSFuIXBAJqbeL7gfjxInBXY/MDPLLPN637oYMcTbh9dHiV9u9YMkiomJTE42NI+EooOSsjIagBi/ghfrwI+ECotLBREwB8Yfi0y5iukVCRUHn9kSmHE5oSfJhlrgYf4of4cSOguORLc4peGU7I/Zvh2gvn7Z0joSKhcjskSxAJVQk+JAQ1+BA/xI8bgWUbmus1Aq5FEbRo9IXdj93LOj6zFwD+CwAeAwC6JEyTkr6IhGpDAAmB2x8xQlWDCvFD/AJAQK3JYpv/lm/YvIQQfSELNT0Ch3Z9P7hjM2ojNayNSUlqMBabw6uhNVYb8VNDFPFD/NQQUNMOwv9opAoG3GAt7AA6vLFn47pjata6F3ZQbTunj4SqBmMQDqVm0WhttE8NTcQP8VNDQE0b/U8NP1zyxSVfXz0IX0g1OBE/xE8NATVt9D81/JBQkVB99SB8IdXgRPwQPzUE1LTR/9TwQ0JFQvXVg/CFVIMT8UP81BBQ0y5G/xv805nXZiPGDUAIvc8bQNPORbL6G8nvnAm0OL7aSA1r4x6qGozF6PBqiI3WRvzU0ET8ED81BNS0/fa//sdmfIBoBrM4vkaMQ6UPtwdWHF8NCSRUX/Dz26F8McrSCNqnhijih/ipIaCmXUz+l4tM9axrcfyIEXnBIVJ9drhKEr157RYAeBAA1uCSLy75qr2BiB/i5ysCao0VEyGoIcXWLib8+h6r+zRoJHcHqtMnS7T2yodbWcXxvz+s8+3hW2YIANDavqM+WCkJKyUpvafF9EIqAeWgjPipoYr4IX68CPR9v5arOH7Zt9tYxfEXA8BmALgOAF4HgPsA4FUkVIyweP2PSw4nNC6YHIUQP8RPDQE17WLyP0VCpcHnKQD4MgD8IwDMBgAapWKEakWgmBxK7dXDJSPELwgE1NrE9xfx40WAZ8kXiNZexl7ypd3Qm2ZWA0AzANCl3zEfXPLFJV9ef2TK4YSmBB8Wd1eDD/ELGX6rH90W3/7omrSiWSPqfs4v3Y/PqI8Qw7U4vktSErXp/QDwMgC8DwBeQ0JlIODngPnlRBhB+4ckjq8alogf4seLwMoHt9RldP0jCS2297mN93Tw6rnJ+e1/3d+bsSQSMZjF8TWiHyp9+KzbsZmbAYBeLE6JlfnBCBUjVCW/99vhlYzBH0x+w4cRoCKixfR+3NW4bTGAsZgASSe0xC4/SDUI/HKRqkFuGMn4JVp7hOhHPQo7fBYAHgGAbwAAvcoNCZWFQBADpvgOjlJH+9TQRPwQPzUE1LSLyf+WNzbfSQDmUsT8ItUQ4VcOAAYA9Lt5BEaoGKEqzRghcnjmc6B9SsOLEaoafEWF37LGLfdroMWtkMW1+A6VSDXs76/dPZBQkVCVpoywOzzapzS8RUUIakixtYvF/+7e8GxNmqRX2VEgYHSUJaO7ZBOVwo4fEqoNgbAPGNqnNs0hfoifGgJq2sXif8seenqhpkWXMNEi5MjzTzS8JINkEPidXr/qWpLVFmig5aomESDtWoQcnbV5BxbHlxkkq04QA6ZqE9rnH4I4vmpYIn6IHw8C1v1TlnzEILt3PtnQytNWkPPfmbVrP0DAoTg+6Idmbt2KxfFFBynIAVOxhaWLE5oaoogf4qeGgJp2sfgfa//UihwBracsqe0QXfr1Ez8amUJWdy2ODxHjBYdI9Y8B4AuWZ/pXAHgSl3xxyVdthkD8ED9fEVBrzM8JV80StnYx2LfywX+syOplDZ74SSz9+onfqbX3ftpc5nWylS7/zt76DKs4fg0AVAPALAB4AQA+NvznqKYwKQmTkjzfAzcBPx1eyRAHZbRPDVXED/HzQmDZhuZ6jYBrBSKzDdGlXz/97/Ta1VzF8Wdt3c4qjk8fIQoALwLATwHgT1m4IKEioXq9L67f++nwSoYgoQYBH2b5KqJaDO/H8sYtSwlo9TxQ0fOpZcnIZt6lXz/x84FQHx++C/V3ASCLhMpAwM8B43EoURm0TxSx0fKIH+KnhoCadjH437LGrQ0akApepDSAlt1N6xyrDVnb8RM/xSVfSqJPAcB7AeCc07NihIoRKu97wJTz0+GVDMEINQj4Qh2h0tqxX195w9lPfeh9gc9jsuAW+vvBvX9qAzALZO9PmhpavHD1E7/ja9fWx8G9OL5LUtJ/A8AHAaBn2OZtAPAVu/2BO2JTUxNpbGwMvB+vgXH63s8Bk7XBTQ/tU0MV8Stc/OhS49o7rn5h6753Prq7qYHubY363PWt5htL4/ox3uVFNaTY2oXuf7/TuGVuBLQ7RbGjS79Ro3/Hzie/bBJUXn6wn1m9egnRgV0cH4/NiA7jWPlCd3h1hNxbQPzUEEb85PCj14T1DWbXN9xx9Y+a97V8VQNyzCTV3Hcp406NQJ1oEoycNc5ahT6+dz205XbQtBtlcCMatO7ZuG53vgOKM2vX1huQvQELO8iMmodOoTt8AJCNahLxU0MY8ZPDz8wsXXfH3E2UUGkrhGT2G1qkRwdYeqWmrH7w+aY1B+V6Udcq9PFd1rh5lQY6PVIi9fH6wRN2/OwPHfhSLC75SvnZiFLYHQrtw/FVQ0BO26zMYyVUVksiCTBylhTvCo7s/qkVMa8oNezzCxKqDYGwDxjapzbNIX6Fh591IvciVFqhZ0/T2i1qKMhrF7L/qSz3WhGNGH1bnPZSw44fEioSqvzswNAMu8OjfWrDHUb8rIXYvQiVPn1pUn9qvBKTwoif1SNk7TP3sO3Xtcl4m3X/264va5+MHX7o4JIvHptR8qOwOzzapzS8oTw2Yz33yEOoXvt0aggV55KvSHUkL3zdij2E/f3FCBUjVC//Fvo+7A6P9gkN5xjhsOFnv3eTh1ABxi8xKWz4+RUBihZz8PZC9hiFHT8kVCRUb98WkAi7w6N9AoM5AZb07ft2PIQ6nolJheh/tKBGVteWq3nWaG2nve6w44eEioTq53sQyiVBP/aIfAXJpbGwTxhhso+1b8dDqOOZmBQm/FhuKGPfsg3Ny+kZX7/fEaLBi3s2rjs2kd5fJFQkVF/fA5kX0lcDPBpD+9TQDgt+l8k0s8J+5pGHUCkCrMQk2mbQyUphwc/JC0Tt8+OojJMtrCM0ovapebu6NiYlYVKSkheF3eHRPqXhDcUKBN03TZHUClZGKS+hsmrH0sSaBMQ7ntt4T4caSs7aheZ/IjfLyGD6fNO6UVenhR0/jFAxQpXxc0edsDs82qc23OONnxuZ0ifjJVRWYhJNrAGNHLQvM6ohNlp7vPHzehZR+5Y1brnfj6MyTnYhoXqMGFZK8nJp9+9FHV6tN3FttE8cM6sG4ueMH40ggZDb3SZwXkLViNG2+4n1u8zerhR1DzYDuJDGN4hkJPvoI6EioarNqB7ahfRCBgqUQ+OInxrq44UfvSkGDLjdy3peQqVnHfc0NdD7LHMfM7HGTrRe/Yl+P1748dopYp+1oAZv+6JySKhIqKI+IyQv4vBCDfskjPapAYn4jcVPZJ+Ol1BpL2aJO2tijZ1o1UZzrHYhja/IuMjiiISKhCrrO1x6hfRCcj2wz0KInxqg+cZP9PYSEUI1E5PsxBBkacJ84kezluloi2Qui9gnOjYynoeEioQq4zfcOiIOz92oj4JonxqYiN8V/GSOZIgQKk1MKk3CYXqPqnVfNsjShPkaX7onTK+t00Fr3d20bi+vV4rYd1dj8wO87crKFQuhlgNAH71yUBQoTEoSRWy0vIjDq/Ukp432yeFmaiF+VkIVr8AjQqh0v9QAo0XToktGj1pwiUlBjy+NSgdSsJgQY6H5TG7F5u3eymtfPhKSqG2FTqhXAcAiAHgWAK4BgHcBIAEA5wHgJ8OD8xYAfMdpWkFCxQlXDQE1bd4JQ60XeW207wp2MkkvIoRK90sB9JQGpMI6YiIEJDrSQY7v5WIXZJX9eaiNrKpDLNt57burcdtiAGOx6POLyhc6oa4CgA8CwDcBYNowoV4PAN8DgPUAkPECDAnVCyH373kdXq0XeW20Tx47qon4XcFP5n5NEUJ1GikCRseepvU71EaSrR3k+HolCbGKWdit3P/K6+T/2fl6wmvf1bzQPQiMrG0WOqGaz0qXek1CpUWRNwMA/ZV3AAAeAoAXMEINxtWCfCH9sBjtU0MR8buC3/KHNq8gml4rgqgfhEr7s0/kIja4yQY1vjxLsG7XolGb6b7rZ++4+p3mfS1fpVF6BqDlJ00NLazn8f92GTZqxUioHweAmwHgbwBgLQBsAAAatTL3VzFCVXs1g3oh1ay6oo32qSGJ+F3BT2bS9otQg0pMCmp8eTNu3ZZ+6YrAug9f/UtKqOYosHCgS8v9g8b9ap7Op12MhEpTs7PD/0WGl31nAcCZjRs3Pqpp2nft0K1evZoPTZRCBBCBokXgpTdpasb4fK6prYCrqpLj07lgr6cv9MHpC/1cWlOrknBt7agt4xG91965CH2p0bt2LPlL/UPw+qkurv5UhW6/fuqYJubPnx94zXlVu019XkOtS75/AgD0qb8GkKtk8i8AMN/JIIxQ1YYqqF+4alZhhIr4+YXA5XbsF4fztu5XhAqEHHn+iYaXePvllfP7/aVHizJ66SreerpOhSvMI0os/OzncvOVkEQxLaYIlWb80p+QdI/jZ8ORKf15QyPS3UiovK+YmJzfL6RY797SaJ83Rm4SiN9ldHj2BFk4+kWoQZUg9Ht8ZZKD4lp8h/1GHVonWSOwlIUfIZn9e56477CJt0yfsm9FsRAqC5/pAHDOCziMUL0Qcv/e7xdSzZqx2mifGqKI32X8ZKMgvwg1qBKEfo6v/F7m2HO2ZoYwk1BB69nTtHaL6dkye9uyb0UxEyoXZkioXDA5Cvn5QqpZwtZG+9RQRfyGCfWhLbeDpt0oiqZfhEr7NWv9itqQrxUI2SiedSzIvIbNCT8zOUmmepUKfkioHughoaq4F55TVEMP8Zso+MkcmaHP5i+hkt07n2xoVcXMqu/nDyaZwhemLdZ9Uet+tRN+ZrGLK9fc+YmKc1tIqEiogXqany9kEIaifWqoIn6X8ZO9uNpPQmVdQq42uv7+oPMq5OBmq/X4jHV53Q0/SsL9g7AwHxWSTNuRUJFQVd85V32ccNXgRfwmBn6yhdf9JFQNoEWksDwPsn76n2wUT+20Ppu1HTf8aHKSDvpc0WIbPLg4ySChIqGq+I+nrp8vpGdnEgJonwRoFhXETz7D1+8l3yBKEPo5vrI/OihOZtKVPbHJlVBB6wEwErxHdNTehMvaSKhIqH74kWMbfr6QQRiK9qmhivhdLoEXAe1OGST9jFBZE7qMTVYdv8bXj+QgmmiU1iFuxdpv/FTxQkJFQlX1IVzyDRBBvya0oExE++SPzPgdodL2/C5B6Nf4qvzoGPFdQo7k/m7JpkZC9ffN5q2UJN0rZvlKQ5dT9OuFVLPCWRvtU0MW8QNQSbbxmxDsRQ3URte/91f2nK7VfrqkDRCJW6978xs/VbwwQsUIVdWHMEINEEEkLDVw84GfSrKN74TgcwlCv/ALqlqR7/ipuRvuoXrhhxGqF0Lu3/v1QqpZgREq4hcUAnTJt/kB2db9JgS/SxD69f4GVa3Ib/xkx9HUwwgVI1RVH8IINUAE/ZrQgjKx2O2TL6d3eUSCIAQ/70b1a3xVfnS4+W4Q+Km8K0ioSKgq/uOp69cL6dmRpADaJwncsFqx4ydbTs9EPQhC8LMEoR/jq4oREqraOyqijUlJx4+TMN+358cLKeIQorJonyhio+WLHT/z1hNZFIMg1CyQvT9pamiRtcmq58f4qmKEhOrHSPK1gYSKhMrnKQ5SfkwYSgZ4KKN9augGjZ9q9moQhOpnCUI/8LtL8uIAnpEPBj+entkyuOSLS77y3sOh6ccLydGNtAjaJw1dTrHY8VPNXg2CEPxMTPJjfFWyoL28Mwj8vPp0+x4JFQlVxX88df14IT07URBA+xTAQ0KFZY2bV2mg18iiGAQhENt9oLK2+fWDSfbiAB67g8CPp18nGSRUJFQV//HURcLyhMhVAPELN36q2atBEYL1ujMVBFX9TzUL2sv2oPDz6hcJVRIhPIcqCdywmuoLqda7tzba542Rm0Qx4+dHOb2gCMGvEoSq4xtkhi/1y6Dwk30rMELFCFXWd7j0VF9Irk4UhNA+BfCKfMlXpeSgiXpwhKAffL5pzUG10VXfI1dN2vKyPzj8vHpmf4+EioQq5zmcWkhYnEA5iCF+4cXPj73BoAhBA3Jsd1PDi2roqROqHz863J4hKPxkcUNCRUKV9R0uPSQELpgchRC/cOLnx3JvkEuWft2Nqup/QWb4BomfrNchoSKhyvoOl57qC8nViYIQ2qcAXhEv+foVeQUZYflRglD1/VBN2vLyziDx8+qb9T0SKhKqjN9w66i+kNwdSQqifZLADasVK35+LPcGHWHFtfiO5zbe06EywirjG3RCUtD4yeCGhIqEKuM33DoqLyR3JwqCaJ8CeEUaofq13Bs0IRANXtyzcd0xlRFWeT+CTkgKGj8Z3JBQkVBl/IZbR+WF5O5EQRDtUwCvSAnVr+XewAnBh7tRVd4P1aIXPJ6JS748KPHLYC1frOXL7y0MSZUJQ6ljTmW0jxMoB7Eg8PNruTdoQvWjBKEsfkEXdDCHGwlV7f2wayOhIqEqeZTshKHUqYAy2icAVh5+MPm53Bs0oRIg6T1NDU+pICjrf37j5PQMSKgqoztWFwkVCVXJo2QnDKVOBZTRPgGwJAiVRlLbH12T5u1FtRi+vZ/ACUFx2VfW/4K8YcaKYeD48TrGsBzuoXoAhqUHBT3KJi77Qqr1yq+N9vFjxZKcyPjRLNRMRCvnTdwJYhkzH4SgkpwkO77LGrc2aEAq1LzLWzsf+HlbcUUCCRUJVcRfhGVlX0jhjiQV0D5J4IbVJjJ+yx56eqGuRWp4KwoFkbWaD0KgS78JLbFL5AgN/fHQlzLu/PMv3LxrwfX1QiuBKx/8x4qsXtag5ll82vnAj8+Sy1JIqEioIv4iLDuRJ1zhhw1AAfFTA9UNP7osSTSo59lnzBHMYHa9BlpczaLR2vkiBEqqZcnIZp7l7VzkrsOd9FkfXrNw05Kb3yNEqMs2NNdrBJb6iZNTW/nCj/dZkFCRUHl9RUoOCUEKthElxC84/MyyeDwFEIKITumT5ZMQaDnCsmR0lxupLt+wbQkhxkIT9W+uvGHTJ25/rxCh+nmsyGv084mfly0YoXIghHuoHCC5iCAhIH5qCKhpu0aojc0P0NYJyezf88R9h516Cio6zTeh5p4VSDpqwN6dTza0Wp/3clRKltgvS//yJ67ZdM8nbhEiVD+PFXmNPhKqF0Ji3wsNtFjTl6WRUGVQu6KDhIr4qSGgpu3kf9Z9Pq/zmkFFp+NBqCaamqYfLklA7nq3gRQstkalVsQpYe08cCrBs1RM9e7e8GxNmqRXqY0avzYSKj9WPJJIqHhshsdPHGWQ8JXgg4mKn/2cZGlSf4pFGkFGp+NJqJejVa2H/umWjUsJa/sv3plhj2idvIYmemladImaV/FrI6HyY8UjiYSKhMrjJ0ioSig5K09UQrVHnVkge3/S1NBif9Igo9PxJlQel7hMWKdu4b2s3O9zul42IqF6IST2PRIqEqqYx9ikJyohKD20j8oTFb8xEz+jAELQ0elEIdSt/3Vi5e4n1u/icZugr2uz24CEyjMq/DJIqEio/N7CkJyohKD00D4qT1T87IUH6PLnnqa1W6zQ5CPaChshsAhry753vshztChf5QatNoYNPzw24zG5YFKS2uw7USdctaf2TxvxU8PSCT9WJBUx+rbsfPLLuX3FoJd6zacKGyE4RYA8R4vyeVwmrPghoSKhqs1YHtpICGrwIn7y+NFM3qYv3dFtr/TjdPG1eXwmn5HWRCFUnqNF/YPG/fKjJacZNvyQUJFQ5TyZUwsJgRMoBzHETx4/GjH9X3e/54Wlty0atTXklImqAbTEtPjBFEmt8LsiktNThI0QnCJUDcgxtxKN+ayOhEu+8u+ElybuoeIeqpePuH6PhKUEX2iPzZjnTL/wsXmb1tz5/lHzhNNNKLToAYCeykdR97AuWToRKmuP2Sqbj/1mlqeG7QcJRqgYoarNqLjki/jNnx/4D1tRkM39PDrh/uu+d662HokxSw6KthmEfNgIwYlQ6b+7ndUdj+VealPY8ENCRUINYp4YaRMjQDV4ET9n/IZvRJlrv37NWgWJTrhb97V8anfTur1mS/k+2uHmAWEjBDdCdTqrO17LvUioanMLSzvwX8aY5as2aEgIiJ8aAs7a5kRuv+/Tmm1qEpaZwZvPq8V4nnsiESo4XFa+bEPzco1AHc/z+i0TNvwwQsUI1W8fH9UeEqoavIifM35W4jRJ1U6YVyZc/SCt9pPPDF6ekQ8bIbhFqKyax+P9AyVs+CGhIqHyvPfSMkgI0tDlFBE/lwi1cWuDNYGIkqpOSB0Brd7UMidcM6kmX+dLeUc9bITgRqj0O/uyb75r93rZx4t7UHJIqEioQfkWEoIPyCKhskHkjYyshEXJIApaPQGY68PQ+NLERCNU+tD0x4kGmWMRY/BYRi+5037lmy/AcDYSNvyQUJFQOV1XTgwJQQ43UwvxY+PHGxlZJ1x6ztQArSafx2K8Rj9shBD2CDDs9hULoZYDQF/ux9WVTxm9ChAADDenx6QkrynB/XskBMRPDQG2Nu+5RyQsNfQRPzH8Cp1QrwKARQDwLABcAwDvAsAUANgMABkAmAMAfwYATznBhoQq5lB2aSRUxE8NAYcItXHL/TzVjJAQ1NBH/MTwK3RCpTfHfxAAvgkA04YJtREAKgDg2wAwHQDaAIBGq/0s6JBQxRwKCVUNr0LGj+570uczC9DLIuVUi5fVHhKCLMqX9RA/MfwKnVBNNOhSr0mo/wAAPwOA5txl9ZeXfOcDwAkkVDHn4ZHGCJUHJWeZQsKPZthqkK1wqwnLg5ZIpi4SAg+izjKInxh+xUio2wCA/vfMMFTtAHAbALRs3LjxUU3TvmuHcPXq1WKoojQigAiMQeDg8Q7IZAksnl8D0Yh8TZbX3rkIfSm6Y4MfRCBcCNx+/dQxBs0PYWlOJ9R430prhPoIAHQDwF8CQAQALgJAtVNyEi75qjlsIUVYakjIaRcKfndveLYmTdJ0CwbslY1EkKHlBkXqxmKEJYLuWFnETwy/YoxQVwLA7wPAnQBAQ88/BoAlTrAhoYo5lF26UAhBDQV57ULBz3rDCwGjY0/T+h0yqIhWOkJCkEH5ig7iJ4ZfMREqzfg9DwAlALAHABYM//2TAPAyEqqY4/BKFwoh8D6v33Jhw49GiNsfXZM2n5PXvmW2qkZxLb7juY33dIjiZS03yKOLhMCDkrMM4ieGX7EQKguVWQBwDgCG3CDDCFXMoTBCVcMrzPjRZdsUGVxalozuMkmVh1BZUaXXhdVOKNqJ2QttJAQvhNy/R/zE8CtmQuVCCgmVCyZHIZ4JV60HNW20jx+/kdtdwOgwSZUHP6eo0ul+TUcy3dBcrxFYym8xHvsQwYoli4QqhiASqgdeSKhiDhXmCIv1JDyEoIaAmnaY7Bt1u8swqTZ9bnHKK4txmUMRBkIy+/c8cd9hHoToGdaMXrqKp5iDtT0kBB50nWUQPzH8kFCRUMU8RlA6TISAhCo4eDbxZY2bV1kLodPkor/40vufua7+Gsdse7ckIvMGGB6r7H3z6FAZJARepNhyiJ8YfkioSKhiHiMojYQqCJhNPJ/4UfIr0RI9TslCdzU2P2B/mi9/4ppNT+19rdKp+pFXzV2eIzQihRzs9iEhqPkf4ieGHxIqEqqYxwhK55MQBE3LiaN9V1CjS7oGyXawlmGdyv3RCXfLvne+mNASu3d23ggAACAASURBVOxEbO65uo0LAZIuS0Y2WzOHrfIiZQZZ/SAhyLwVV3QQPzH8kFCRUMU8RlAaCUsQsHGMUOlep05Ix+4n1u+yW+0UJZoTLiVGA+DFimSktX9waCEBfSH3fichR55/ouEle5/0iE7fIFmlct0aEoKa/yF+YvghoSKhinmMoDQSqiBg40So1r1OVvat09KtXxNuxOjbYl02vkymmRWql1f7ZZ/aKDpro31qyIYNPyRUJFQ1j/bQRkJVgzdf+FkzeLNA9v6kqaHFarlTpq5fExrRoHXPxnW7aZ9+kSltyy/71EYRCbVY8ENCRUINytdz7eaLEGQfAu0zCSy7fmSJ1rYES4+sZPWyBhbGfhIWJXK6ZOxHZGra6qd9sj7mpuenfQujb9e0Zaf0XSCTBv2y1U/7/LLJ2k7Y7ENCRUINws9H2kTCUoM3H/jZk4fsx1ncjr74OaHRfgGyadVl3jBPuHZv8BO/LyWfvfVAZuGJw5lrhUs6Onmpn/apvQls7bDZh4SKhBqEnyOh+oRqPgiVtT9q3dO0FrYPkhB8gmxUM2GbcIPCb3H0yLTboofq38jOP/XC0G0n/cKyWPDzCy8kVCRUv3yJ2U4+CEHlAYrdPqfr0KxVjJY/tHkF0fTaoJd8Vcax2CMsGp0mYTB50ai6tCV91yG/sERCFUMSCRUJVcxjBKWLnbAE4RojHjR+TmdFNYCW3U3r9lKDWAUdTENxwlUbYT/wM6NTakkWoplNg2v2q1l1RdsP+/yyZSL8oENCRUIN0t8xKUkR3aAJ1ek4DD1Xuqep4SnrxeATYUILaklVcRgd1f0gLDM6NTvZlvrdA34lJvlhX1DY0XbDZh8SKhJqkP6OhKqIbpCE6kWWEYPszmjZGk2LLin2JVXFYQyMUD8ae3nODZHjs60d/Cz9wUPHjDmX/LA5bIQV9h9MSKhIqH68d45tBEkIfhherPbx3d6iH9QgW0FAq0dC9cPbxrYhQ1hTtIvJaq07UaX3JG+JHp0XgUzU2rKfiUky9gWDFLvVsNmHhIqEGqj/Fyth+QVqEPjxFk6gt8nQ53A7xhK2CS3sEYyKfZRI1yT+/VYv32o3ajp2pD911EuO53scXx6UrsggoSKhinmMoHQQhCBogqt4MdrndQOMCL444YqgpRahfjD26oz3Rt6Y59XjICQH/2nwngNecjzf4/jyoISEyo0SXjDODRVTsBgJSw2x0dp+4+d2plTGbpxwZVC7oiOC3+fiP765Qu8r4+nxR4N37x+AkgyPrJuMiH2qfcnoh80+jFAxQpXxY24dvwmBu2NOwWKyj+c6NU7YRsTCNqHZ7S8U+3iXe83n9ysxqVDwE/VrWXkkVCRUWd/h0ismwuICRFDIL/yCIFP6KDjhCg6oTZwXP97lXrN5vxKTeO1TQ0FeO2z2IaEiocp7M4emX4TA0ZWUSDHYFxSZIqFKudwoJV5CEFnupR34lZjEa586EnIthM0+JFQkVDlP5tQqBsLihEJKTBW/IMkUCVVqSIUJVXS5l3bgV2JS2AjLjnjY7ENCRUJVnxVcWlAlhECNK/Dr5YImUyRUde/kIQTR5V7TKj8Sk3jsU0dBvoWw2YeEioQq780cmkioHCAF8INk+YZtSwgxFqr17q0dtgkt7BGMjH2iy71mH/bEpJlaW3kHqR4Uyf7F8fV+B6wSSKhIqGIeIyiNhCoImE1cBr/ljVuWulU3UrNotDZOuGpoeuEns9xrWmRNTKJkeldi38JfZxacOJi5sZ3Xaqt9vxP77/m/zrznrF91gnltcJPzws+PPkTaQEJFQhXxF2FZGUIQ7kRBodDsyyeZUtjDNqHJRIAK7qOs6oWf7HIvNcxMTDLJlJYoFE1WMu0zb7R5ObPomAghKwPk0YAXfkH3b28fCRUJNVCfKzTCChQsRuMi+HkVuw/C9rBNaIVGqLLLvRQHmph0ILPwxO3RV+ut9X7/dnD9Pl5foOP79v7dj9DLy6nOiezs1p8Mfeg4r37QcmHzPyRUJNRAfV6EEAI1xKHxQrJv2UNPL3S7GSYIfMM2oRUSoZbAQPSLyeccb/qRHc99mVuPHs5cm6vT7PX5yvvjm+KHnnralOsxyvr+Jf3pV7z06Pc0Mr4tdmj2nvSHj7H2bWnUezQzv0NkTzfs44uEioTK825IyxQSYUmDoKAogp+fNXp5TUZC5UWKLeeGX71+suoT8V8uUuthrPYZY3r7zvTHjnm1uyT26oyl15Y9cunEr0cIlerwZg+by9X00vOXMjcdM0mcPtdt0d/Mp2UURcidZW/Y/A8JFQnV671S+l6EEJQ6klQuJPvuamx+QBIGabWwTWhhj2BE7GPddSo9UBZFSnCbBtfsd2qLJkJ9PPZSfY1+qapq3i332QmVt6yhfbma7t8OQSIzU2+dZvatuoQcNv9DQkVC9eMddWyjkAgrUKAcGrfjR69e2/7omrRdfOWDW+qyurY83zaGbUITIax8YyUaYTXEn180Sb9UFYSdTpEhjUoXRd6ebe65sgiVp6whb3ayyBKyKH5B4ObVJhIqEqqXjyh9j4SqBB9Y8aOkmYlo5Xs2rhuzXHdX47bFAMZitd7EtZFQxTGzarjh99XktiX2y8PVeruizVr2ZUXELEK9aFRd2pK+65CbLSLZybxLyEiofo2+czta0F3g9W1qCCOh+ocfvXqNaKR2T9P6HfZWlzVuXuV2EbiaFc7aSKhqyDrhxxvhyfZuX/Y1j8XY22MRKpXxyhQWia5VjuKEzf8wQsUIVfad5NJDQuWCyVHIip9JmhGjb8vOJ7/cYyrRZeD+QeN+tZ7ktMM2odmfYqLa50RwcqPE1jKXfa3nVHkJ1W0fVTQ7mTdJCiNUP0ef3RZGqMePk/nz5weOg+xQIqHKIndZz8RvFGkScuT5JxpeMlv+ncYtcyOg3anWk5z2RCUsuaf1X8sJP1qVaF7kVJ3/PV5pkRLZS0M3nVqV+I+bnJaWnSLU17I3nPjl0E1nWfaJ/hhQKeQfNv/DCBUj1CDf2VF7gIF2JNn4RCF8a6F7AiS9p6nhKfOR6VIwaNqNkhAoqYVtQiuUCFVkyVR2AOmyb7+RSNHjK05tOBGqW8WlVfGfLpimd9SI2LUt9bsHZEoahs3/kFCRUEX8Xlh2ohCW8IMFoECjUNqsNYvXxM9eUpBo8KKZnLSscWuDBqQiAJM8mwzbhFYohPq15OY7PMHPg4AToTodvRFd7jUfQXYfNWz+h4SKhBroa4mEyg/v5ShUr3i+ac1BU8vEz06aGkDL7qZ1e1c++I8VWb2sgb8XfyXDNqEVAqHSPc2ViRdu8nek5FpzIlTaGiuqXBh9u+aO6IEFor3J7qOGzf+QUJFQRX1fSB4JlR+ur/zx3y0b0uPT/s+ff+lHVkL95qYXK1mkSZOTMpGyWo3AUv5e/JUM24RWCIQqcuTE39Ec25obobKiypXx/6yfqZ8bKdzAa5/sPmrY/A8JFQmV1+el5JBQ+WH7/37vkT/XiZH88eQb/9pczqX4feOH+xexa/TqBzXIVuTrqjbWk4RtQisEQpUlJX5P45d0I1R7VEmP+rglOHn1ujP10VfPkNpeLznr92HzPyRUJFQR/xWWLSRCbVu3bu4QQHp2c3OrMBAeCn/9e4++vzbT+w0q9lbyqsMP/82DT9K/U/z+8O8PfIoAzLU3QUDrATASGmi5vdfx+IRtQisEQlW5YcZvH3AjVFrl6Jn0nYcWRI/XLNCPz3BLbuKxyy1z2Ek/bP6HhIqEyuPr0jLjTagnV69eHNH1nkxsKHduc+7Tz7ZZH8ZuH70C7bmN94y5iePM5++uMdLRFVRXj2d2zfzn57hu6+ABjqxeHd9dXvedwUgsR5oZLZL5bUnN49/56wffzkWof/+rL44nabo9Q9gmtIlOqLJJPTx+JiPjRqi0PZqc5Fc1J9G7Wmn/YfM/JFQkVJn3jFtnPAn11Lp1dRrJjqpvqyUyO6xkOKa0n06W2CsRUcI7HYH1GoHLkSDROmYSskvbvn1MTV1uYCyCretXL36pZPY3iKZFzH9Og/7OZ//hyUcOvf4W2fAvr35Vpt186IRtQpvohBrUDTOyvuBFqLLtsvQoOf/z4IoDIte5hc3/kFCRUP18J8a0NZ6E2rLu3tsjxHY+04D9s7ZvP2waarXvSj1c/aCZaUvJ9IymrQCNjDpXpwFpnbn1md1u4LGOwdjl31y5ssIon/SV10un3mz/rnag6weZP/iD/X/23FEkVEkvDduE60X4Qd0wIwkf5JNQqY0dRtWlrR51gq3PErbxRUJFQpV917j0xpNQT69Zs8pOhBEgLXVbn9nLIlTrfaJxLb6DLv2eWXvvcgIau2KNRo7Nan7mRScgcu0R0mutamSXpe2/mbzqjoux0jF9lBmps5n1n3to089OIKFyedtYobBNuF6EKlMUQRIaLrV8Eyo16oxR174zvdTzvlYqG7bxRUJFQuV6sWSFxotQaeRXVpIYcz6TaDSpaPtIlaHRtXKvFEggYHT8sHX7iyQVXeX27DMNeIq19Gu9Ts1ee9dsz1ySPlg+69YhTU+y+ol9+I77/v7oABKqpAOGbcL1ItQvJZ+9NQmDTF+QhEBJbTwIVYRUwza+SKgFTKhn1q6t7x0YaLt+586RQupKb5eE8ngRKn12AgbzfKZ1H5VZK3f4OT974bWhO3p+G3N7bKJFdrOyfq2FGDQgx3Y3NYyJZGl02h0pu5a13Gv2Wb3ohvs2nYl+fUBPZCTgD1SFHpNY977YX+0/3PLIyeyMSzKl4wI1MIQRjBuhBn3DjAzW40WovKSKhCozqs46gReFn6jXt51ed+9SIFq9BvqLM7du5Vo+8XdoLrc2XoRqPj/zmSz7qKZ9rAu613X+5tbqTH8qS7ToUCQ2Uu9UIySbIEO9CZIdTEB2z0d+9Hf/ae2HdTepPUo1o9OTyeoZbbGqeU7YT76x/r6X3+58/JcVc08GMT4qbdL9vg9cO+lbl078+mnaDj2cv2Xwd18VSSpx658WWaffH8zc2C5rZ9gmXDdCla0yJIsNj954Eiq1z+uu1LCNL0aoBRihjiITj30+npdKRWa8CPXUutX3j2Tl2h7Auo9q2mcnwbp0V/md3b/1LP/WFq9o31t1w46SBBykNXhpKcCMXrrKfszFHqWae7MHS+tutpK1HWtKqO++fvypHZMWHAhblEqXJ6fNu/ErJqFS292u9RLxoyWxV2fcFHkj90NDts4r1Q3bhOtGqPm4YUZkDKjseBOqlz+FbXyLkVATAHAeAH4y7FxvAcB3nBxtIkWorIxUXdd6ZmzZtkX0RfJLfjwIlZ4Zddv7tO6jXik+33yntXjCR7t/O39Ousvz+qwePd63Y/KiV2iRhahh/MLQtRtZRRgonhGD7N75ZEMrjU77df3eU4lJsy9FSlzLtFFC7Txy7Om3E1NOhSlKNaMp+4T7Rnb+qReGblOKplfGX6yfqbeOwkWWVMM24boRaj5umBF9r8ebUL3GPWzjW4yEej0AfA8A1tMz9F4ONpEIlZXVSp+vbyC1Zbz2UceDUE+vXr0QdFjiNrbmPqpT8Xm63Js0MlzJIU9NuWWflx/R74kGrdEseeWzna9+WQejnkfHJFRa7CFMUaqZjWqfcGUO51txcMty9ZpcWXiGbcJ1I9Sw3DBjtXG8CdXrB1rYxrcYCZUe9N8MAPS6qwMA8BAAvDDRI1S3PcPx3Ee1EirPuUwekvGSOblmzQpdI7WucsP7qNQ+e/F53uVes/29lde82hqv5qpBOi/VWfXhnhOLvJ7B/N4kVPr/YYlSrdV87BOubJFz+nw8F1OL1nsN24TrRKhhumEmTIR60ai6tMXlXGrYxrcYCfXjAEAP0f8NAKwFgA0AQKNWsnHjxkc1Tfuu3elXr17NO/+Ni5z+zgnQLlxw7JtUV4NxLVdAFKj9rZ0DkIzpMLmCrroH94kc+JVn41ZMOntS8ObZ7hGdqvOtUNbljKe98c7auTBYXunZJxWoOXMCEgNc3DumPUOPwLtXXw/0z/H8VA6chJp+ulPC/pyc/DEwtKiwiTO69kM8656Q3puog/Pl43KXuvDziCh4YSrSViHJZvQSOD0pFFfDcsF6+/VTx8jNnz8/8ORZLuM4hGQMpeXjssP/0ZmJLvvOoueJWf2Ffcn3nZ/9B4n+/Q9dzynaz15y4OqbiP2cpw5GG+sIiUyHdK80kk5U1DY3t5j6tIB9hmTv9GrPxITa9wd/f/AWAGOxqSOy3Et1eCNH0eiUtm2NUEX68np+le+tZyVZS4JeiSSsvkVK7rHu4XR6nrBFMHY7TfvCdMOM1cbxXvKltvzt4HrHLZWwjW8xRqh/AgD0Z8TXAOB2APgXAJjv9EKGmVBpEtLJVfekIs8963nw317DVmVCFdEd2aPMXZ4NSwmQ9J6mhpHCCiJtWWWt50wJkJZZhvYiLbDALDfo0AnFJPXdP7/whz98eSXR9NwSsehyL9XpjCQv7Zx04yGvZxElahah0r3UPVXXvdoZLR306i+I7+3Ex5pwvfa9WHaJVAgSaT9sE64ToYatoINpZxgI1W2ZP2zjW4yESifOnw1HpjQ6pUu8jjVZw0yoNFvU+Mynz/IQKthq2AYx2bLatBDqco1ALms2C2TvT5oaRqJKUVtYRRtoxAkQ2RvRjI8YBqH7494fA/anm5oOWW9z4c3utTY+qEcHmye/j+7HO34+2NMy59rUhdneRo2WsEeo9Ft6VOenldeNy9lieyTFmnC99r3sGIgWNBApoh62CZdFqD/e98bXv5h8zjWJTtRv/JIPA6Huy9x69HDmWubtTmEb32IkVNPXpgPAOS/HCzOhUmLJ3P2Zt3gI1V7D1uu5/fr+ctLPr2ZkdW3k1henykE8fboWbOBpwCJDMen6k8d/+n8/9cpIhL+q89DNFUZ6pIgDb5NbJy/c73ROdHKmP7my6+itvG1Z5ViESr/fWb3gQL6jVBbxsSZcSnibBtfs531emfOXvBm/YZtwWYT6yi9/8eAn4r/kTlTjxdUPuTAQqtuKRNjGt5gJlcvfwkyo9Nqv9Mp7fs1DqOO1j3r5guxffZSANpIVRc9s7mlaK3w2NnfOVof7uQaOQ4hicuF/ffNH/7593/enDPVUl5JMgveojL35/6qYd+hEYvIlVrcrLx5ZNDk7WMVh0hgRJ0LNd5RKM3vvje9dZL9E2mnCZe1z0kzW22KHZu9Jf/iYWU2Jtvv55K5bRe/U5M0mDtuEyyLU9v/Z+vgNkePCqxcy/iSqEwZCPWNMb9+Z/hhzRSZs44uE6uFhYSZUejyE3HP3Th5CpY/pVHdW9CUTkT/65jFijQBNXfM2F5G2WPebiuizZM9/8q5Nx//nSK50nsrn9ZKrThwom33W3sYNg+01t/WeXiDbtp1Qk9pgYpAkU6wole5v9pN49gyplUsjdjGSVWyBijtNuKxlOnO5mEawL6RvO3rMmHPpg7FXZ7x3uCKSKEY8UWrYJlwWoWov/+AHk/RLUj+4RDETlQ8DobptIYRtfJFQJzCh0kIO2XvufoaXUCMROFi3eftB0ZdKRf5nL71G/mLnG2OTpgg54natGatPnoINorae+sjvbGp95Q1lQnWKGGUSkazPYCXUimh35dTIhWm92bLui5nJnafik8/QvVS6FPuR2K/mTdM7aqxkJYqFk7wb6TlNuPZlOuvZVbOf48acszP09hrZ21Xo3Zk70x87eo1+pmpq9GLZVDhf/fOh249Zi/SHbcJlEWrVgSefEo3Q/Rpbr3bCQKjURqdM37CNLxLqRCbUtasfyN59zyZeQjWI1jZn27ZdXi+RX9/TQg533zYn9a+/eGcMocos+4pk8PI+w7Eln9xES/vxyjvJsTJ9ZRORnAh1eryttlQbKDe/p8Tam4xeLC3tjKViMJDViGF+92r2hhP7h24aEzGLPqfXcRanCdceVahEoiI2n8jObv3J0IeOmzphm3Dtz/L5JTWbyl/9f5X9TwQjEdmwEKrTUamwjS8S6gQlVPO+TxFCpY/qdH+nyEvGK0sLzq+7Y/avm/e1MI/1iC77clVA4jWOlmSMxJJn37/0r/wgVNqttQRhiZGKrrp49NYoyYpXOLA8gxmhxmAoNitxeq7b42WiJHVhUvaUKSNyUTOrXZ79TacJ156YlK9jIfZ+wzbh2nH+yvvjm+KHnkJC9Xhvnc42h218kVAnKKGa+4mihJqvMoQ0Ou0bzK5vuOPqHzkRKoB+8PmmNdxL0G43yAjw6IjohWhpdeetH3zCL0K1liDkiU7pfmhdvHX2EImlMkQzhkgy1ZGZ3ElAp4VHch+TUCdFu6onRTrHlmGxPXhHtXFqKGbk9ljpx6tUHyVNp+vW6PVsXskybhGMGVXk+1oy695q2CZcu59+46beTdk3diKherzAr2VvOPFLxopL2MYXCXWCEirN8M1mYbEooebr9pnljVuW0sxeN4cnYHSUJaO7+lLGXJ2QOgNgrg7QUpKMvESvQrMOjd8ZvrRtehdp6qZbH/GLUF8un3X0jeS0Dt7odEr0wtTKSHe19TnpMu67mWkj93+ahDo7cXJuFLKul53Tdroqs22DCTKSlOQ0EVFZupw7I3KumnU7DCs6jQ3pCSNKhqxLy26EahKbSNEGmR9Gdh26t7p1uP5r2CZcu63/e2HbpoG3X0BC9Rh4+1K+KR628UVCnaCEau4nihIqfdygs33pnaBZvayB9iXj8JRoE1ryxec23jNymDuIDN+3klPnaze970G/CNUsQfip7rfqa9M9rteyUWycSLI1XXfKzOSlhNr/+qHtNJLlIZu+UqOjp8zoNGXdbn+hEWh95GTdjtQnX7Um8lBde3QaIZo+qUufOVBidPUlyUjhYzdCpZPgrzPvObsm8e9SZ3B5ntdJxoyOZfxPpV8RXfqj5Y8WnP6B9T5ZEf18yIZlD9Up0zds44uEOkEJ1dxPlCFUULh0nJLlzie/7FrB3IxOZQk1R/pA0gbAi2ZFpSAyfA+V1S5KLrrx634RKk1M+u+Kecd4ijiYy70s9xsw4gNtQzNztaUpoUbf3Pcf5ZE+rur76QTp7azMtpntuhVZ+Fz8xzfTc6X2c36s6HTKxcjsaEZL2Nt3m3DpJHiRVPXNi5zyvFfWb3IwI5qwTbjW56QrBKuuTz2JhOo9+k7njsM2vkioE5RQzzasaaAl9qQI1SE5iRaWn57NttKauCxYVj64pc7Qod6tuL01OlUhVLP/iNG3hRJ4EBm+B8tn3Vqx8Pqv+EWotAThxWjJJZ7olLXca8X8fHZKe0+mspsSavXbe18CMLiumLEnJtE2Wfuo9mMs1qQPe3Ra3R2ZlkxpI4R+YVK2JRMlQ7RtrwiGEvp4HAkxf0iEbcK1jjHF+QPXTvoWEqo3oVIJ1tGZsI0vEuoEJdTTa1c/QE2XJVR7bV+aNVxamlhF6+HObm5uZcFCs3bprSwmybFkljc230kARrJRVR2ekMz+PU/cd9jvDF9q+/9UzLnDqRIR3ysuL+W9J6pn30nNPjn9uukNJS3/87JIT+emZt62yrNKt9kThcx9R3t0WtGnTy7r12us7fWVGed7So0uHkIVsdtvWbqHe+2S5d9zTorzu0ex9hrizy+ae821X0dC5cONlemrOr/w9cwvhYQ6AQnVup8oS6jW5KRcwo+mrQCN1LgVfzDJ0qkW7+80bpkbAW3U1WmqDk/3U/c0rd8RRIbvb0umLhwPQnVb7rW6Y3e2sqt87qxP6adfFyJUawRJ22PtP7GuC6MEVKn1Jc3M3sSQXkL3Te2viDUK9opQ+aci/yXpjwTttq9/PShCpUu21Gpa8UnG+q8lN98RZvzC9oOJVRlLdX6RGTc3HSTUCUio1js/ZQmVPnZUi+yld4laC867FdFf1ri1QYPLN7nYo9S7NzxbkyKpFRpo9L7ZkY8fDv/BnhM7Pnfh1VV+On9bvLLmZGLSgvEgVK/lXutzRmtn35ZpOyVEqBerjTOpmDFgbce+XMY6F0qXSXNjC5nc2dnJXfrM+JBewsLdJO2wE0L34m/e9/Qv2z2vN5TxLbpkm4ChqLWQBG87ZsGMsOMXJvtYKy1+zC+8Y8Yjh4Q6AQnVPDJDTVchVEqeWUNrAx1Gro5yOlZj3xu1RqmXz5xmVmgwemmQ2ueHw3+o953f3nf+lWt4HJpX5niiZs75ePns8SBU7+XeK08hQ6j2TF/amnW5jOe6NKfo1LSsP2l0dVcY58M04TLHfsGq+/72lUQghEqTumif/5L+9Cu8fmfKmfvUYccvTPaxMtb9mF9Exw4jVAXEwlgc3xpRqhCqEyysakqs5VwzSrXvm/odoX6o93jZfed/06cwjGNUXy+tXdATidfkm1B5l3tNg2UIdTBBursqsyNnWWlb1l/3PGUA3aJT2p4RIUPvTs62hGnCZflHxfwP3PfXr9d+3al4hZtP0X3mtuyUPvuRIqpjTer60eDd+0Xbp/untCB+2PELk309Rlmf/ccLEqqfsyKA5m9zY1sLI6FaE3SCIFTWOVUzIcmKEI1SCUR6aKKS0zj44fC06tA9Fw+1l2WHBv0ab3pkpl+PV+WbUEWWe+mzyhDqUIwMdFRnc8duzI91H9Wr0IJXdGq2SasylV538+qwJ9XsPZZ+5GDmxlE/MLz8yEzOOpK99hSrQo81qcvtAmynfr6a3LaELq2HibBYtobNPvuPFz/mFy9fEPkel3w90AojoZoZvtT0IAiVlZi0/KHNK4im14o4F5X1w+HpfaLvGWzvmDPYpVzs3bSfZvjSvwdJqKX6QMn0WHttP0kMDBolA4PZ5MBV8fZanopHKhEq1bVn+tJ/M/dRzcncaSy9olNTjy77au+9+VNhJ9T2E0f+4Z8G7zkg4rtr488vqtEvVbGiItqO9VJ0t/s6WX3Se2FXJl64iX4XNsKy2xs2++yJSX7MLyJ+4SWLhDrBCNVep09hSAAAIABJREFUgi8QQgXSUrf1mb1WaO5qbM4d0xH9+OHw9Aq0iqGB7OL+VuG9Kpa9tCj+4dK6XPWeIAn1qmj7NN6CDE64ykSotK3zU7LHrSUC6b/RfVT65yfiv1zk1B9vdJrT1yE7cOv7bg87oVL7nIqrs3CwL4mzbjoxi2JQfd7Lzs2+rO2HjbDCTqh2rP2YX0TnNDd5JNQJRqj2EnxBEKo9MYlm8KZJWirL1g+Hv//Cr3PR5ML+1gN+LPvSovj0yEyQhMpzOwzPiyxLqKxMX1o9KAWxjFvBe97o1LQ9ddPC2y6eeTX0tWjdSjBax8EaPZr/bq+HzLrb1el6MdYYW5fckVB53oLRMmG+/AAJdYIR6pm1a+sJGEtNs4MgVNr2rK3bf2j2sWxDc71GYKRPkVdAlVDnpTqrPtxzIhdR1Q5dOuHHsi8tit8Wq5oXJKGK7pX6HaFaiy+YbdPlS/p3Wm7Q3h+NTMv6oMbpmIyTfZkbb7jtQvvh0BMqtZ+H9KyRpxU3azIM6/Yc1hlJJ8ysS+5IqCKzyWVZa5RqnV/ouKSMeEb2XLC4JWM1kFAnGKFaj8xQ04MiVGtikrU2r6jTqRLqe/vbpt3Uf7ae9hvLDvXRZV+6ZDugxxOX9GT1/FTHSVGbzCMzQRGqBkbk6sSpObzlAt3sl41QzWMtXtiUDWqViUGtUpRIzXaN+vrb3r14dEIQqtONJeazsKJT8zsrGVv3T83vZSNgJFQvD2V/byaCmfMLHbu7EvsWDkE0I7pfLmcBWwsJdYIRqr0EX1CEai1NuKxx8yrWGVMeR7QSal26q/xitGRwQE/kCgjwfLzuFZVZBjYzfIMi1Ipod+XUyAXP22Z4nl+WUFmZvrS/sn69OpbRErpBYrIkarVbm3P1bW39b08IQnW7KIA+k9u9rdZlX6eiGJsG1+z3GtPF0SPTboseyv1ApB8kVC/E2N+bpTLp/PLjfW98vSH57zclYTBJpVkFIOR6EddCQp1ghHp6zZpVtESgaXZghGq5kUY2IYnaaCVUmq17MlHT/lppLfcRBqozOTuYK/HG+lwzcP7wlEx/rq4s74cWxR/S9NzLF0RSkkjhBi+bZQmVJgydq8mcsLZf0a9Xl/XpnpeUe9lk/Z7adyZzYkIQKrXb7cJ1twvVzWxft6IYXpe50/7tJR+RUEW8bbQsTTS7+YMfeZK8/IMf0Ixs67c8y/vyPTtrIqFOAEKlmb0nE9ma6FCswrp/Sk0PjFCJ1jFr27Yd9IaZrK4tl3U+k1Bv7Ts14z0D7867EC3v2F19/VHe9miGb9LI5MiP9ZHZVzWPzARBqGV6T/m02Hnh40VOzydNqLajM/Q+06mdkblgANetNbzjQ+07P9Cyw17qkFc/aDk7YblduG4WW3CyiU7ScyJnq6wRplXW3jYl32qtO0FlukhlihaIsEe3SKjyHkCj1JobP/F1OLpjzA866yXz8j2IayKhhphQT65evVjXwbFoQqCEOpyYtOyhpxdqWnSkNKGoi1FC3fvC0T9cdumtm6Ikm6sRu3Xywv08y76TM/1Jr7tFp6Z7T4nso/ZESsteL52aKxkXBKHWxs7MLNHTzPq3othReRVCtWb6sm6NkbHHrkPtu9Tdstu8fcaPNv1sw05YbmdGvc7n0qXECq0vMVM/x1zON4tnUCK9Pfba7Jl6q+eyPxKq2mi74SeSKKZmxRVtJNQQEmrurGmE3A5EG9lrcTIzsAiVXvKtRXZ/be5nbrRexybqeJRQ+3fu/oF12fbV0hnHeJZ9vfZPqS0V2XTHe/rbuCNesyh+EIR6uZBD25jbWUQxs8qrEGpPRba9L0m6g4pOTcLv7Tz5H/ZSh/S72JCeIBoxzLtTVXCQ1bVPuE6FGnjqG9PsUmqHuVfHsikXNdmWH91sR0KVHdnLem74ee2Zq/XM1kZCDZBQyaML4tqjR5mXdTt1a71KjWfAgyRUmpj01fn33mjeMMNjj13mS++t2mT8/OejlmR69HjfjsmLPIs03Nfx6hIzqnXqu9RIX1rU15YrWMDzsWb4Unk/91D9jk5NwhK9bcbEwSySH1R0atqXfvfkf9O6vnb8K3v0qek4GRhMkF6esQlChjXhsi6qdktICsIus00kVDV0vfATKeihZsllbSTUAAm193vTFmpGvKPs0dPMC7vtXVMyPR2B9RqBUVeguZkYJKGmI7ETfzB7Ze68Ju+HZvImiREpy6aSFUY68f76Kd/uOvTGmD2OndULDnRGSx1r81qPy3j1/YGek/ucZNK6Ho0bxkhW8RulV9VfipSMLMX5RahBRKeqhEozfbuqjNYg9k5NvM0ImlWZ6arOyNzBGOmjt9J4jWFQ37MmXNYk65aQFJRttF0vQgiyb562J7p9XkeleDAQkUFCDZBQ+x+rXZUBra3y4daXeAbFXrSBRydIQm1NVBrfq/ukzmMHlWHteToR1uslV504UDbbsTbvqs5DN1cY6TEFCFi23Nx3er+VNE0Zel71SEntzbXZnpbZAxdzP2qsR2ZyNt9Yf1/nkWPKWapBRKeqhEpvhElHYSCZ0ip5x1BUziRUe2Umutxb06XPtl5GLtq2H/IsQmAdq/C6MMAPW1htTHTCCgoX3na98HNa4udtX1QOCVWRUJ2Wdbsfn1ETIcYqjUBH6cNtO3gGpnXtvXdmQZvLI2vKBEmotKLQX077UDtPAhG1hxVVOhGW27IvjXLv7P5trng4z8fp6Iy1xGCMGIPTh7pPnY5Xj9qX9oNQg4pOVQmVBztVGZNQ7Xew0uXe0kG9mrbPKtSv2i+vPmvCZRVhYJ0t5e1DRc6LEFTa9kO3EOyTuV5PFjskVAVC7Xt0Vp0RGaqv+M65F+3N9Pzp9KW6fjmpqHRo0lNee6n2ove8AxokodLl0b1V9R1vJKd18Njz0e7fzp+T7qqzyroRltOy76e636qvTfd4Zkia/cxJXTxam+4eY6N9v5T1DH4QalDR6UQi1HSC9HZWZttMjOlyr57VYvT/WXWFefzJDxkWIdgLrLNq8/rRN08bhUBYPM8ZlAwPfjLX68nai4SqQKi5PdKIvqQ/OrRl6kMXesymaNTaF+tcr4GW2wvVdbK3ZMO5MUkb1q5Pr169EHQQPp4SJKHS5dE3klf1vVB5zXEeB2Mt07oRFmvZt8RIRdd2HhbCwenojHmJuJvtqoQaZHQ6kQjVWkjCXO41cbdHrzy+5JeM04RrPfhfr5+scruBxy9bWO3wEEKQ/Xu1XQj25XMfFQlVgVAHN9bdmTXIXNCM1rJvte82mxp8fEZ9llgK2BPtiNc+Kq2AFCvprzeMyGA2Hc8VMef5BEmotAACb0YutdW8FcZqtxthsdrmOSpjx6UqO9B+Q/+7x+z/frC07uahSMx1H1aVUIOMTicUoQLAhUnZFnpExrrcS5/BqQwij3+ryjgRgjVqGa+EJPpshUBYqmOkos+DXz73UZFQFQi1/7G6BqKRilwTQ9HdZjYvTUYiGoyUB/TaR31z5cqKspJEQ7S8e76WiXUNDZbkli9pUg390+3KsqAI1XpnKE8hBuutMLyESuU6I8lLA5HYYJ+eHOyIJvtu6m+b51YZiTVcTkdnrBWRnIZZhVD9uqLNzQVVzqGqTFS8ulb7uiqzbfSIjHW5N9cOowwib/uqck4TrjUxabwSkpBQVUeX/wdJvkoRIqFKEipd1u2PXbzfVNeI1lP6cOsWMxnJ3qzbPqq53BuvunBzNhPvyPZV5m5QOZuomtarxcuvGzzvuOQaFKFaCyC8XD7rqNc+qlNkqUJYvK8bTTha3Hv6gFXempDk1o6KfX4WwXeycSIRKl3aHYqSdHV3ZEzpxY5q49RQzEjxjqlfck6EalY1ov2wrmzzq3+vdngiLK82gvy+UOzLV9UkJFRJQqUJSRDLjKpxS7LGfqJpNWYykrVpt33UXMH76NCMZFXnrSQT7Uh1T85V/qFJQf16ospOFtZ23QiVkgqVFS0eT3WsCT0n49WtXvuoy7veXDAl0zsSlZs2qhCWyERhP4tKf4zYM3pZ7anYd1W0fVp5pC+wIynU3olEqHRpN6vDEOuYDut+VpHxlZV1IgRrFZ2vJTfnLrAfj0+hENZ4YEf75MXPreSkn7YjocoS6sbaxWCMrrNLgOSqIpnJSKOIz2EfdWS5t6R3WpTuoWajl9KXJucq/5i3orjdqOJGqJQUM5oedYtwnR7fmtDDs4/qVMRehbBEHP09/edfqcj2j+w982T40vZV7PPzVhmnZ51IhJp7Bh2yrAL8gwnSzSpPKDLGMrJuEy69HaZUS0fGKyFJhBBknt0PHV7C8qMvmTZ47bNndsv0xaODhCpLqI/VrQCNcN8q4rSPal4YHq/oqtdj6dxRkcHOq/ZZi7g7Jd1QWTdCpVm6Q0SL0ku5eZzBKmNP6HHbR3UrYq9CWCI223902As4OLUla18+9k+pzROOUB2ApkUmWOUJRcZYRtZtwqXLgEltKPreyBtC1cBk7HDS4SUEP/sUaauQ7MvHPioSqiSh9n5/+v2sSNStOfvxGip7tmFNg2GQivik9tt1TctdrTV4afKBk7EpNW2xqtyLrhGSva33FLPakhuhmkk5Mpdw2xN63PZRbxhsr7mt9/QC1rPLEpbIS09l6TVu84x3u0gmljIMLfNy+ezbyTCebm3J2peP/dNCIlT6LKzyhKLjLCrvRgj0OEVcS0ecbo8R7UtGvpAIS+b5VXVE8HO7uk/VDlMfCVWCUM8/MaWiNBNrEB2EiKa/mPzW2ZHjHWc+f3cNSUVXReLpslh518iVYuneqsOHo3PreiLxkT3JWemuYzNSl8ZczO1EqNakHCddJ/tZCT1u+6isgg5m27KEJYrt9Myls/Xx31bTpK6Bgeqzr5TN4jrLKmtfPvZPC41QzSxg0bFVkXebcGliUhQy0Qq9j6vEpYodGKEGgR7/HirtnVUhy2+rkFAlCNV+zpR3UAyDHLNWVTKXeyNl3XNiicHZZjtDqeSpl7QbZ1gjLKdrypwI1bqHKHrFGSuhx20fdeXFI4us17NZ8ZAlLF5MTbnZkdPl8/RzvQYh2daeq4/+tmTqQp42ZO3Lx/5poRFqf9LoynehfJEIhsdf/JZB+9QQFcEvH9e5IaFKEGr3Y3W3RzRyo6grmEdrTL1cdq9GauJVnYv0SKbK/Pe+THn3AXLDmOxR1tKtE6Fa9xDdloxZz+CU0OO0j8oq6JDPCHVStKt6WqS9fLrRfYb2e2ao9tJvYeYInm7jJEOo+do/LTRCHY8CDyITruj77Ic82qeGoih+NBHtDKkN7DpBJFQJQu0TTEiydkGP1pQ/0n7YzO7VdRKNV58ftTx5gVRFj2TqR64cM/XpPuGcwa5RN7Q4Eap9D9QtU9gOgVNCD2sf1amgQ74INakNJurirbnofrbR8Tb985xWPfnN9LWdPK+qDKHma/+00AiVPk++91FFJ1wen/FTBu1TQ1MUv6DPoyKhyhDq92sfkHGDN4eunlMSSQ3Oi5zbev7V2xO0dm8sOVATKe0ZldBzXq+sfT113UihcbOvWHaoz56xyyJU1h7opKH+Vt7jM04JPax91Fv7Ts14z8C7jlmSVsLSwIgQ0LMy2LF0aHuzEqdnRSGbK8Jem+04EdMge06vnHlqaHZHv1Ey4NWXDKHma/+0EAm1pyLb3pck3V7j4sf3EaLpk6bfuP5C+2Hl6/n8sIfVhighBGWHU7uFZl/QdX2RUAUJlVXQwWwiRaJR+veElhkTXR7KXFffSSpzx2IW6McPl52c2Z/qrUzTcoPR+OCoG1pO6TXXvpOae4JFPva7P1mEylqyZVUTYj06vZDbKaGHtY/qVNCBFaFOj7fVdg1N6hwkSV8q5kyOdtRURy5NNvuaanSfLYGhforfgBEfaBuamVsCdvvIEGq+9k8LkVDtt9J4jY/K98mUVl5TMe8z7/a9s308qjTx2F5ohMXzzH7KiOJnrZDlpx1mW0iogoRq3jBjVeshpcnT2Rl1F0jVdPrv1VrPhasjp09VaP2DlGRfydywKAXJkUzCeIboN3QMxCIDscPR5MBs0EiuZi/9DECs9LxeOePcUO0ZVoRlX7plEapTUXie4zNeJfto7d0LsYouWnf3VLz60qe73rjJrfauSVhlek/5tNj52vPZKe09mUrlCIVGp1cnTs0BMHJHjehnstHbFoeh1Dl9Uu5O2dOpWS1DEBvyk1CtS8xBvJD2NgvlHKr1ufK17EuL9FdOmvupTPuplzoqjbNhJFVRQsiHz1n7KET7/nZw/b6gcERCFSRU857TS0Z1WReUll80qmu6SNmYknu02VJt4FKWaFErmdJ/r+jXq8v7tJrp2c4WukRpNaETSmt69ZLJF7OTz1/MVHfZzbMfgbETqluEydqDtbfPW2GI1yEpoV488uYWk/y6s5VdFzJTzvPqO8mxll3LjYHOOGRTnXp5ruBGb7as+93MtDFHjaxtikaoNAFqUqRzqqr9vPqFSKj5WvalRfrjV835UKbt1Mu0gtOFquxpehsOL/b5kCtEwsoHbmYfMvgFWeABCVWAUO/e8GzNVxP/9IcEtNkGXC7CIPOZ3B2pjae08ihkUtVG//kYGUqbxEr3/9IQK3EiHvvdn3ZCtRa1t9vGc3yG1g++FCnhutybZrvWxC9MaU9Pe9dpb5QSVvzYL35eqg2UU3tSRnzgLMdSrBuuTlm2JZDqjhhGhv4gMfW9olRRQqXL1uazyIy9qE4hEmo+ln2jGS025WJkrhW/TJSkLkzKnhIdgyDlZQghSHvsbReifUFeOF7MhEqXYGnSiuHmoE1NTeQb2T+veyN94/wj5OrPTNU7uMjGqU2aKDH1QmS+/fsIGEM0uhqAmCvx2K8qy37605siP/7xV8323kpOnX8xVjpqT9bal30P1m4Hb8k+qmderp2ByNC76WltrL3R6dfX3lf6zi9fvtKPnj2RmntCZVJwSgqKw9BABCBrYkj78NpLFSXUeYmWedZlZpXn4NEtREKlzx30sm/ZoFZZ0ROZZsdvvG69cRrrQiQsHr/2S0YGP+vVfX7ZYbZTjIQ6BQA2AwBNHJoDAH8GAE85AUsJ9YHMD77+cuZ971eJSs32zRfdeyDZxGPN9KUZwtlb3/t45MBr3zLvUPW6VNstSnVbLmbZa08KupSt6ujLlvXpGtEj+lAsDkPRSbMmLTNaWyyEyre36YSPSeKs7+mPEg0MIwPRhPV7p+VzKiNCqOY+sPfY+SdRqIQa9LJvdXdkGr31xo7feFRrcvMGGULwz7u8WypE+4JMTCpGQm2k25gA8G0AoElE9HgKjVb7We5FCfWWwf/cZN8H9XZFtoS53Muj75Tpa15VRjOEyftuejB2dP/TxlC8PdNXdeKlsrmeJfec9lJ/U1a7aFCPcxVEoPbzLH+yCKF9aGpbn1Ehdbi6NnZmZomeLuHBzxoVn07NOM1KUBIhVJ7nFbPLW7pQCTXoZV/zknM7fvTO1p4yg+uMsvfoqEsUImGpo8Lfggx+vBWT6KUfiwba6l6smM+9olaMhPoPAPAzAGjO3bR2ecmXLsEyQaOEunDwJd/OsU0/H72W112cMn3Nq8qSk87fOvSeD3yFEipts89IRn6TvV73ymyllZMWDFx4zXrdmcjeqWk/z/ERFiF0Zas6OzM1Hbw4mHJu0alXW05Lv7yEms/qSNZnKVRCpc8Y1LKvuX9K+7DjFzSRe/mh/XsZQhDtQ0W+UO3jSUx6b3/btJv6z9afjVe0/0fldSM12N3wLEZC3QYA9L9nhoGhWaC3AUCLU4R608Vf/aWKU5q6GoFoxYDGnSHal63s6ifJMcUJpmZ720qMgWxVsnuGcdPHv6m/+vO/oH10a4mKjmy11kvKe7zsLcmke68ifbls2349ljwfuZwZy/vJZvXs9MS5mV7yifr3rU0d+81Wq1zKSAx0G1VjMpi92pqkX6yJ6kNxLzmn77uz1R0pEs/dWWt+ahYv/qOOgwc9xzehpeOVkS5mNresPTx6LPx49PIlo2Jff4J0ZiLgy5lk6/NGs5AoTWm5xDS7fUMRGBhIEGHfCwrPqkUf/qNLh/7L0/+C6t+r3UK1753s3NMpEnMtMjMlNVBdkR2qphidi5edG4hGBt3wyuiRzP/+s8d/YJU5fvw4mT9/Pg3cJsRHxtBHKPcAAHVimql7kR4dpZHqxo0bH9U07bv2J183l261qn9IRQUY19/A3VCs8y2IXXxrjHxnbwpaMrXQWXbdqO+un1EJkysS4KRnb6irLw2pjAHTqkaOwXLblk3WQGrGB7nlrYJaph9KTtJFAv5PpmIWpK+6iV+BIakZQxBv+xVEBoWDYxiY8wkg0VKl/lF5NALaxYug/zZXLdLXj3H1PCBTaKoE+xM58Ctf+8PGJh4Ckb5zEOl3PVEH2rwpALErhznIpQGAcy5H6CuTMPChz40Bo9AJdSUA/D4A3AkAqwHgjwHAcd+RLvl+9tWDI1m0Kq6T1ciRuc3PMO81ZbXrVJXppFE37a/67+ujRZ7X3TF3U/O+lpx9EaNvy84nv5yLTvsfq11FNAgsosoS7Ujlw62ez+L0C61PoHwjAZIuG5q8WXv06KjoUnYsKK4kll2qASnvvvXBTZUHnnQdX/stQbL9yuiF/Reuqn2nG9asAoP46qd9A6kt1+/cmXsPWPYF0afM2FIdt/uMZdv0U69Q7dPjqep4+SXnG6m0TKp0xokxv7wGL8ysNwZLmSc94ledPFD1Jy1/bcVf9f3wcyx52pKJUGlCyx5aARAA6N8/CQCjslCtHftJqJEIHKzbvP0gz4NRGad7V1uz06J/1N+YK29oEiolnT1NDSPZyt2Pz6jRSXaF6CXovLbZ73Z10nMkVJELBnQ4WLahjRs33megVa96PtB4yItQYSi6u+zR06287fopF/YX0g/7Tq+7dykQrd6Km6ZBOgKRF1OQqYsQjf9mJw16ZzVvp1n8uQ/Lvta1996ZBS1XTWu8P4VKWPnCVRY/1qUkVpv1ZH97csqZMfummXQimX53zq3259MTgx3JqaeOln277YfFRqjm886iS+MA4Fo5xU9CJVpk9+zmZqGJmXWzzYBRcuILfY/nCtKbhKoRo233E+t3WQeTVSbRL0fPavqOym+d9Vw7dZpwea/AI6D1lg1VP+NXdGp//lMv/5jU/Oz3HCNU2n/5t1tHJmi/8ONtxw/C4u1LRs4v+8y7gakNESAttYb2orZ9e25F4uSaNSt0jfDt8Wvk2KzmZ150JdT1qxdns7BY5nn91pElBL/tcGqvkO1LVJ9/v6aTUUfsTByiFReOxas6mWvCrCg1MencoUhZ96ViJlQun8wR6m8OfhYI5AouqHxkCJVGqSWZ6CprpKnrZO+qS3+xlP7blSVf/eDzTWvGRHEiS6siz2Z3HCddpwmX95J23khYxHar7Im33yRXbVv6RadI3rxuT7Z9VT2/CEvVDtHxlenvzNq19cQwErO2bz9s1SerV8fPRLUVPEvDGugvzty6dSSyYOF3at26Oo1kl8vY6LdOIROW31ix2lPBL1HZuUCLZpjbDXT5NhpPMZOQxkSpluVhJFSPUaeE+oXf/ObqDMnSPddRH7osRQhwZ53O2rp91HIAr8MNbJw+1zC0kf7poC1/aPMKoum1JqFmgez9SVPDmExllbtbHe0jWlvZw62jomHRCdft1h6zrXxEh3TCnb7tQ7eAMTZi8Xvvlne8rXLFRKhu+Jz5/N01kI6u8HrfrPuntD0WfuZdxDLj4beOCiH4bYvfhBV2+yJl3XNiicHcXcqjJ3b2/qlVxhqlWqNZJFQOQm1sbNTsy06UTCGe2aWnIot59mOo/Mzm7Y4Vmbycb3Bj3Z1Zg8yN6FpLckPr3uWNW5YS0OpNQrUmJI0a+GE9r/ZFvhdJ0nEjBK/oWaQfEftZhNX7/br1NEnpCpmTtKFFdvEsa8v2zaOHhHoFpbZ16+ayftiOSOhax6wt23bw/CA5vXa11J3GPGMmIoOEKoLWWFkV/JwSk5z2T629m1EqASNbUtvyKz1y+cpOJFROQqW/kEkquoqKm2Q685+f68gtU4Gx1MstDKK1zdm2jSuqY7VFHl0Q74t13RvVtF8nv3X22F2N2xYDGIspoW7Z984XrQlJVv2+jbWLWdGXl71u34ssg7oRglcmMl3aLtlwjnk+WMV+1oRrX4LOR988z4CEOholt/1U+3Iv1XTCT2hflmegJGVUCEGySyG1QrbPKTHJbf/UCh6NUjV9KJWY3H7S/HckVE5CpWI0G1Gj2YHxzC5KpvTfcvs7Otzv5aU00aJu6zN7veTcvqfLpP0lAz1TH7rQs/LBLXVZXVtOCXXrf51YaU9IMtvh3asUsksg69WNEMyo26nv0qFJTwWVjGT2abXPJPig921FsEZCHY2WU5RKf+TOyMJmM5GJNb7WlliZxSLj4pdsIROWXxi5taOKX7yqc5EeyYwqt+q2f2q1hUap9P+te61IqAKESsnzbEmmwiRTU5UnDV/0yIyXM9Kr5NIkveryku+pW1gJSbQNnr1Kr77s3/MmJFE91yVfl+hZI9BR+nDbqOU7UTt55K32UawicaOcrgDw6OZDBgl1LMqn161ePyZJ0Jbd60Wo1qzifIyjUx+qhBC07YVuX7Skd1q0pP/KkS2H86e8OCOhChCqkyjPsi9rOYp3kJzk7mpsfoAS6r/ue+dqVkIS1XM6yyrbtyjRuRLqo7PqIJZhZ1sGdPbU/txIWLKecFlvPPA7vXr1QtBHF2NxyqB3si8smb6FTlhq3uWtrYqffdmXZ//UzSokVB8IlWfZV+bIjJc7LWvcuqrhjjnPbP/F65VmhSSWjlfyj1c/1u/NpCheHbcJl+4L98cuMpfLec+58trhJDcehCBiM9o3Fq3cSlEE1o9k/NqKOVg1nPALS6avKiGI+JKMbDHYZz0+E6tqPxqruOR5vt4JSySEcsYKAAAYqUlEQVRUHwiVNuG17GtP55dxbrsOPTrz+Y9fs3PNne93rRjllfwjZItg5OhFCKxjPfS4Svm3z0lnRIs8j5d9Im0FIYv2sVEdtQdqwH772VVTyw2/M+tW3+91DCeIMbW2WQyEFSSGfuBnXfZN1p7Yb2bsytiNhOoToXot+8qeQXUzj2b6fu13r/n1XR+52ZVQfT2LKpCQRG33IgRaIjFCjFz2tPnJx3EZnglX5oXyW8cLP7/7E21vvOyzRpgzDXjKnozEM75hyPT1gxBEx0xEvljsi09qv13XsxlW/V4RvJBQfSJU12Vfxvk4kUFykl22obn+wc8seGvpbYvcCdXHozOimbc8E27Pn05fqutXarnmM8uWxz4/xkq2DbTPGbkcIepGj7XUoF3aDb+WdffeLlQnWHYQXfQKmrA0cgyyWod9v9tPGP3CL17RVR8p6U2WTG85pGIfEqpPhEqbcVr2VT2D6mQiPTrz6OduOnvzwutdCdW3mr4CFZJ4IgRTxp44JUraKi8AEpYKet4rEGqtu2vTIzRUora52fGsstv4spKbgrSX1bZfhBCU3bL20WNMvf2pHfTWH6/tMBXbZe2z9xlLDtTEp5wpt54plbELCdVHQnVa9hW9to13IFc/ui3+2PqbU9fVX+Meobpl0/J2RouWa/qLokdKeAnLLEAhmkUsYD5TlNc+1X5k9dE+WeQu67nhF4ZMX78IQQ0lZ21Z+6zHBHOrdxG414966HZLZe1jPXH57DevildfeFcFSyRUHwnVadnX7zOoVpN5Jlw/js7I1tXlsY8+z+VKUJ3rNV07HMRVbU7DzGufykumoov2qaDnTqg82flqvXtr+0kI3r2JS8jYxyqyYa00J26F/4TPajE5561zpVXnp6vYh4TqI6HSpljLG0EcmTHN5p1wlY/OCGb3itpH5WmUmiV6Sz7r5/Lip/KSqeiifSroeS9JB7kcyWO5DGHxtEtlcpd3aFoPzy09Tm3K2OcUQARRTEPGPqdnTc4/squ0rGsFL74sOSRUnwmVVRotDIRqL/4u6jSy+5pICKJIj5ZH/ILFj2YLl5cmVo3X8Rk/CWEMUho51tefPqjyfKL2OZWANG3zO7N6lH0a9EZ0eEvmrlvz8hLVeRIJ1WdCpc3Zz7cFcWRGNAJUOTqjcowFCSFYQlBrXV27EMY3iMiJF1lRwuJtNxehDt8N63lLj0ujovZ5bW/5XVDDap+Z/Hm6Yc0q0ajc1O1+rO72iEZuFMHZKouEGgChWtPxVa9t8xpY3glNxVFUqhbx2uf1nEF9j/apIVso+DHrA6tBw6UtSlhcjQ4LWc/nyh4RErWPJ3jw8weM1T4z+VNmv9bUtd89LYI3lUVCDYBQrQMa1JEZ4QiVcRaVJhrphKSIBsxb63N9SByVsUJaKBOu6Ivllzzip4YkL37jlfErRFga9F5+J2Hk3l4ndFjzjkzkJmKfyFwnYwvrWa32WaNjYdK2VNvq/f70+zXQ4jKeh4QaAKHSJs1fvH5c2+ZmIu+Ewbp1Jku0I6lY+nBJJrrKyYFkjsogocq8imwd3vH1r0exlgrJPmaCkq51ZInRloBoKz3vKjxRe8ApQlh0CZdo2TogV4qgODbPKMcos9wqYp/Xcq/VVpko0otQ7bkqIqsOVl2vayXdhhQJNShCHb4RQ8TJxKayy9K8ExqrxF9/dGgLvVvV6Yo30UL4LPt57ZN5dj900D41FAsJP0o4ydL4wiiJXDA0rXd2c3MrCx0/M4NHEZaudQAhCVYEam4d8e6HOtUOF7VdhFCjWmSvW5ENO5ayy9DWdqz22Z9ZZNXBujyucoc0EmpAhGr+Ggzi2jbZCNB6dMZeQMFeTYlkjf3lj7QfVptu+QlftR9Z/UIiBFkMVPSKEb/c+dWotkI08cU1wtK1jpkZsut0JDJFI9kxVxpaf5ifXrv6Adcxc7l9h5eQzfZFCNWtpjLLXj8KPljtY+3f8iwt2/Nc3G7B8npXkFADIlTaLP01mNGiR5x+6XoNDs/3IhOadW+AtZRLa+pqul5naNpP/ToLKmIfz/P6LYP2qSFarPjRJUtIR1eoHrfJEcKPn7uXkqlZ4J8VRVrJyivK9KrMJnLLDjehupC4m4e5ETzdk9V1UuG2Zzxin0O9dJ4omLX3K3sqAgk1QEKlpQh7BwbaaD1LtWnLWVtkQrM6CetcKf1lRnvSHj2a9steEfv86lOkHbRPBK2xssWMn9cNUzzIZtbft2nu008nrLfljNnr1Mgx6wUAXv16Lb2OuvrOw0heQlXJFWGdTTVrAZeVxhe77Rmb9jn1zxORs36AyNY/R0INkFB5XihVGZEJzbzVxY+9UV67RezjbdNPObRPDc1ix49nSdEN4fTDj2yav3DhmFrc1uQn+96gW3IRzzE9kYQgXkIFlztpvTyM+TzD7XkR4gihRuBg3ebtB+19cZWXZNguW64VCbWICNUsQK/rZG/JhnOON3R4vQAi3xf7hCuCFUsW8VNDMGj8eJYUHZ9A1zrSj218Zv78+WMI1dxfNAytZ862bbvsbTgROW+kyMyA1aBXA4hbl7F5CVW1GpwVR+sSrBchmva55ap4/ehxsl2mahISahERKj20nDVgafm3zz2lNk3xawc9ofFbwpZE+9QQLHb8RKK9MUhr5Fj6+0+8wCJUKkuXdp2yjZ2InDcJ0n78h0a2EM/syqQj11nviOUlVJ6CDm6eRonzbATWUxnz2jdT3o0QTfvcCN3rqJNTMpVMMRwk1CIiVHo8JhvNzq18uPUltWmUX7vYJ1x+pJDwVbEarwhf5LzjKBsN2J9uajrkRKhueDgRudNxGXtb9mVWk4jt/85DqCIFHVyfae3aemIYiVnbt486XeBGiKZ9bhnGbsdn3JbIWUcNvXwUCbWICJU+KnUSvzJ4vZyLfo+EyoOSswziF378RJJ8rE9Do6qh73//rAyh5iLYdavvty7P8kanYyI/W9KTNUmIh1C9sorVRhDAbRWA2hf9t2e/OLN5u+uqm9NRI68fAzQI6S8Z6KHn9elzeBV9QEItMkJVdW5RfSQEUcRGyyN+4cfPK3HG6QnoMqnK+JpEbi7Xzvzn5zpE0DpNi89EtXrrkZ0cUdNIEYyl9O88hOqVVSxik5Os01Efap/27HMrWfvM1racbrkR/TFAk5XcKsshoSKh+uHvjm2oTBiBGjbcONqnhjLidxk/kbOdOYXhc5Mq+FEiz0J2Kd37FCVTakJu37IkU8HSNZ+Hh1B5l5lVPM3p7G3Ovn/b8VHrsSJWP7kfDzosGfOdRHaymdzJ6gcJFQlVxc89dVUmDM/GfRBA+9RARPwu4+dVbGEMysPLrCr4uRGi2qgCmElPXoTKc0xH1ZbcDxZL1Gxtj9oX3/nsLawjM1Y5p2Vjmexkel6/L9Z1rwZkzCUFSKhIqH74O0aoAaGoMuEGZNKoZtG+4QjVYcJ3HIPhyCis+JnJSV6EyntMR9UXnc7eUvv0f/vxDJ5qdKxVBNFyieZzONX7RUJFQlX1dVf9sE4YptFon9rwI36X8fM6L2lH2YyMwowfjbrTd6/6aeS5Z7+a26cl+kt6xKgwDFhoJkMFffmHFTdWNnUuKWnPtik8S97WVQTzeWZu3XpM9g1glSdEQkVClfUnLr0wTxj0AdA+rmHEFQgOmJwSX1iq5rnNMPsf3aMdXHXPO4nntt9SOwSHzfKINFosSSaX6hqplVky5YCSKcI6e0sJde66hjGFMVgNjOyj0gIW8cxPeUjYzVbWsRokVCRUWf/m0gvzhIGEyjWEuALBCZNj4otd31LIPfTvx7FjZH59PZOwKOGKXNfGCaOjGCubOrN23aar71nFRaj0h0BlSXxJraG9aK2drGIXzfpNpqOLdf3yHbVIqEioKv7kqRv6CeP4cSJ7DtDz4X0QQPzUQMwnftwXeFvOfebTPhkkw2affR808/kvbLr6ruVchCrz/Lw6udq/Q/GlZQ+3jioTGTb8vJ4ncCCbmpr+//bOBMaSqgrDXzMsiiIuMIII4rQK7gPjOpjRuC+4RUcU49buIIJb6EaRYUKYERd0JCbjrijuYhQNKjiaqKjELSYGNBo1qCju6KAM2OaH+0zx0q+7+p2q9069/ivphDB16536zqn733Pq1r3zs7Ozrf/OUjc66N+zO8z2DevZG9uZX7f43SCqe++5boqpQwdu7Vb5VMP+XZ5/+7fN23X8CdvXbNjg/nl5GAee3TpIC2rMU+4wzC9GINZ6XPF3wyQlOGxqFev6hbX63nFc9tWlmtG+6ic0u048afua9Ue1rgN1efWfl5HfYvfSOkgL6rCh5AwrRs78JoHfQu9VqwvJZ+9ws9rX47pr7pTta9Ye0boODBuLWfkNup/WQVpQhw0lC0KMnPlNCr+bzP6tTEhyST/mYS29eO3mM3cMmjQVu3ozrS2ofRwtqLHAyh5Qts/+jRFYuvVNVunpW4je8bc0v8XOML8Yv/7WzlA9SzUUUX4gQ/g8aaomvv9vQda3dqzjrybAAaeZX4yfBbWPgAMqFlDmZ34xAvVba6Ps+fndLqkuk+f4q89voTPNL8bPgmpBbTSC/EDGcJpffX4q/R50ze5XVxcVML/6/CyoMVZ1Wrvk65JvnTgZeI47tBA+l3xj+MzP/IIEmm1uQbWghiLKghrCZ0GI4TM/8wsSaLa5BdWCGoooC2oInwUhhs/8zC9IoNnmFlQLaiiiLKghfBaEGD7zM78ggWabW1AtqKGIsqCG8FkQYvjMz/yCBJptPoyg7gVcBVxYTLkcOHWQWV7YIeYwC5b5xQjEWjv+zC9GINY6e/z1390wgno4sBk4FrhuKVwW1KUILf7v2QPK9tm/MQKx1o4/84sRaLb1MIJ6NHAesA9wKXAysMMZarOO6V3NHUaMq/mZX4xArLXjb7L5DZOh7gdsLQ0/DOwBHAmcAxwDzAHKWue3bNmyaWpq6rT+H9m4cWOMqlubgAmYgAmsSALT09PDJH5jYVXH0H2BmWLdxcBlwPXlb1Up+x4MXLHQHbjkG/OrR7jmFyMQa+34M78YgVjr7PE3TIba3+Z0YH/gOGA9cC4w7ZJvLHAGtc4eULYv5nfzM78YgVhrx1+MXxOCeiBwUclMNSlJJd4LLKjNOqZ3NQd8jKv5mV+MQKy142+y+TUhqL1rHABcuRQul3yXIrT4v/uBNL8YgVhrx5/5xQjEWmePvyYFtRYpC2otTANPyh5Qts/+jRGItXb8mV+MQLOt60xKCv2iBTWEzyvBxPCZn/kFCcSaW/Anm58z1D4CDvjJDnj71/6NEYi1dvxNNj8LqgU1FuHmZ36NEohdzIJlfjECzbZ2ydeL44ciyh1aCJ9L0jF85md+QQLNNregWlBDEWVBDeGzIMTwmZ/5BQk029yCakENRZQFNYTPghDDZ37mFyTQbPPWBXXbtm3zO3fubNZqX80ETMAETGDiCaxevZqZmZnWdaopkK0bmv2zGdsXCyXzM78YgVhrx5/5xQg029qCunXr/OzsbOschnWbO4xhyd3YzvzML0Yg1trxN9n8+u+udSFxQE12QNm/9m+MQKy148/8YgSabW1BdYYaiih3aCF8zqBj+MzP/IIEmm3euqBq0/G5ublNzZrd3NVsX4yl+ZlfjECstePP/GIEmm3duqA2a66vZgImYAImYAI5CVhQc/rFVpmACZiACXSMwCgFdTfg5sC/EjDaHdgTqH4gm8m+2wD/AK6vsMpm31/7/JjJPpl22xJr/yl2ZrOv/zHIZN8tANlzddL4W6gLycRvH+CfwHxSfuOw72alP9tVg4ni7xrgvwm0YlkmjEpQXwCcBPwWkJg9G7hqWZY2c/Iq4F7AC4tzX1Uum8W+Q4BPFDbXAT8AzgCy2Hc48FHgF8DewEeAjyeyrxcldwJ+AjwW+HYi+/Yqvr2wGHo5cGoi+9TpvQ/Yt3RmPwROS2Tf64CjKgOkJwJHAmuT9C8aCL+nDET2Bz4NfDARv8OANxbf6hl5d3mG2+xfJI73Bs4CzgbOX6TP1QDkPEB9n+x7c+HXTO8/gquMQlAloBqV3Br4O7AN+D2wZQT31/8TtwQ2A/cDvg9IUDPZ9wZgj9KJqXPTKE2B9esk/F5dfPcx4JHAW4F1ifwrf6vy8EngzsDLge8lsk8DEsXfsaXTkL2Z4u/5wAOA4wD1DU8Fvgj8O0n8VZ/nNwFXAu9M5F/xezzwDGA98AHgnonsk4D+DHgLcNfy3xI8VQ3b6p/vCzwPeDLw2iKog2Jegqrs+fXAAaWvkX2dWWpvFIKqju0iYLo8DSeUEaWyxHEdxwN3KYKayT6VxBVU6sAUgG8DHgV8NRk/dbgvBc4FPpPMv2J2MaA4k3hp8JYl/o4uI3B1GpcCJwO/SmRfb7CpQdIVgAZ4lyWyr9df3Kd0zHcHDkpk34HAj4CvAQ8B3g58NpF9yk6V3CiZeRBwCfDgUnVqu39Wtq7qljLUQX2u+j49q6p6SZtU8pVdvxyXUCz3d0chqAr+TwEqN+h4DvBQ4EXLNbbB86uCms0+ZVhzwGuApwB/SshPmf3TyshRo84s/pVNGog8F1BZVQKhd1lZ7HtEKVGeAxxT/KxsRhl1hudDGdWGkmUdUUpuGgRksa/XBby3iIHK05me30eXQaYywQcC1wKnJIq/ewDfKSIvIb1bEdQPjSD+qoI6yGe3KrGmc3X8oXDUoLMTxygEVVmXUnZNGtAIpPfeUvX0cR1VQc1kn8q86rz0ICrDUnaVyT4JvEqovyslIk1M0ghS71Qz+Fcj7tXAn4H7l5LWDPDNJPZpsKSJZvrT+3y9K1Lp7edJ7FN2r0lcGtD1OjQNAvQ+OoN/ZdPtyiBT7yv/luz50IBEGb3K0apCaGJh75VNFn56P65Bkp5ZDTQlqqPon6uCOqhP6zFTZq/nQ/2LStGdmZw0CkHVQ/Dj8l5GD+aXyzvCr4xLTYGqoGay7yUl2J/UxyYLv62lwz0d0GhXpdU7lMlTKgOP278HAxqU6FD28i7g8yWbyWCfuGmyimzROzaVzDUgyeJfVY9eXN6P37Fwy+Rf+VVVCL2Tqz4jWfipWrOm9C8S0u+WkrTma2SIP/V7sk/VL71yU6VQ1ZxR8KsK6qA+V8/uKwBl+hsBzdlQJt2ZY1SCquDXjFAdmuSgSRnVKeWjBqbAUkcmh+nIYp9GuJrYUD00gtS7ogz8JKIqZymr6pWzJApZ+FW5XQCcWWb5ZrFP79j0jkiZqf40g1Z2ZrFPs5A1aVATa5S1yD69z8pin/yrLFqlQGWBvSOLfbcHvgDIzzr0ykGzfrPYJ5H/UsmcNWBSWVrVplHYJ0FVH/a5RfpcCarsUz+jLFbzRzQo6cwxKkEVEH1moXKDypgZD9tX3yvqMNSpVUsx5lefn2YwaoZq9cjEb6HvoDPZtxDpTPYpq9dngdVvLjPZp0qOJp1Vk5px2DfoN2Wfno8qv/pP1xjPHKWgjvE2/dMmYAImYAIm0C4BC2q7fH11EzABEzCBFULAgrpCHO3bNAETMAETaJeABbVdvr66CZiACZjACiFgQV0hjvZtmoAJmIAJtEvAgtouX199ZRHQrEV9DqNPinyYgAmsMAIW1BXmcN9uawT0qclfynecJy7jV7Su6mxZDFyfIvkwARPoKAELakcdZ7PTEdCH6Fp8XMsfanWmuodWn9Ii+fq2t//b1LrX8HkmYAIJCFhQEzjBJkwEAa1DqqUYtRazVsfRDkFa5UWrvmhVGq2CJfHUM6cF019WFjnRJt4PL4KqdXS1aYT+tOOQ9oPUVnn608fuWkhf2+ZpWzptnae9c32YgAkkIWBBTeIIm9F5AtWSr5ac0y5BOrSe8MOKsGrpt/3KXrw/Bb5e1njVecpQtY6u2m4qG2lr6TVtqK1F9XeUdbC1BrAW09f2W51bSabzXvYNmMAiBCyoDg8TaIbAQoKqTFUbHjyr7IOqNVPXFtHUfrza8UM74Ug0JajfKLtrbAcOLVsd6h2rMlqtYdvbqUlrO2tXEx8mYAKJCFhQEznDpnSawEKCqhKvtkJ7etkqS4KqrbMkslpI/Y+lFKwNEQ4BflP+nzYg6B3aiFzvZLVQvTJXHT0x7jQwG28Ck0bAgjppHvX9jItAXUHVZzXaUeP9JTt9R9k7Uxnq+aWU+7hSIn5mmeik2cN6H6vNoVXq/VbZekv7qvowARNIQsCCmsQRNqPzBHqCqs2RzyjvUHvlWu3hqe2rlKFqP2BlnI8pd9wTSe1Ao82zzwKeUP5NE5yUzWpTd23jp3ewryz7WWrrwbM7T803YAITRMCCOkHO9K10ioBm/irz1L6j/Yc2IVf2qX/3YQIm0BECFtSOOMpmmoAJmIAJ5CZgQc3tH1tnAiZgAibQEQIW1I44ymaagAmYgAnkJmBBze0fW2cCJmACJtARAhbUjjjKZpqACZiACeQm8D8Q/mjexbmz1wAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<VegaLite 3 object>\n",
+       "\n",
+       "If you see this message, it means the renderer has not been properly enabled\n",
+       "for the frontend that you are using. For more information, see\n",
+       "https://altair-viz.github.io/user_guide/troubleshooting.html\n"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.plot(kind='area', alpha=.4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.vegalite.v3+json": {
+       "$schema": "https://vega.github.io/schema/vega-lite/v3.4.0.json",
+       "config": {
+        "mark": {
+         "tooltip": null
+        },
+        "view": {
+         "height": 300,
+         "width": 400
+        }
+       },
+       "data": {
+        "name": "data-13099b60e16e19b1dfc8ec8ad5449064"
+       },
+       "datasets": {
+        "data-13099b60e16e19b1dfc8ec8ad5449064": [
+         {
+          "index": 0,
+          "x": 0.10174192426040822,
+          "y": 0.31973437326889537,
+          "z": -0.24087925640418273
+         },
+         {
+          "index": 1,
+          "x": 0.46377109678002576,
+          "y": 0.39284953965450403,
+          "z": -0.8470307992657274
+         },
+         {
+          "index": 2,
+          "x": 0.5427920704495576,
+          "y": 2.0215438525479135,
+          "z": -0.5041337657185385
+         },
+         {
+          "index": 3,
+          "x": 0.691790393493323,
+          "y": 1.4080784951558476,
+          "z": -1.5530227427069885
+         },
+         {
+          "index": 4,
+          "x": 0.5438454859014044,
+          "y": 2.282289197786082,
+          "z": -2.47969679801141
+         },
+         {
+          "index": 5,
+          "x": 0.8412672776574759,
+          "y": 0.9336365164416933,
+          "z": 0.11586844310132616
+         },
+         {
+          "index": 6,
+          "x": 0.4440696728540403,
+          "y": 0.5846040675015804,
+          "z": 1.198605562039081
+         },
+         {
+          "index": 7,
+          "x": 0.37689265681375916,
+          "y": 1.8445078498152159,
+          "z": 2.1971366928099076
+         },
+         {
+          "index": 8,
+          "x": 1.7088994296520779,
+          "y": -0.2965165131611587,
+          "z": 2.4854050834183345
+         },
+         {
+          "index": 9,
+          "x": 0.7594255157953386,
+          "y": -0.7840081732519648,
+          "z": 2.530393125472639
+         },
+         {
+          "index": 10,
+          "x": -1.4872055561564141,
+          "y": 0.3599911702784182,
+          "z": 4.835100132883255
+         },
+         {
+          "index": 11,
+          "x": 0.2150577809319032,
+          "y": 0.11582875972667908,
+          "z": 5.208579582224949
+         },
+         {
+          "index": 12,
+          "x": 1.5744840005341858,
+          "y": -0.372546574433127,
+          "z": 5.51545982910521
+         },
+         {
+          "index": 13,
+          "x": 0.3679772618606698,
+          "y": -2.878238152804081,
+          "z": 4.186569493581132
+         },
+         {
+          "index": 14,
+          "x": -0.11537830312732728,
+          "y": -1.9506804820892456,
+          "z": 3.339122687346829
+         },
+         {
+          "index": 15,
+          "x": 0.268552495967064,
+          "y": -2.3876264052815257,
+          "z": 3.7811188858038514
+         },
+         {
+          "index": 16,
+          "x": 2.226832215019299,
+          "y": -2.126093605804431,
+          "z": 2.0328388792460435
+         },
+         {
+          "index": 17,
+          "x": 3.8506435691911456,
+          "y": -1.3191840891125446,
+          "z": 0.6586872458863735
+         },
+         {
+          "index": 18,
+          "x": 3.176396308806726,
+          "y": 0.5053296955453654,
+          "z": 0.584394876179876
+         },
+         {
+          "index": 19,
+          "x": 3.6109830595525274,
+          "y": 0.24878768452561512,
+          "z": 2.154914558728954
+         },
+         {
+          "index": 20,
+          "x": 4.268315558606928,
+          "y": 0.28702041547905166,
+          "z": 2.1925933269587845
+         },
+         {
+          "index": 21,
+          "x": 5.051792703926308,
+          "y": 0.8084957713851727,
+          "z": 2.726933416131036
+         },
+         {
+          "index": 22,
+          "x": 3.960653857760024,
+          "y": -1.0602674336345799,
+          "z": 1.6993094433335816
+         },
+         {
+          "index": 23,
+          "x": 4.0584745148057975,
+          "y": -1.6941204224418502,
+          "z": 1.6515505886605286
+         },
+         {
+          "index": 24,
+          "x": 3.786081117290783,
+          "y": -0.46754429414988685,
+          "z": 2.4685878205488523
+         },
+         {
+          "index": 25,
+          "x": 2.741724342276396,
+          "y": 0.1523948677505672,
+          "z": 4.58321713054731
+         },
+         {
+          "index": 26,
+          "x": 2.8013085128398605,
+          "y": 0.7990974820535526,
+          "z": 4.892019651329498
+         },
+         {
+          "index": 27,
+          "x": 0.2069234183914137,
+          "y": 1.24699471682072,
+          "z": 4.654423098801681
+         },
+         {
+          "index": 28,
+          "x": 2.1655806809093194,
+          "y": 0.4687251097775069,
+          "z": 5.912860340821911
+         },
+         {
+          "index": 29,
+          "x": 1.9829943803653802,
+          "y": -0.05890571295352498,
+          "z": 5.893990033926627
+         },
+         {
+          "index": 30,
+          "x": 4.248989972799317,
+          "y": -0.254524993710882,
+          "z": 4.507886736419069
+         },
+         {
+          "index": 31,
+          "x": 5.934371725729361,
+          "y": -0.8869058278485157,
+          "z": 4.571610341559309
+         },
+         {
+          "index": 32,
+          "x": 5.4140845862818425,
+          "y": -0.5044805179694067,
+          "z": 5.62977884584074
+         },
+         {
+          "index": 33,
+          "x": 5.4501816431594925,
+          "y": 0.3429631069122123,
+          "z": 6.02974958340587
+         },
+         {
+          "index": 34,
+          "x": 5.399664441419694,
+          "y": 1.703967924986447,
+          "z": 5.61243990526056
+         },
+         {
+          "index": 35,
+          "x": 5.172968470830933,
+          "y": 2.397689255319875,
+          "z": 3.692298753317647
+         },
+         {
+          "index": 36,
+          "x": 5.750154694482398,
+          "y": 3.1886569430215896,
+          "z": 4.344349548933432
+         },
+         {
+          "index": 37,
+          "x": 5.092582320162698,
+          "y": 3.1067826056283856,
+          "z": 4.917785581801794
+         },
+         {
+          "index": 38,
+          "x": 5.254272059482469,
+          "y": 4.141413004966657,
+          "z": 5.620976316751887
+         },
+         {
+          "index": 39,
+          "x": 6.357545531371504,
+          "y": 4.097757647686296,
+          "z": 6.18646564919352
+         },
+         {
+          "index": 40,
+          "x": 5.57987671819632,
+          "y": 3.514169061914425,
+          "z": 5.664795621912372
+         },
+         {
+          "index": 41,
+          "x": 6.868678223733693,
+          "y": 4.438871989278683,
+          "z": 4.971151710223277
+         },
+         {
+          "index": 42,
+          "x": 5.978478595171977,
+          "y": 4.256481510544367,
+          "z": 4.290192930843104
+         },
+         {
+          "index": 43,
+          "x": 7.27385413218568,
+          "y": 4.4418126528036,
+          "z": 4.195896001192871
+         },
+         {
+          "index": 44,
+          "x": 7.60085135587176,
+          "y": 4.162472682994865,
+          "z": 2.032617349280593
+         },
+         {
+          "index": 45,
+          "x": 7.948721752538825,
+          "y": 2.81277416046235,
+          "z": 2.694012623718799
+         },
+         {
+          "index": 46,
+          "x": 8.364290165030434,
+          "y": 4.0841944872584115,
+          "z": 2.759878490550716
+         },
+         {
+          "index": 47,
+          "x": 9.359794630240813,
+          "y": 3.482878122855636,
+          "z": 2.927735045609092
+         },
+         {
+          "index": 48,
+          "x": 8.104774336021741,
+          "y": 4.190030140622708,
+          "z": 3.614185846205572
+         },
+         {
+          "index": 49,
+          "x": 9.715417613466196,
+          "y": 4.623986629439741,
+          "z": 4.015269442644731
+         },
+         {
+          "index": 50,
+          "x": 9.370471485459165,
+          "y": 5.504467326189326,
+          "z": 3.041052583158115
+         },
+         {
+          "index": 51,
+          "x": 9.065885308371291,
+          "y": 5.4206861985537556,
+          "z": 1.394615266131908
+         },
+         {
+          "index": 52,
+          "x": 9.218321631226758,
+          "y": 3.739325038071642,
+          "z": 2.40901501723681
+         },
+         {
+          "index": 53,
+          "x": 10.198316200824136,
+          "y": 4.573143244874159,
+          "z": 0.8947416224225218
+         },
+         {
+          "index": 54,
+          "x": 9.35226463525669,
+          "y": 4.335863561983189,
+          "z": -0.13679849716142778
+         },
+         {
+          "index": 55,
+          "x": 8.762788860077656,
+          "y": 5.119003366159331,
+          "z": -0.4334589388760052
+         },
+         {
+          "index": 56,
+          "x": 9.117564250500054,
+          "y": 5.418976864353279,
+          "z": -0.18891403242086383
+         },
+         {
+          "index": 57,
+          "x": 9.602651859227619,
+          "y": 5.086966380253811,
+          "z": -0.6121778154020331
+         },
+         {
+          "index": 58,
+          "x": 10.879607109217254,
+          "y": 4.311484927031843,
+          "z": -1.425664934927123
+         },
+         {
+          "index": 59,
+          "x": 10.537410942379033,
+          "y": 4.387162376655904,
+          "z": -0.5399290309997808
+         },
+         {
+          "index": 60,
+          "x": 11.225578975297841,
+          "y": 3.5183673813659633,
+          "z": 0.832419083266073
+         },
+         {
+          "index": 61,
+          "x": 10.359691864727573,
+          "y": 2.7040074025101597,
+          "z": 0.44964576655079536
+         },
+         {
+          "index": 62,
+          "x": 12.26761043202559,
+          "y": 1.0648754608317819,
+          "z": -1.5795325927036103
+         },
+         {
+          "index": 63,
+          "x": 11.022252084971917,
+          "y": 2.865679137865471,
+          "z": -2.1572375190414115
+         },
+         {
+          "index": 64,
+          "x": 11.452264641911409,
+          "y": 3.3518049587910395,
+          "z": -2.096341110341587
+         },
+         {
+          "index": 65,
+          "x": 12.158060551893351,
+          "y": 2.321521136777985,
+          "z": -2.0022892663135545
+         },
+         {
+          "index": 66,
+          "x": 13.177127890975944,
+          "y": 3.6645282775200165,
+          "z": -2.4389101160888402
+         },
+         {
+          "index": 67,
+          "x": 15.522945188865691,
+          "y": 2.361464107419462,
+          "z": -3.568480388365322
+         },
+         {
+          "index": 68,
+          "x": 15.81688552955633,
+          "y": 2.5220984282537025,
+          "z": -3.7165067259278377
+         },
+         {
+          "index": 69,
+          "x": 16.129729433656294,
+          "y": 2.4937185572111527,
+          "z": -4.2466357168853275
+         },
+         {
+          "index": 70,
+          "x": 17.06784855711916,
+          "y": 3.93583270540669,
+          "z": -2.493002296789477
+         },
+         {
+          "index": 71,
+          "x": 16.70326660367303,
+          "y": 5.5249944902113155,
+          "z": -2.121319801745191
+         },
+         {
+          "index": 72,
+          "x": 16.950199127276772,
+          "y": 7.159967308032584,
+          "z": -2.7152283810749513
+         },
+         {
+          "index": 73,
+          "x": 15.248282457364098,
+          "y": 8.210170853853088,
+          "z": -1.9355365448498585
+         },
+         {
+          "index": 74,
+          "x": 16.054992388109284,
+          "y": 8.250469654794461,
+          "z": -3.107166689002126
+         },
+         {
+          "index": 75,
+          "x": 14.164541809906131,
+          "y": 8.916046264798378,
+          "z": -2.7773149839259865
+         },
+         {
+          "index": 76,
+          "x": 12.298760173518286,
+          "y": 7.155427687411402,
+          "z": -1.605128707862652
+         },
+         {
+          "index": 77,
+          "x": 11.8800503728053,
+          "y": 7.481289338966637,
+          "z": -2.065024272465417
+         },
+         {
+          "index": 78,
+          "x": 11.643534036485335,
+          "y": 6.424359008166599,
+          "z": -3.0244706955932585
+         },
+         {
+          "index": 79,
+          "x": 11.869846216582067,
+          "y": 6.834063197344662,
+          "z": -2.5672367692080074
+         },
+         {
+          "index": 80,
+          "x": 12.120206533204701,
+          "y": 7.066807418005693,
+          "z": -3.424208815445228
+         },
+         {
+          "index": 81,
+          "x": 10.594880908570588,
+          "y": 7.4382606295506015,
+          "z": -3.239480823160873
+         },
+         {
+          "index": 82,
+          "x": 10.458719301874376,
+          "y": 5.9438633998527735,
+          "z": -3.4561830287704414
+         },
+         {
+          "index": 83,
+          "x": 11.455597611962888,
+          "y": 6.077430806863743,
+          "z": -1.8707027699876657
+         },
+         {
+          "index": 84,
+          "x": 12.754059866940093,
+          "y": 7.177908821156228,
+          "z": -1.209913816481841
+         },
+         {
+          "index": 85,
+          "x": 14.708054346196757,
+          "y": 6.939716516222237,
+          "z": -1.6791085690526817
+         },
+         {
+          "index": 86,
+          "x": 15.281672532246994,
+          "y": 7.147083287222761,
+          "z": -2.2179803046948017
+         },
+         {
+          "index": 87,
+          "x": 15.52144984592544,
+          "y": 5.812799723614566,
+          "z": -2.8043770783954693
+         },
+         {
+          "index": 88,
+          "x": 15.117744315987167,
+          "y": 5.444030417678696,
+          "z": -2.280572102090161
+         },
+         {
+          "index": 89,
+          "x": 13.927728756982127,
+          "y": 3.220712999501728,
+          "z": -3.5345034995471702
+         },
+         {
+          "index": 90,
+          "x": 15.193044682415191,
+          "y": 2.4866111100918293,
+          "z": -3.937726991578081
+         },
+         {
+          "index": 91,
+          "x": 15.071570219335568,
+          "y": 2.9177719361150682,
+          "z": -1.6453903467106312
+         },
+         {
+          "index": 92,
+          "x": 14.202344173379267,
+          "y": 2.364584729551816,
+          "z": -2.172403692590777
+         },
+         {
+          "index": 93,
+          "x": 15.887154022596365,
+          "y": 1.0427051146283275,
+          "z": -3.492515229576884
+         },
+         {
+          "index": 94,
+          "x": 16.68478992256872,
+          "y": -0.6943145021549451,
+          "z": -3.228226032811297
+         },
+         {
+          "index": 95,
+          "x": 18.131774750904352,
+          "y": -1.6764272841025862,
+          "z": -1.1351491559933211
+         },
+         {
+          "index": 96,
+          "x": 17.814194344521113,
+          "y": -2.8151228157108497,
+          "z": 0.2388957166555099
+         },
+         {
+          "index": 97,
+          "x": 17.305576906316734,
+          "y": -2.7856877507761673,
+          "z": -0.09130337260940496
+         },
+         {
+          "index": 98,
+          "x": 16.804003476374817,
+          "y": -3.385818957044541,
+          "z": -0.7751946313592928
+         },
+         {
+          "index": 99,
+          "x": 16.013016105881928,
+          "y": -3.569795812183962,
+          "z": 0.018632786890970587
+         }
+        ]
+       },
+       "encoding": {
+        "color": {
+         "field": "column",
+         "title": null,
+         "type": "nominal"
+        },
+        "opacity": {
+         "value": 0.5
+        },
+        "tooltip": [
+         {
+          "field": "index",
+          "type": "quantitative"
+         },
+         {
+          "field": "x",
+          "type": "quantitative"
+         },
+         {
+          "field": "y",
+          "type": "quantitative"
+         },
+         {
+          "field": "z",
+          "type": "quantitative"
+         }
+        ],
+        "x": {
+         "field": "index",
+         "type": "quantitative"
+        },
+        "y": {
+         "field": "value",
+         "title": null,
+         "type": "quantitative"
+        }
+       },
+       "mark": "bar",
+       "selection": {
+        "selector006": {
+         "bind": "scales",
+         "encodings": [
+          "x",
+          "y"
+         ],
+         "type": "interval"
+        }
+       },
+       "transform": [
+        {
+         "as": [
+          "column",
+          "value"
+         ],
+         "fold": [
+          "x",
+          "y",
+          "z"
+         ]
+        }
+       ]
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAdQAAAFbCAYAAABswX9hAAAgAElEQVR4Xuy9CXRVx5Xv/a9z7qBZQkIgEJMRYIxnbBIPcUySdhLHQ/eXGAfanZepX7pfnNdD3nMbOgN2utNg5/t6WrG7X2fsDAYPL+91PMTpOA4eEjt2bDyCmQVIIJBAEprvvafqW3UHdHR1hzrTvSVpn7VYgFR1zj67du3f2bsmBrpIA6QB0gBpgDRAGvCsAeb5DnQD0gBpgDRAGiANkAZAQCUjIA2QBkgDpAHSgA8aIKD6oES6BWmANEAaIA2QBgioZAOkAdIAaYA0QBrwQQMEVB+USLcgDZAGSAOkAdKAClBDAGoA9GWpqxrACABOaiQNkAZIA6QB0sBM10AxoH4RwJ8A+C2AOgB3AjgF4AEACQCLAXwDwPdnuiLp/UkDpAHSAGlgZmugEFAjAMbS0ekQgC8DmAugE0AtgC8BaAFwHICMVodntirp7UkDpAHSAGlgJmugWIQ6C0AvgCoAvwTwTwB+D8BTALYDyWU3MuXbBuDgTFYkvTtpgDRAGiANzGwNFAOq1M5qAN8D8BaAzwL4AYCHADySVt0JAO8G0L5ly5a7GGOb7Sptbm7G2rVrZ7aW6e1JA6QB0gBpwI0GRFtbm+GmYjnqFAPqB9LjpX8G4MG0gF8FcAbAPwIw0xFsQ77JSVu3bhUbN24s9pxA3/3AgQOyUcoqg3xBHeQgGcZNjXSR0oUOetBFDh10oYMM07E9bty47S4V0Dy2dYNSuVz3KgQZ+bv+dIr3JVvlmwF8AcAHAawDICcuXZlPUAIqOfBs2yCHQTaRy1/oYBckw/S1zXIDdRmAfVmG/+8A/huAJwCsAlAJ4Lr0LOCcTCWgTl8DVfna09VxTscvcGoPtxqgPqprP/XzA8cjUOX8ITkh914AmwCEAXwtW29e0qALAXQBiBcyYwIqdVaKUPP3ED8dhluc6CADfeDo5SemY3t4BOpKALsByAztjwGclwbshG7nBahK/ZeAqldH0cF56iDDdHQYSh0yRyFqD+qjFKGOa6DAGKqccCvHV2WW9l9z6YyA6tYLuaing+MiGch5UsaAMgYq7mu6+QqPEapUmdzYaCuAT6ZXu0xSIwFVxbJ8KjPdDNStWnTQA0Woen1YUHtQewQdJXsEqpxT9Gp6Qu4303svdGfLTEB1SwUX9XQACcmgl+Oi9qD2oIxBaTIGHoH6nwCeBfC3AP4tPSnp0wRUFyD0qwo5z5QmddCDLnLooAsdZKD20OvDYjq2h0egKmGAIlQlNflTSAfHRTLo5bioPag9KEKdEhGqEgQIqEpq8qcQOU+KUHV0njrY5XSMiNx6DWoPvT6ynLQjAdWJtjyW1aGjkAx6dVZqD2oPHT+y6APHnbMnoLrTm6ta5DwpQtXReepgl+TA9fqwoPZw5eKTx68FetHGDnp1FB2cpw4ykMPQyy6pPag9coHIT18x9PUWpU3vq7/UpVQul7wE1EA/Jybe3E/jcCs2yaCX46L2oPbQMWsxHT9wCKhuqZFVTwenNR0N1G3zUHsQRIKORqaybVL/CKZ/eATqT9K7JMmT1y4H8FcAbs22M4pQ3fY8F/V06CgkQzCd1YU5JKtQe1B7UISav/f42T88AvXraSm/lD5lRgCQe/tOuAiobj2hi3p+GoeLx5MD1zBzQTZBQCWgTgmgXgbgAQDnAngbwB8B2ElAdUsiH+qR80wpUQc96CKHDrrQQQZqD70+LKZje3iMUGXweQTAZwF8B8AiADJKpQjVBza6uoUOjotk0MtxUXtQe1CEOiUiVCmkPGlmHYDtAGTqd9JFKV9XaHRXiZwnRag6Ok8d7HI6RkTuvIT7DM5Nf7X9ilzPfPTe9S+6kUUHu/BTBo8RqlThuwD8FsAlAF4noLqxKh/r+GkcbsUiGSgi0hHqBFTvdnnjxm1rAcg/9mvHY1s37HDjL6abr/ABqKvTB4tLsOa8KEJ1Y2ku60w3A3WpBhpDtSmObMI7SNzaYa56U7k9CKiFLcEjUG8D8FUA/x2APMqNgOpnx3Nzr6ncWd28b746OuiBIiK9QEbt4b09CKh+eqlJ96oBwAEMF3oKRaiBtsHEm+sAEpLBu+Py02SoPag9su3JrU3YgSoEqhnEuQJsj2HgncwzHt2yQc5QVbrcyqF0c8VCOsigKGqyGAHVibY8ltXBOEgGcuB+OXCP3WFSdbLNlErc6mESUBnWCKCdAe0pZ89OPrp1/f2q7eZWDtX7q5TTQQYVOTNlCKhOtOWxrA7GQTIQUAmo+TvyVO4fBNTCDvro+luVNr1fuP0hpXK5nkZA9QhJJ9Wncmd18p7FyuqgBy+RQLH3c/J7HXShgwzUHt4/9AioBFQnvsd1WXIY3jura+XnqEjtQe2Ry550sIupLAMBNVCgfhHAJ21P+DGAe7OfSBGqn6Qocq+p3Fn9VJMOeqCISC+oU3t4bw8CaqBAbQLQAGAhgF8BeH/67wkPJaD6SQoCqpI2CajenaeSohULUXtMj/YoDFS2BhBjjOE3mbdNwPz3n225tTufmehgF37K4MMYagiA3CTj5wD+JpfeCKiKTsePYn4ah1t5SIbp4Tzdtr+uqVaKUL3bZXGgymeIlzNPsph5HwF1co8oMCnp79JnoV4PwCKg+umFXNyLYJZSmg560EUOHXRRThmu3/RQc6Yrbf2ji09u/NHrc+T/Czl6F11PuUo5dZER0q0MBNTCzewxQpUQ/T6AiwF05XsSRajKXc17QbcdxfuTvX/9TjcZCKh62MSNd267HQxJqH54devmJ1/tvLtY5OSnLWbfayr3UQJqoEB9HsDVAAbST3kIwB9nP5GAGmTvzLr3VO6sfqpJBz0QUPUGqpQuxPlHs+3u0XvW/y8/bZGASmOo2TZA61CL9DBy4Ho4T68pLb8dqQ52MdNlyBehyrY2hXW7vc2d7vTjxl6mcnuoRqgCqJC64SH2rZq40ZPR08P33Npv19lU1kWutveY8lUyJ4pQldTkT6HpZqButaKDHihC1eMji4A6uRe57R8OgLqEAUsA9hIgMpu9Tzrmza0cbv1Crno6yODkfQioTrTlsawOxkEy6AESnaL1ctqEHajvWj5780v7ep4WzHgRnMuNxq8QDEfd7kXrpruWUxdubOKGTQ+e3WyAQawEx0ow7BNCMDZhL1+5bEZe4mUBEFDdGIdCHQKqgpL8KjLVOqtf7519Hx30QBGqHh8WOYD6jIycJgPB+ebubuxXB9t0IoNdf3ZQElDdtL73OgRU7zpUvoOTjqJ8U4cFSQY9QOImGnHY1MrFy2kTBFRvKV8CqrKZl6QgAbUkak49pJyOixy4N8cVlJnMdJsgoHqzSwJqUD3T3X0JqO705qrWTHeeOkGdPnD0iNQJqATUQs5UB5/pxNkTUJ1oy2NZHYyDZNADJDp9XJTTJgioBFQCqgOwbN26VWzcuDFwcE+FRimn4yIH7s1xOTB5R0Vnmk3IrQZD3EhuLygvzhIbAMxiEN3pWb40KenAAdHW1qbkMynl66i7BV5YqdG8SEFApYgo2350gAilfMtjlxKoEzdsGF/OoQrUGzZtuyaXT3p8y4bnvPiqqWgTBFSvLe5vfQKqv/oseDcdQEIylAck+QxjprWHH0C1b2Bg0+ukjQncdO2p1h5egZpaXsMuF0A7gzgsdZbZkWqq6cJNe/tdh4Dqt0YL3I8MNKUcHfSgixw66KKUMhBQizucQu0h9RdmuCRzF875zQDqAXHQzTrUQut9S2kXOn9wFm+x8RIEVCfa8liWDJSAqmP6O2i7lBElY1go311w1IHhAwI4k9oByXnKdyZHqIU+SAioHh20D9UJqD4oUfUWQTsuFTlIBkr5lhrqqnvMqo6hElDthwbk3lJQdackilBVvKZ6GQKquq48lySYUYRaapipGG3QdklAVWkFtQ89ilCd6bLUpQmoJdR40I5L5VVIBjXHpaJLP8pM1/a46c5Hzj+rH8bXcPA1DBgqFDlNxwhVAtCw+OxsW3n83vW789lPsTHUfLOkKeXrR4/0dg8Cqjf9Oao9XZ2nIyXQpKQJ6pquNuFm9ul0BarTc10JqHp99Drxb6pArQEwJOcUOLm5LEvrUPUyjunqwJ3apSxPugguBU9ATel2coq2+Kk5BFS9fKYT31IMqHJHk4sA/ATAMgAnAUQBdAN4Mv2gPQC+ku+hBFS9jIMgQu2R3VeDsAm/gSoEqg2GnlAi/r14KHy1ELiKMSYKHZDtxBFmyvqhCzlmLIQh/SQY5w3CwI1gsFTPdSWg6tVHndhRMaB+DMDVAP4SwNw0UFcC+BqAPwSQKPYwAqpexuGHwyjW5sV+r4MMFKEGa5d+A9W+vEb1gOxidpjr937YZuFJWLkj1ORYqxAXS5lu/8iKX9z3xN7r5L8f3/rxp+xy0qQkN61aujrFgJqRRKZ6M0C9EcADAGoBvAzgTgC/ogi1eKP50VmLP6VwCZIhWJA4bZ/p2h4EVKyVtiAja8awJrUTkfzDVkGIM5yxn2dshTNjh/x3Zqz1w6tbN//81eP3gPEeLvh37DbFWThEk5Kc9rLSlXcD1A8AWA3gmwA+DmATABm15hxfpQiVHHi2OesAEYpQg7VLAmpuoNoj7UwLWMy8LxuoT7567InU74UMWpJXdrnUT2kdaulwWfxJboAakW2b/mOm075yF5SOLVu23MUY25z92HXr1hWXhEqQBkgD00YDz719AoOjqRGh0wNjOD0Yw6Lm6uT/j3QPobE2isaaSPLf8pK/c1MuEjKS9ZfPr8OyeTJpVv5r37Ez2H98IClILMHzvm9G0mvOn5sMZZ/bJaeopC67XlTLudFfdnvI/9dUhnHNqrMHApVdoaon75Rd0OQ+yGqXPeV7N4BmAJ8HcBWAHwJoy3cbilDHNaNDZEYyUHtk99UgbIIiVIpQ1dBSuFQQtumHXPnu4QSo8pNFzu6dB0AOlMvPT/lHRqSPEVCLN5MOxkEyEFAJqPn7qh/9Q3VnqIwUlPINtj2Ke2b/SqgCNdcTWwB0FROFIlRy4KVw4MXsMNfv/XCebp5rrzNdZZhpEWryfcHSOWexFMBSMPZqoZ2hCKjFe48O/aO4lOMlvABV6TkEVAIqAVXvL/AgnNaMBCpLDoXJ2ZlLGLAEYC8RUJUwkbdQELbpTaLCtQmoQWo36946GAfJQB84pfjAIaASUP1wrTr4KyfvQUB1oi2PZXUwDpKBgEpA9T9j4OYDglK+xR2qDv6quJSU8nWiI9/K6mAcJAMBlYBKQM2fkh7fyYl8hXPXTxGqc525rkEGmlKdDnrQRQ4ddBGEDG4itsKnzeTewECXvXzdvK+DCFWu/QcLmd+Sf4uE9V/TdWO0sYNrdxxIRQJqIGrNfdMgHJdT8UkGilCnU4QqJ/0YjC0WELsE2NuZd3t86/qHnfYNLx9ZQQJVdZKTP+UoQnVjN5k6BFQv2nNYl2BGEWopYObQLAPJGLgBjJsIdfIs2uLHoxXSj9s+6uZ9VSNUf0CpukUhAdVp/7GXJ6B60Z7Dum47q8PHFCxOMlCEWgqouwEMAdW6XbaN3BzfvpcvAbUtcE755WMDF5TWoZIDL4UDd9Mh6OMiuIwBAbX4spkUKFkrhHhRMEOe7XolIDqvX936SQJqcLbpxleo1iGgqmrKh3LkwPXqJNQewbUHAVUVqJPLEVD1CkKcuH4CqhNteSxLDjw4B+6maag9gmsPAioB1U2f1DWbpfouBFRVTflQjhx4cA7cTfNQewTXHgRUAqqbPklALaI1GkPVK31BEKH2KIXTIqASUAmofmgg6x4EVHLgpXDgbkyXPi4oQvXLNt18QOSbvUtjqHr5TCe+hVK+TrTlsSw58OAcuJumofYIrj3cAGamLZshoBbvtTr00eJSjpcgoDrRlseyOhgHyaDX1+90bQ8CKqV8PbrLZHUd+oeT9yCgOtGWx7I6GAfJQED1K81pv8/1mx5qRoLXZX5mMvZHMHgjgF7VjQkoQsUaAbRTylevPurE7RNQnWjLY1mCWXApRjdNQ+3hX3tIoJoitdNP6lLd6m68HAGVgBrEx54b3+C2DgHVreZc1CMH7p8Dd6H+SVWoPfxrDwLqttvB0Cw1qhqR0xhq8V6sQx8tLqXtM9JJYTdlaZavXukLHQxUBxlkq+ggx3SRgYBKQHXDh2J1dOgfxWS0/54iVCfa8lhWB+MgGegDJ4i0GgGVgOrRPeasroO/cvJeBFQn2vJYVgfjIBkIqATU/B1ZtX8kPyASfGHmTsIUt4JjFjNwnFK+Hh2lrbpqe/j3RG93IqB605+j2joYB8lAQCWg+gRUj5OwaAy1uPvUwV8Vl3K8BAHVibY8ltXBOEgGAioBlYDKkG+dLB0w7sXNE1C9aM9hXYJZSmE66EEXOXTQhR8yzLQxVD/elyLU4g7UD9ss/hT/ShBQ/dNl0TvpYBwkA0WoFKFShEoRalF37aoAAdWV2txVIphRhBoEzNxZo78fFn5EbL5s7CBYJTNYNxeJ79j18vjW23pV9KTaR/14X4pQi7eIansUv1NpShBQS6NnbVKdOhioDjJQyjc/UG/cuG0tY2izdw0hcOCxrRt25OsufgDGF6DadmjKyGox876fbbm1W6Wrq9qmH+9LQC3eIqrtUfxOpSlBQC2NngmoNj3r0kl0kENHGSRQAcg/9mtHNlCT4IUwZCHGRQNn7PcFY4IB7eXbenB8K0NVoN5016NVmbL3blg59Ffb3qmW/3/0rpuGg/yAIKAWd7469I/iUo6XIKA60ZbHsjoYB8mQPzLz2LyuquvYHk6AmgGvEKhmLLUX7VQDqv19P7y6dfOTr3beDWDSB4S9gSlCdWXujivp0D+cCE1AdaItj2V1MA6SgYCabcbZNkFAJaA+unX9/eQrnDt8AqpznbmuQQaaUp0OetBFDh10MX2BypqSBsf4A4YVOp3puD+999Y9H7njoZbM/xnjVwG4ihngH149/w6KUNlJAqo7N09Adac3V7V0dJ6uXsRjJR30QEDNH6lPlwjVPkYJiMx4aDKVm+8AdAIqbezgxb0RUL1oz2FdHUBCMlDKd6akfAmobsa0CagO3fqE4gRUL9pzWJdgRinfYjBzaFK+FJ+uKd9Js2iB+YLhDcaMN8HFjYCoB8M+ezmKUAmoXjoVAdWL9hzWJaASUAmoguWbDez3OlQ3p74QUAmoDt06RaheFOalLgGVgDrVgXrjndsvPjuZxxCXC4HLATYgRH5QqoJNd6De/KVtl59tPyFmcYutS/6f4Zibdbe0DrW4N9XBZxaXcrwERahOtOWxrA7GQTLQGGoxqBealJRvMs9MAKpdL36suyWgFneoOvir4lISUJ3oyLeyOhgHyUBAJaDm38mpUMqXgOqbK1S+kQ7+SlnYZLIi4Gvr1q1i48aNgT+n0Gvo0ig6yEEyEFClBuROPyFh3SD/veHapd/b9szBT8t/P7p1w/cpQs29sQMBNWBY5Li9Dv7KyVsHDjoCKjnwYhGRE4P1s6wOnbVcMti3zstst8eQWtBPQCWg0sYO7jwNAdWd3lzVKpfztAtLMtAHTiZCNYV1u/x3IaAmxwqBegb2CguJVzhn68DFLDkRR3WykWo53SclUYTqyu15qqSDv3LyAgRUJ9ryWFYH4yAZCKiOgepx03sCqrMNFq5f3frJJ1899kTKUsXLqvrzpxwtm/Hi5gmoXrTnsC7BLKUwHfSgixxB6+LGTduTY6P2y4LxmPy/coRKQE2qjyJUhw7Ph+JB9w8fRJxwCwKq3xotcD8djINkmFkRqn2ZS+bN5YHbBNTxc1NVd0oioJbQWaYfpYO/cvLWBFQn2vJYVgfjIBkIqARUWjbDgCUAe2ny+mFK+Xpx8wRUL9pzWJdgRinfbJMJ2iYoQs0HjtwR6vsvarnj6de7vgchXhMmdmba6/EtG56jCNWhw/OheND9wwcRKeXrtxJV76eDcZAMMzdClalNCMyGYexgwmJCsGvB0JOaBNN5d65lM0HuCMQwMVLUYZZvEqhvHH9GAO0p+cYjNgKqqqfzr5wO/srJ21CE6kRbHsvqYBwkw8wGaq5UHwEVSzJ6mQxUGcmKMSHwG8bQJgTaGGOv+bHVIm09WNyh6uCviks5XkIVqDUAhuQcbtvNqwGMAOCFHkgbO8wsB65ifLp0Eh3kCFoGlb13JVB/9mrnTw3gDAd+xSBWCrBzGdieIMExNSLU3KnhIPVCy2b08pkqPi1TphhQ5wC4CMBPACwDcBLAbAAPAEgAWAzgGwC+n++hBFS9jCNoB65ifDrIIOXUQY6gZVAFavnWPY4DS8+ULwFVpU8HVSbo/uG33MWA+jEAVwP4SwBz00DdCKAWwJcAtAA4DkBGq8O5hCOgElCz7UKXTqKDHIVkkGN2AsZldv0x8Fce27phh6ojIKC6mJQ0YQyVgKpqa0GU06GPOnmvYkDN3EumejNA/TaApwBsT2+uL1O+bQAOElALq14H4yAZps4HTqE9dVU7OQGVgJqdWi+8oxItm1HtW7nKuQHqQwDkn0fSNzwB4N0A2rds2XIXY2xz9oPWrUudw0sXaYA0oK6BfcfOYP/xgQkVls+vw7J5MkGkdj339gkMjsrRGeD0wBhOD8awqFkmlIAj3UNorI2isSaS/Le85O+o3MzVi7SBmsowrlklR/v0uNra2lQ5VXaBVQW1R6hfBXAGwD/K3csA9AJoyDc5iVK+UyciKpU16hAly3fVQY5iKV8Aa7PaZQelfMdn5fo9OSj3LF/ZAqXbU5cmJenlM534RTdAvRnAFwB8EIAMPb8I4Mp8DyWg6mUcukPEifF6Lau7Lijl62xTeWepzQIbO9AYavIYP937h9f+H0R9J0CVOYBuAJUA5EkIq9L/vg7AbwmoxZuHDDSlIx30UGo5rt/0kOwv2Vf3N//4spP5UloEVAJqKSPj7I0sdOinOshQ3LOPl1AFaq57LgTQBSBe6IEUoVKEmm0funSSUsqRbwtAv4G67qGH5DDM2Wv4lcTnYRizmRBCz40EaNlM9p66lPLVy2eWCqhKzyGg6mUcpYRIPgPRQYZSR6ilAur1mx5qzhzLltJ/8WUf5XXgBFQCan6U6OIrlGCXXvaiWtZVOQIqAZUiVICAWnz5Cm3skEpxl/cDh5bNuAJdupKXlK/ScwmoBNSZAtTf/9I2OQwy6fqPr284OgGojCXXJHDOtm+65fxntjyyS+5GhifuufVNe+UJY6iCybkL8hv4+XiM/TpT7uf/cOtpex2KUItH5IUmL9EsXwKqEtjyFCKgetGew7o6pC9IhuA+cApNIsq3wcKHV8+/Q570AmDScpjCp5uMOz4Cqn+TlwioBFSHbn1CcQKqF+05rEswSylMBz0EIYcfQL1p0/YbM2YlBLtQgF/IwDoKHQRNQCWg+jcbmIDq0K0TUL0ozEtdHUBCMugdoapsFZi9vOEjm7bJncpSlxCzDBhyD275n06alFR87NY++5kiVAKqFx9PEaoX7TmsSzCjCDWJOWSfv9kl13XvgxD7BPBexlhN8YjDv4OvyzsJhmb50izf/I5UB5/pxM0TUJ1oy2NZHYyDZNArQnUfERFQJYjqWX/UEuHVYPxIGNaRYVGxmsNAHKEXCm8CTzslZYOcNnbw6OBp2Yx3BTq5A8GMItTcEerxZ+RyCWdb5xFQJRDmGieqr488f0MUY31VLNb3Yvzi+f2iJrbLWvYIAdXN2DKlfJ349OyyFKF60Z7DugRUAqpfQBUCc5hhnGLc2g7G1nCwNQwYcrNZ/FRO+RJQvS0TKjTZjfyVQwdPEapzhXmpQQZKQPULqCqTjVQjXgJq9pi2m4yBf2Arb3tQhOrFx1OE6kV7DusSUAmoBFTBGMudinSzUxJFqP6BnMZQHTr0HMUJqN51qHwHAioBlYBKQE31gvznq1KEGtzEQWVn7bIgAdWl4txUI6ASUAmoBFQCqrr31MFnqksr0+UBX7SXr15fWzoYqA4yyFbxQ44b79z+X2xd6DwAK8GwDxDD6Z8ntxTMt2GD+2Uz/qX6yhsReVuHSilf/+yAUr7eYUhA9a5D5Tv44cCVH5anIMng7wdOPlASUJ07etUx1NXmrsvjCM2rMUZ2VRrDFSuMw1eHER8MgR+jZTPOdoaiWb5ePerE+gRUf/VZ8G4Es+mX8iWgenXgahHqusiTt1SzkXAdG+wYQ2RhJUaaBWP7EggjjNgKC0ZPCKKDgOq1PWiWrxckEFC9aM9hXQLqzAGq/PIHsJwZbLcAe4cJ8QEI1IKJ12nvWOezfCVQ64zBSB0bOjaC6IIKjM4WYHsJqM4zAYU3vCCgOnTrE4oTUL1oz2FdAurMAmq+5SEEVAIqzfJVc546+Ew1SVOlCKhOtOWxrA7GQTJ4G0NNHeCd+OPxu7ArABYqvpk97R2be+9Y9ZQvRajsJTc7Yalu8EGTkjw6eAKqdwU6uQPBbOpHqCmgWrfbgLom9e/86woLOTSa5UtApdNm8ntRHXymEx9PEaoTbXksq4NxkAx+RKgEVLcfEIUirEKzfGkM1etkI9WxVhpD9eLmCahetOewLsGMItRsEFGEShEqRagUoSqjhDZ28BYRKStasSBB3Xl73Lhx21oBvDtV06gGxJWA6HQ2NkVjqDSGinaVQw3Ku9EGRaiKrjRnMYpQvWjPYV2C2dSMUCVQAcg/EALVKrN3VSePUIQaXIR6VXjnFUIY82qNwT1jPMQO8MUrAH68g89/MR/Yrruw6Y4dbx5/DhCHw0y0j4nQ5bLdLZi/dXO+qqod2MsRUJ1/9Dp0xYEVJ6AGptrJNyagElAp5etuL183Y6gSqCvMQytrMdQ5gkr8Ln5+a4+of6cQUG84v+qO5gM/POzXgeUEVG8OVgef6eQNCKhOtOWxrA7GQTKoff3e9D8emH22ZMi4Wgh+dTJCZfLKvY7STQRDEWqwESoBFe3OhiYo5evFzRNQvWjPYV2C2dSJUPNtKegm4qBlM+MHeJdylsoEGYwAACAASURBVG+QEWoUoyEO43LZtgbjh+MidLkAwH1IDVPKV+2j16H7LUlxAmpJ1KwPSAjqap2VgFqqZRq5I1R5isw1odc+GDVip6owejqE2KURFjcNYFehrQfHROS8UUQSlmCvMoZz6thwC4N1cEhUx/1M+RY65UaCvBZDi2qN4QOjiGB3YmnbmAgdKZRqpjHU3I5YB3/lBBEEVCfa8lhWB+MgGQioei3TyA/U6yPP35AZy4zDXGXCQjGg5itXCKgSgE2sf0kdGzxU37L4w+bJ108BvK/QZvvFgOo01UxAJaAq4YWWzag5cCVl+lCIgKrWHhShlj9CLSVQMwCMzl5yVeLUgf5ip9dkA3V/YtGSAVTFenjjzxebxy5uNU4srWQjx1QjYwIqAVXJvRNQ1Ry4kjJ9KERAHVfifz7/mvjHR/dcm63WJ+75+LME1OkN1Co2eoVs9xD4K5eab71rqXl0hTzJJjz7nCvcANVNZJxvEhuNoerlM524XUr5OtGWx7IEM33GkqUkTz63U3zz8XfuzmrWHY9t3bCDgDq9gZpvGU64aekaAio7+ejW9feTv3Lu8AmoznXmugYZKAGV1qGqrUPNTqn6PYZKQM33wUTLZlw7eDptxovqnNcloBJQCagE1FQvyH86EaV8KeWbly40hqqXcRDUx9uDUr6pDSrK68DLM8uXIlSKUJ2HRMVrUMq3uI58K0EwowiVItTyRKgJhLE/sWDBkKg8NCIq31gVOnBdNRsOV7LYIfu6VhpDpZSvF4dPQPWiPYd1CailB6o8ENzg1ruym+rxezY8ThHqzIlQJVDDiK3ILIfJNyZLQCWgOnTrE4oTUL1oz2FdAmp5gGoK+4Hg4w6DgEpAzd4ogoBKQHXo1gmoXhTmpS4BtfRA/dbnv3zeKI981d5uUST6P/evX/tTAioBlYCanYInoHrx8RShetGew7oE1PIAdc7o0L/YmypuhLpu+fY31hNQCahOgLrK2H9pnIXnV2HkrVpjqGKVuf+9ERYbCIN30cYODp2hYnEdfKaiqMliBFQn2vJYVgfj0F2G4+vWNVuG8dFsVS948MH/5Ub9MkJVAWry4HAwA0K8gLD5grD4p5hAI5gYcHMsm+qpNHR8W2lm+foxhmo/vYYzM6wyJktbD7rpteN1dPBXTt6AgOpEWx7L6mAcQcvQuf6WqzJqYmBz5b8FeDuzjFOZn49s3Xr4L/7tpduy1ZkwzF98d//DSJjsdvvvDMZOtm578H436ncEVB/POSWgjoNS9YPkXctnb35pX88zcvN+vzd2cAvUmAifNyrCFmfmq0LgnFo21GIwfkD1fgRUN72WgJpXa7QOVS/jCBqoR9bfejsDmlMgledgiiUQeAmMDac0wXfEvn7Pr/783176AliqXOaymHkfAdU5iFSBpefesXpHqF53aJLg3ZtY0jogKg8OiprXunjzhfLMnF5Rt0PP9qAxVC+fABShetGew7pBw0xFnKBlKBVQ5XIYE2JN9js/tuXjT9h/RhFqcUDPhI0dVCPK7Fm+fgDVnhp+MX7x/H5RE9tlLXuEgFrcYwXtr4pL4KwEAdWZvjyV1sE4gpbBDVDnx8/USMVedabje+8b3A/GrU/L/zOGQfl3rpRvEqh5lsN0feIT1ZmGejbaujIqxv4h+X8B3pgYbuLM6F0y2n3vnpv/y6OPvnx428lQXcegGWGMUr4Ft8RjQDtQHNBuy+mY8iWgtgXOiEJONWh/5cmh56gcuLIo5Usp32Ip32sGDi1ZOdK95Nyx7peqrRgDxBoB0c5gtENgDWMQTIiXMpo0OP7lM8vWIR9Qj65fvxbga2X5HrOquStSc4MFo89iZp8JvjzKrURIJH7Tfe7F63d2jb51INr0zJARHiGgJr86XvaaQiagRhdUYHS2ANubHRlThOoMYQTULH0RUHMDVc5mTRj4Q7u6DMOIu518o2qmQRuomwjVDlQhWDQqEqsFY0e4YEciwlrNU+dWvpB5x5Al7nML1AQzVxlCjmJhV+/Cpdfu6k0cbo82PVZKoMrZorPYmcW1xuCh6nmrrn/2sPHOCMKHO/j8F4OMAPVMMY5HvB9b3L25tuvX7dXGYCeDGQpj7NwEjFMhiA6/I0XVnZL8fu7LiQta+3lNbA9f+hMLxmIh2GII/M6CwTMfdOVNwdMYqqovzVWOIlQv2nNY1w6zJFB9nM2qKoqOQL18sOOKFaPdixqt0QOcIZKAsTrBjH5TiI6IsJZFRCIe4YnnMu+4q2L+3/3fplWn3ESougB1hXloZS2GOqOzl1zV233iVJyFugB2YGfivHNiIow91jk/UY0Uk4BG/5I6c+jgqIiwtxLLzxkRkXZVQJfXgWcB9cRzh6VeVJelqI6NqpYLegzVDuj91qKGo1ZLw36++LEBXnU2Q1Le9iCgqvpSAqoXTflQl4AqlTh5lq8E6tKx0yurrbFOYbBwiPMVnLEeCVQ7ADNN0BWq/9PpBFSVA60LLcOxr48cQSV+Fz+/tUfUv0NAzZ96LVeESkB15kiDDgCcSVO8tJsINQqgG8CT6dvvAfCVfI+ilO+4Zg6+8IIw//7vz0//pJEZbIP8N2NJfeacfFO8CZ2VCNpA3aR8/QbqDz636S9mx4c/KDUTg1FjMHF+ghm92YAuZ8rXHqESUFNjt8mUL0WoZT5OjyJUZx51Ymk3QF0J4GtAcvwvUezhBNRxDR36xS9E6Dvfujv9k+oJk28IqEUj1MORWQ0nIjW1B6JNPxkwosOAuBIMx1KTYMYdgQRqfWL0D+TP4oZRlS/incpAPcfoSE66qmQjby4xj128wDixtJKNHJt6GwlQypdSvvkpEnQAUIxfTn/vBqg3AngAQC2AlwHcCeBXFKEWV70OQH39rXfEl3/0xgeypX10661PF3+D4iWCjFAlUDsitQ35JhExIYTcZeeywSNXLo3JFHLsWKEU8lQGar4DsuVYIYNYZgmj2wA/8nLiooWDojKh77pHAioBdWYDVTrj1QC+CeDjADYBkFGr2LJly12Msc3Z6lm3bl1xTzwDShgHD4IdOph601gMRmcHxKxZEA2zUj+rroF1xRWBamJwJI7ndp2c8IyayjCuWTXHl+eaL74ADA0l78V6e8H6eiEWLIQIh5M/E0uXgp+zFM+9fQKDo6kER+TIITR0daC+OgLOOaxTvTCqKhGprcZQTx9MCFTMnoUOHkWHFUX18nOS9zvSPYTG2igaayLJf8trUXO18v2GBkfRmzBQMX8u4uEw3hkyUVsdRc38ORPud3pgDKcHY8l7yyvfc1XLVZ96DbMH3zr7vmLgOFi0FuGqerxypgVDRh1qF12MQveb2/FTVIuB5D2GhoYRjp1GqHYu5PxlN/ez60/1PfwuV0gvI30nYTCOaH1LwfedSuUOj9bjyGgdKlovAjcrPNuVH+0h7dtPf+CHU2lrK+9aWCfv4CZCjQCw0n/MdNp3IYCOXA+e6SlfcdddRkYv7VdfZYW+/S2ZLpcDp1XlSPnKCPVLP9qZSTunRAE7+ejW9cp75cp1nozxCQQWgp9cuP2RHeWKUG/q3X1LFY+H5cSmmBlaUGHFmwXYPstgyDvJqanpWnHqVL9cLzhihuOvVba09oYq3zkeqQ90+Yp9EpGc5etmDLVQhDq1duahCJUi1JkdoUpnLPdg/bzc3AbADwG05VPJTAeqHTD80tWbjZ2vPJPe6GDiBgYlGkP1C6iZjRPG253vKDdQa/hYpMaKHRs1QguiPJFcWE9A1X2rOwIqAXVmA3UegKfSkanM2ckU72ME1NwaIKAW3xxfdZZvoTFUGaESUKfizjwEVALqzAZq5u1bAHQVyy9ThDp++spUjlBP3XZbXaatR6zYNULgPenUdYgJXAImDgqwg8mZt4LJmTHpLewIqHIW8ntDL98g9VXLBvfWGCMrm1jfgjCLH87eSEBlazp5P0r55t7az+vORrSxAy2bKca0Qr93M4bq6HkE1OkB1AJjo5P23k0PzGYDlTGBEGPixbE7Nm5/7f4fPR4SopEzYzRmhBZEFMY8p3KEmg+AhYAqx1rPNdvPrcHgsVFWKX4Xu6C1W9TtkRs2EFAJqG73TC68AxcB1RHgsgoTUL1oT6HudEn5+gHUzCQs/v7rPrn7hbfeFmCRODOVxzz9BmrdbH4tegcHGcTRISOSeLliSfNQ2Dy8O7TgyctDb30oFVEOvXOCz27pFfUtA6Lq1/Yt4pw4NLdAzWwAkb0DEgGVgOrE/tT3iCagKrj1vEUIqF60p1CXgHo25Xs2kvUDqDU8xqr52LvCnB+rEPFjK0Z7rqvk8XAFTxxSnZTU0By/tq7/2JjB+KkhVsGfj66oPWVW7X07tPgJO7Dy7bnqxKF5Barc23Z3vG3+GVQdGOC1Oy8PvfGRWmMkXMlGD49A7XQTGfHON0601bGhwyM8itcT5y0+g8oDF1yy5kNPvnosfY5s+U6boZ2SsEYAtFOSza/OhI0dFDAyXoRSvuVP+d6wads1mRb53HUrnv3Wz/d9L5WWFUdUl814jVB7QtXVUSQu44J1mFdd+bEDr+zZx4BwghmHVQFoj1AlUNeeOXBDhMf7KoXVZ9/zV/V+dqAmmGF0i8aGuGH0WCK0J9zQfUHEGA0Z4fhbugDVvhzGyVihIbhgjL09hsiCCowklxPZd1QioI5/kNAYKkWojgBHKV8v6nJeVz1CFUvBWJ/B8NPMU4y4eH3eww8n9/n1ct24cZvcpi65Vd37L5q3+ek3jj8jv4Szt+wr9Aw/gJo5l7RiyaKL+490dWeOUVMFoCpQxwxzQYQnZjNgb8IwYXK+QjDWY2Rttp8N1LCwmgE2zIDTo2G0gFmCGThwPFRXf5Q1Vx0PNfyyHzW93bzhYhO8ow+1b+VLpc01TlQvMzuviSJ2ohKjJ1uM7vdUsrFQmCX22SPKYmOomZSv36evEFDNVWZyGwzsKtQeTj5cct2v0Ck3dNpMca9GEWqWjihCVYxQBdZkJvNkVCjP/SwlUK//5yfkwQeTrp/92UfGphJQaypOL2/kA00ylSsjz7FEVVOCsTNMsI5e3rDYEAKWCL1eCKhxg80LcQEGHD9VbdSx6EhVPIRdg6xqxH6ay8rQofdLhVWLobdPiVnzz4jq+TFEflvNBtn1kedviGKsr4rF+lRPN7HP8rVvAEFAzQ1A1WPZVMtRhEoRanHM5y9BY6hetKdQVzlC1QCo9kjW9mo7Htu6odAOSEqzfGXKt1QRajZQ7ZFnR6KlGcLgMR59xQ+g5htrzQZqxWD0EgMWTAtH+iPh2aHwSJ1lsL2h5nMuzbdTEgE1tsKC0TOdDhin49sUnKatCEWoFKFO0ID+QGVrhBBxMLwAYCnAljJgJyCG0y9CQC0QoaoCte5UxWVhSxgmZ932iHemA/UDkd/cJO2sng3tb5w169Zo/57uEBLtqhGl3+UoQqUI1RnyJ5amCNWL9hTqBgnUZETJMHuCGAI9MqK0/6zwGOr4TjX29WkEVLWULwEVS+QJP4UOQC+07tGuP6um9VpjsCO5t7LfoFS9HwGVgKrg1vMWIaB60Z5CXa9AlY9IhIz19kcZgNW67cH7C6VovQJVOkgAFwPiIGPGgU+cevWqusRo5IKRrkkbNkzY5N+Wuk450tSymZme8lWNUA9brecMisp4r6h7ap7Rc2ELO3lOpTHaoQoE1XK6TEoioLY00NaD+R0ppXwp5etryjcJVJPdPgGojJ0sBVAZS62Lk7OBN5x6fU1jYhjlBKqcDcyBWRbMt+T0zCordgGAXjNr9q6OY6iqQA1yVql9NqvfQJWzmhcZJ6+OsrGuCoyd2G8tPjcuQugUc5+kCDX3WDDN8i0ekRBQCahaAPXGO7fdDoOlZ+2KZRDyRCD2+vsvarlj4rKZ3Cnf7BSeLkBVOUVGB6AuiPdUfWz0lT8I88RohPERC6zVlMtBs2YNZ4+hTmWg2mc1u9mTmFK+tLFDNmIJqARUfYDKksfswR4hzHSgxgxznrAM+b1wmNdUrKgYPpNgED1xZsI+G1h12Yw9ZSmXzJywZtf0o/b5+vhYxZozx95nMitmcgzku1+5gCpTw3ERakvA7KprXbnqmfbkxg/YZS17pPBer7k/wGSESkCdvK6V1qEWj0ILlSCgElAJqFIDWafN+DGGqroBRKEI1Q620cqqxdGRIQtAtx9AtadUWSISmn0aqyDYsCnYGR2Bmtl5qWbusrYdHVX7+kVNjIC6dI19GVOQGQNK+RaHLQGVgOoZqOnJPA0Aezp5MyHeL5joYzDa5X8NhTHUZMqXItTkxg75Ik8CampszwlQZUQeZnGzng0ePcQXzupIzGlsFwt+lr3ullK+xTfvJ6ASUItrgIDqF1CTs2PB5LCbWCMg2gmooQXjY6hgIc6XC4YeU6AjzoxVcgckuZUcRajONkRwCtQ6YzBSx4aO2YFAQHW+k9MZUT2vy2qu7RV1zw2LirEO3rLKZPzYpZdcdFP5DiugZTOOIWerQMtmvGhPoa6bZTP25SaqQBUC1QzsQkDsFwbbz1IHgFcCE08PmS5jqJHwaGg+61oFJoZDEGeOWXObIRiP88jO6kjfsllisNFg/HScGYwi1MJjewTU8myOH+Ssa7frglOjNezko1vX369DulUHGRTc/NkiBFQn2nJRtqRAtS1zybdp+3QFqn2McjhkNlYmElXFxkbLlfIdiJizWHS0ImHgAGtacF5s6PAAF0YvM/ihIMfs8h3zRkAloOY6LEMHmOkggxO3T0B1oi0XZQmo/m3sYJ+UlB2h6gZUIxEJNeWZlGQHfqxhVsuQcWIsYeIUTLGPgDpzdkqiCLW4QyWg0hhqWcZQkylfilCTp8OUK0INDVYsrx/mTUywUwmYeSdDTSWgyuUwlUhcbrJ4ZxSxztXh3R+qxnCkio210xiqs7HqQpv8Z2+0UfvWd96OsIRRxwaPHuQLGjusubMO89YnB3jViEo/p5RvcVgHUYIi1CC0arvndIxQ36lovqLOGp0XY8ZeU25dxEdXjDDzeLM1/CIC3HpQhwg1boQSZ3j1OTEW6hSc7W/E0BVRjIVChrXXHKxYVj/CGxk3Co7dTjWg5juGjoAaLFBzTf4ioAbssD3enoDqUYHFqusG1OvPrb9j6OVXd0d5orsSVvfuijlt8qiZ9orG/yi0oP+m3t231PIxVm+NHBlGeEkU1hwLxoEKkYjPiQ+0MiHemQlABQ8jaiWWcWH0meBdFYOR88MczOA4qRoZ6wjUfccGjg6jMj4gap4+yRvn9YraecOi8oVC57oSUAmoxfyf199TypdSvlqnfCVQa3/z7OEIj/dVCqtvZ3Xr/H4zGttXMbvgDjkSqDV8LFJjxY7ZI8WZCNR8GzZMZaAOnDjYbSI1G7gQKPOd50nLZpwvmyk0hipTvhShAgTUGQ7U4+vWNSOMczJq4AK3cM5mgaGTX7p6s7HzlWdyri/Nkyp1tGxGYQyVgDp+LJubWb4yQiWgFgevfWOHlebBS+IiPL+ajb4Zg8FO8OYLTFidPWLW6zP5tBkCavH4lYA6A4F6dP36tQL8cvnqAqhhEFcB4lhyIwYbKKcSUOfEB6vPHznxvrBI9FTyRHcNj70raiVCJvgeilBzbynoR4SagLkqBEvujrU76XDZWBNg7I0jhMxWgYUmt6ge32YvJ5fNBBmhXhXeecUK89DKWgx1cmaG873HTNscP3sZE4NYZgmju2be8hUjXXtPmIgb2RkDGkMtDuFylqAxVB+0L4EK8LXpW1XnOx90qgF17ZkDN2RSwwlmrjJEKjIpF1DlDkh11kijyazuuMGMShGfC7ARBpwu1bKZoCPUfMe8yclQugH1gLWo4ag1t+GgWPh4NUbYhyLPfySKsb5KFus7xpvbhkVlfAjVO2ahf9Uco2dxhMWOFgL+TAeqfW9l+weOBO9Jq6lmSFS9MCQqYgethecaLNHVwee/mG+9Oc3y9cGxu7gFATVLaYNb5n04W49CiFdq/7qrO59+CailmZSkuqWgaqSoY8p3KgE130YRbiNoAur43srZQK1Aam9g+/IaAqoL4gVchYCapeChr7fIw7yTx56dHQdluC8bqEf/8NaPnC0gxEUQuBACnZPGPH1O+W5rumTNgBGN7aya94IQrA1MLGXM2Jn9RVrF41dI+UzOX71wtGvNGMyWGh7bu6Bt3kfNXbtPhGANyoO5801KkilfNxHqoBG5RhqVBeO1sEgsDEMsiDHj1WEWZl2RmhssGH0VSxZd3H+kqztXxGsZDCHOV3DGepwcHE4RavHN2AvtlOQm5UtA9W+Wb6EUfL6xVgJqwHR0cXsCqkug2pfDFNx7NwCgnjar8FbV3JeLLXPJOSu3de6asc6u/gyw/AbqW5VzbxFgkTgzj9UnRhpq+VhDDY89RkAdnwxVaNkMRagzc6ckAmpuetGkpCkwKWlkS8tai7OoXVTBxVjtV7p2qEao5QLqK9ULbh5mYQwY0YPHInXN3aGq5p5wzdNDRnjCDip5l7mUEKhVPN7YYI3WR3ns5zEjhB6z+kMJZvZXLFlw4VSKUCUAQ0a8QjB0JmCiKiZaITDqduyWgJo7sqOUL6V8s7FKQJ0iQOUcmUlESYk5x46pAFR7BHg4MquhI1Lb0B5tekxHoOY7ELxu0fy2qQZUlc32VcduCagEVDm5TzUFTynftsAzqS6yuzmrBC7o1q1bxcaNGwN/TiGFZH/lyAjVK1C7/vi6fxJWqF4+V1jhFm6ZLULgefDwSJCzfAmoA00G4wUPDlcFm+qkJNX7uSmXvTk+pXwp5Zu9jImASkA9y7fpCtSTf3rtg5wbc5PRbSLSIOLhBm6FHyOgjo+hUoRqNQNsuFBqmIA6vsMQpXwp5Usp3yKx8kwA6n4sXBBLRJtGWMU7piXicxODC4TA3uy9bf1Yh+p3hCrXl44ZZkKA7RwwI6094er6fqPi+QpYWDV84n0Rbp0JCeuk6jpUu3x+ALWlovMyuQG/icSJMdNoruJxec5pT5yZyHdwuGqkSBFqbgeuuvUgzfKlWb5+pUrz3YfGUGfIGKo9QpVAHbEqZ4+K6N6QQN7N4u1A7QlVVxvAuxNgxy2DHau1xs6XefFqHn+q0KzhIIDqdPlKoY0dggBqhCeMEOPdqqBULUdAJaBmj2WGm5auSZw60G/B6HG7ntbrhwalfMchQkAloCoDNbMu02JmX0vizHxT8Njc+FB6k/rUwdzZ61oJqAkZoXZThOptM3Y/th70Co5sYFHKl1K+lPKd4ilfwVDNgCbOxWshw9gpGP4fIUQDBI4U2tjBjwiVgDp5K8PsjR1kync6R6iJ2oaWMfTELMb6GOOHo0Pjx8GdqjbqWHSkKh7CLh23HiSgUsqXUr4TNRD47Fvdx1AlUJMb2Au0M4Z2MKxJqkjgZQJq7h2LKOVbfLKRagQtgRoa6LNyTV4ioAYDrEKpXEr5Agzs5KNb19+vQ7pVBxmcfDQQUBWBWnN83Rm7Yrvjb/4Igs3hAsLtGOp0iFBrzQEssE4vMZjVUSeG97zJll7FwcKjomKvX5OSpnuESkBNZSoo5UspX0r5ToOUr0qEOrjzGiRMJvf5TV7h2lO3MLCIYNaxmQ7Uc1jnChO8pwJjHW/yZauEMDEiKiecSmNP5TrZ2GEmpHwJqARU2nowN0goQp1ik5JUU74E1NzHt8kIlYAqwIDjqrOL7eV0TPmmjgtrrBkUVS+GYWGReeyKEIsPBj3rlSLU4hGqBO/ueNv8M6g6cEbUvHaSN14kP2D7UfNMob291Y95o5SvkxRvdllK+SqmfAmoBFS/ZhdPBaBmjgtzc2C5W/ASUNWAaj8X98X4xfP7RU1sl7UsvToASwD2Ep2H6gWL7usSUAsBlWGJEFhiAC8lYpVs+PiSNTxW0W6N1rZTyjeRPJ+RItTcp8j4MSlJgtcIxSq4IY6MsZBlVY62csb6YYp9cQS3bMbv2buq9yOgElBpDHUaj6G+lVh+BWdsRUxEjxpxgzWcii7g8ejexkH24lQFal1r3Zpw16EhwXAmBKvnFG9YZAogIcKv5ZtElH0uaVW0b1koYdQziKOVbBgtrHchY1Z/hFv7aQzV2TrZQilfeyQ7Zhp8uH60KWHilB9AZYlIaNYZrBQCQ5H65tk91slBw0jACotXVAHodzkCKgGVgDrFgXrCamquMYcvtYTRIWAercToJRxABYs9J4EaR2hlTIQ7zUQIjacirTwefqcQUMeMMMKcL0+eNwreMTc+0JrZsCF7p6RyzPKVQG3sfmMMTAyHIM50JFqaIQwe49FXVIFaU3F6eSNPbVIfYQnUWKNNguFUhFv7CKhTB6izT2MVBBsO1TXOOsl6hg0zwQmoeu+UlJ2Cp5Sv+/RsEDVnfMpXAvWYmHNDAkafhXBfq9E1PwQrNs/ofsQtUEN8fP2mfQckv4EqAciBWZyF3hxmofjblXMWD5nhg8cj9S/mOw+VgDqeotVh68FyRqgE1NTsYnukrfs6VAJqEBj0754zEqj/5+51f77cPHiJVOMQr6wfFRVXjiE8aEJ0RtnYsgrE4hEWe6abN64yYS2KI3SkOpHA/F6+nHGjpzLBj8KwzhecMQG2y75sRkaopQRqlKfGMoXJDYNjmWDoMYCOhDBWhYSQrzhh+QoBlYAq7UWmfAmoBNTJk5dolq8XvM4YoP75t393Q0ZRHwo/9wdLjI4rIogNcGaG7bPm8k32kA5o8emxZRCsL2zxExEWb4MADIE3dABqJDwams+6VhVL5QYN1E6z6RLOTWYJ8+gp1DfBMuoSCO2Js1Ai86FB61DNxsyB5bpEqGdip0aZwQUM7B4IheeEQyMNFmP7gtzykPbyjS7INZu60Ob4FKF6wV3wdb0AtRrAiDwOtJCYumw9+OYP/+ePx0S0VspqCNFWZw62GLAOqi4LsH/Rm4KdMZk1NyS4MITYf5TPmR23KutGENlrB4eczHOO9W6mOwAAIABJREFUOH6OIRBvxMBTVtvFf4Ldu18B8GIPq2f2MdSoSLRFuRWvEIkdVVa8JSpi8xjw6yoen3Bgeb7TXHQB6slQ3WWGEIaA0d3FZ9dZVrhqTER2qQJVvgdLsDYBnDYgjjdFey4Ki4QRAj/pZp1nodm2lPIdH0ONDfTFQjy1nrZUWx4SUAmoxRA3EzZ2mA3gAQAJAIsBfAPA9/MpplxAFX/X0jwi8Ckp15lLPn/v3t898wZjojImIsfczE7MBmrcGE8d5gOHBOp5oX2rTHBUY2SX1bT0WnScOCwPIs8Gqv280frESEMtH2uo4bHHhlmYhWGt4czojMM8dixS90EGhC2wdvskomygHrfmNEMwHuOR16qjfW1mwqxjjB8zm2Ytr+49EmcQo/Lga78nJfkBVHukbdczAdXfWb72lC8BdTQ5dEJjqJTyLQb5Qr93E6FuBCAjvS8BaAFwXB7jCWA414PKCdRhgeRWgYMXfGbzvtdffFsAkXICtX3WRdeiu69nRFTsHEYFLMYuTTCjP3tZSjZQ7ZFsvoO+s4GaD0TZKUavQE0ww6jhY00cGAgBx4bMSJvJuQGwLrcRKgF18s5LQSybIaBO3zHUOfHB6msHDnwkyhN9UZHo21nV2jpgRmP7KmYX2QCCgFpqoH4bwFMAtkPqPpXybQNwUCeg/uDLnzjv3RVv/kUyxdt23eeO7n39IIMIc5gHVSPU0GDF8iji9eCs0xJhs2aUL2KCJSM7NxFq96wF1470JoYsmJ3DiGLUqmrlTPRzHt5XKELVAajJPXWFxUxY3SMhs6nKSlQKgZ5CKVUCavFTaXQZQ6UIdXpFqBKoa88cuCHC432VwurbWd06v5+A6oWVSnXdRKgPAZB/Hkk/4QSAdwNo1wmo//kXt11tVA39uZSpZsnF64YOvt4h/y0MvMC5eb4Jq04wtk9YBgzDWs6BM8zA24zjyky58Gjo0sqE1cC4cTzODIR5YgkMYxBCHIQQFyXfl7E3BkX1IsuKVMYRfgMszrgVXg6GM0ywtxcbncn7VZsjL/Q1Ll4n+np6EsJM3m84XjdPnoNpWeGdAiJZjoG9UMWGl1VYoqISsZdipmD9vG6NZbARS5gH7OVgYpWwRL1hYK98bqMxeKEAHzGZdcQuX5wZS8PcqgEz2tE870Kc7BzIvEd/Yta58rkxHvlV9v3s79EUPv2+5McJi++x36+QXvpF7UKeCFfFWeQ1hgQDN1cIhv66c8+94Mw77yTbQ76vm/co9FxV+URN/dVsoG9A6sWP+6k+t1B75Gs3KV+sIj6fG0YvN/lOu52q2nN2ufpRfqHgbCQ6f8nCeOehgYw9D4XZIoSsqkSIvVGof7h9bt7+Vjd/XaLvWEexfun3c+33q5q7/H0jXXs7cvmDIJ9r13Pt0otXqfqrjsT8C2S79fKGn1Ri9LIRRGsrhLU/KsZYw4i1xhTWaJhj//GK6mS5M5HIhHIw47EhVJ1riPhgnEVeyvjwO+/927t1GL/UQQYlkqYLuQHqV2W7APhHAKZsSwANMlLdsmXLXYyxzdkCrFu3zolMvpRlQ0MwXnzh7L1YR0cqnF6wAKy3F6yvF2LBQgghYHR2QMyaBdEwC/Zymcr8iishqmVWO/cVOfkqIid3pvxRYhTh07thVc+DVd2Cp7uacEbUIN543tnK15w/F3VsAFX7fnL2Z7KOvGS5zu5exPq7YVU2IwQLs8f2w6hrRdXshcl7Z8qZQ8dhDnUh3nQehFmR/HlszmrE5lyqrMOqff8bxlhfsrz9fnIGs/095O95dBaGl39U+d6h/oNgIjVnzYidQcWRX0IwlryP3++hLNQULeiHPU+w+3A4qQmxdCn4OUsnaMU4eBDsUDrhFIvl7R+q/YjK5fYvfugleuh5wLIg6upgDPUAQyMQjXOAEBBhhyCa5sKa1wb2+p5kG1tVLTD6u4GBIfCGyeXc9POgu1RbW5sbTgUtVs77uxH0ZgBfAPBBAJKUXwRSUV2uq1xjqMfXrWvOHLdmvf8Dm81f/vKJpHwML6dOZRBLIPASGGOAWCMg2hmM9uRRbulymfcJWeK+eQ8/3J3vHUe2tKzlHGuTDiprb+Bvj96ypkfMws7Eqpc/vLp185Ovdt5tMfO+J2r/DJkx3vTzzh5sPsIql5kisZiDvWIkv1oSlwlmHA6JxP4JB6Db9hoW6TFszrGj9itdO/LJmv3FN/T1FjnO3JyW4ezexZyBTTjWLklFnKze1HW/G0uVk8TsY9o1b3831R7yIHcX7+FGhuw6Onz9qsqQtOfUnIWU2hhbbzAxSzB2UtqzAbEAAi/CMADBr+AQHdn2nGX36TkPfEfs6/f8yu60jq5fvxbgSXtOzY/I3T9U+5FqOfvGJ4X6per93JSzrnnvHebzzz6Tyx+4uZ+b9+Dvv+6Tqv7KvgWqYfAFghuzBcReI2TFw3U9rUY49k6oYuhFu98Y659zhTVUu5JboU5mcEwoZ+vnqrbpR19U9VdBPsuPe7sBaiUA6QxXAZD/vg7Ab/MJU06gCsNIhmpjn/70z0Pf/+59AOoBHFDtGOUCqh0wk8DG0sB3CaJyAnVUCGkr6L3yrh/Xv3C3nBleB+BNAqrzL/Aj62+9nWU+hNKGKj/85D/t5/baPxAJqMU/DAio4x/OBFTniHUD1MxTFgLoklnKQo8tF1DtMknDCH9p0xcyDshvoIp7m89GDuBm04iFT6eCLwy6iVCnI1Cz26Nl+9UyyzEpMlaNtJ2b+uQaU9lhEFCLZ5hU+7m9HAGVgOrFt3gBqtJzZwJQ7Yqwpzblz/MCtfmLg/Z6I6PWnwjBZ8tRWAIqUCx1rWR8RQpNZaAeXb/us9mvF7LwU4pQx4dsCKiU8vXDTzi5x4wFKoBICOIxK6WtGwRE3O0Yqhug/mzLrRPGZJXHMkuU8s28U4Lz3zDT+HXm/7V/3ZV3LFnV8CTIJkWoYBFwPM4M3i/vwy02WGgsWPVZhcpNZaDmey/73IFkGducAEr5UspXzlmgMVQ/vEfue8xIoGZUUWzMyV6u0KSk6QjUIFOvk4CaViBnuM8PYKt2l+kK1LjJbrXp4L1MoEZOxstnz9l6oElJNClJTj6cjv1D1Te4LUdALTCJg4AaTOqVgDreXYN2WvnGWu0fiATU8Vn/U28MtfejsBhgWO3MTCwFjBYhxEGa5esWid7qEVCDACpjH8s0yzeHb7t2kFfV7rTO+5192YzuKV+KUL11LNXaBNTxMU9aNpNKSTtZNmNP6Ydqeq9g4CuZwTtZKDFxOYxtqEimfHkitJhZ4QMcFovU9C+FwQ8nl9fIK708LmjbVOkjOsigImemzIwBasWXN8p1sxMuI4HX5A/yLTNwE6FmP+PGO7fdDpaazUpATWmHIlSKUHOt8ySglgaoBSc9ElCd8HNS2RkD1Hy7bRSaxEFADS7lq8PuJzp8/QYtA6V8nS2vmWopXzcRKgHVEzMLViag2nZUSmrKxU5JhTRMEepk7QQNEdXuooMcQctAQCWgZu+UREBV9RDOyxFQZzhQ7SZj30Ix8/Mg1oMGDRHVbqCDHEHLQECdWUA1jEQbTOuIGYojXNu7CGb8AAFV1SN4L0dAJaCetSICqvcO5fQOBNSpOylJCCwDw24DYjcX7PcYE7UAe8PNhhL2PX/dTkqKNh1fEq7uXRKu7nsJ4cTEvbjzrF8vtGd30Lap0ld0kEFFzkwZAuoUByoDFgN4SYjUAe+c4xknm+NThOp8H10nHaxY2aAdBkWogUWoZw8XWLj9kR12PRNQi1m9+u+D7h/qkqiVJKBOZaCm29jJhgiFDJQiVLVO42epoB0GAZWAyhja851SRRGqn71ZHmYW8KXLXr7lnOUrGGqkmm9+18KtP33p6EbOzO/6sg6VgOrJeoOGmYpwQcvQcdttC7LlMGOxMdrYIfeevw5m+VKEqmLgHssE3T88ijepOgF13bpmbhgfyGhGQHxQyGPFGN7K/KzYeaiqjVLIOFzt5UtAVVV9znI6dFYdZZBbD3LwtfIsXjBWBcHlhgOHi5yvmvdcYdUU6BRbh0pA9dT71Crr0D/UJE2VmvFAzVaWSorMiYLtZQmoKW3o0kl0kEN3GRxstq8JUEUTGDsFI/RjiMS7wfEuQIyqHvStTYT69FP/AbABIdjTDGIlIM4FsLfQe9CkJLee2b96BNQsXc5koA78zbzzcplW7VeO7/bP5Aioqh9Zfuq80L0KQX3KAVXunMfYydZtD97vZpN/t0A9um5d49ksl4n3MMGuTocsBlD8lJtJs3yf/uXdTt/DCI9F5TOra059q2LFPvAR/Ff5fyHYGI2hlqY3EVAJqKWxNNtTdIjKdImUddAFAdXV5vgTUr72TuQG5H4ANSODHKJqufQ5DAvcflYuWjZTEj9HQCWglsTQdIvKCKjjLUJAVQbqXKk1ZontiOB0RoMLf/zwmwTUYNyIDh+cTt6MgKojUIFk+igh8KNwGIAlbkunbnonpG7Ssvu1bMaJ4Xgpq0sn0UEO3WUomvIVaBECz8sJTILhPYLxLreTlwpPShJRZhjd0crqb42ODl7DON6T7BNAeEJKNcCUrz0CLHQ+MkWoXrzDxLo69A8nb0NA1ROoSakkKOV6m7ypGwKqE1ufVFaHzqq7DLmAygALEL/NKNTk+LfkB6DJxlOMtj2xfZnlqwrKrHJMiOSSNQHUg4kbBHisEPALjaESUD11N1eVdegfTgQnoE4xoDKGJgGctizjgYzozOSna/+6q1ul4XUwUB1kkLrSQQ7dZZBAtQxjbbZtLXjwwYftPysayaL4BgvWVVdvNn/9/D8ZMH6QgqD4RPJvhn75t9IkHVs5N/LpClQBfr58HwbUQOC9gvHu7A8DO/BpDFXFG/pfhoA6xYCaFDd9ALAbc9Ddgbt5J7d1SBcpzfmhB1+A+v4PbDaf/uXdclLNpIh3KgF1w4aLztqkEI0C/ONpGJ6wn2aVL3JP7uVrm+Wr+mFAQHXrCfyrR0AloPpnTYp38sOBKz6qYDEd5JguMhBQc5tatl4YEDYY6zZCkW/xROIaLqxrUtE4IpmxYALquC516B9OfA0BdQoAddBis7Mb1e3aUB0MVAcZ/IrMnHS2XGV10IUfMiTBYeBT4+/IroKEBMPLqmOo1jSJUAtGlAqRNgGVgJrXr+i+l2+24J3rP3Zp9s8My+goNKtP1akq75SUvqGT2bt+yKB6D6/l/HDgXmUgoAbrtJRPX4FYCsb6DIafxj752V9E/v071xlx8bqUbsIkJwUQJccUNRhDJaD60TtT99DFV6i+EUWoqpryoRwBVa9OokNnna4yqAN1fLKRXReTUsh+AxVinsGM0+B4mINfDuAyAP1+TEoioPrgLNO30KF/OHkbAqoTbXksS0AloGabkA4OIwgZ9Adq7lnD1nuu2Ww+/+wzAqK90Cxa1YyVmw8DSvkGmz3x6MYLViegBqndrHsTUAmoBFQ2cRN9W+Rp7x/dN99cm6trNv/0pwM5Nk44j0HsBYy9mToLtj/0r24ixekMVMbEGOfsBQbRBmApA3uNzkP1FwAEVH/1WfBuxYBqGKkdkjJXQuBfVdeXqr5GENGI6rMz5XSQQcqigxzTVQavEWohm8oCaroo37Fw+yM78tVTjRT9Bmrvpz7VkEumWd//fl++HZX8ilBHGaqzn125qat9ZEvLWs6RXFssZBm5CYdAe/Igcnmll+VNV9t06q+clCegOtGWx7JkoBShUoSqFqFOF6A6eI9qP5fNFEpJE1A9OvIC1Qmowel20p0JqARUAmr5gJpvxyd7pOh3hEpA9eZgdfCZTt6AgOpEWx7L6mAcJMN4I5IugvvACTrlKzifkEplBu8rlPJVBRsBlVK+Xtw8AdWL9hzWJQcenAN32BTJ4tQewbVHkEB109YE1HENUMrXbwsavx8BNTjdUso3j251ABkBNdhIfcoC9Zr3bjafffZeg4lfi0ji1yJufhbcaALDSEZjcq9h1WUzqiAH5AQisUYu13E2KUkweWjA/JWr/sX+LHbXXTzfswmowTl9AmpwuiWgElCLWpcOHxdByDBlgZre/hBIzRq2v4eWQM2zM1Qhw0sDNXV6jYEaIU+v4eimWb5Fu2vRAgTUoiryr0AQjsupdCRDsJEZtUdKA1MKqOvWLcu0W/yOO/aFv/GN5fL/Cx9+eP/RDbd+LLtNQwnxrDYRqgug2t9H/F1L84TzluUvadmM0258tjwB1bXqnFckmKV0poMedJFDB10EIYMEqsFQJ/Us5CYCQpwjBF4F8z7L13nPU68RhC7yPV3OLhacR5O/F6KBmexGAW4VSvkeXbeuMtf9Fj788NmUtPrbAimgss9NqGOI3upNXfeXUhf5ZNZBBif6JKA60ZbHsjoYB8lAEWq2GQdtE/k2MMjezD5oOVS6b7lksG88kTl1J3OguorcQZQply7s76KDDE50S0B1oi2PZXUwDpKBgFoWoDLeJJ9rgNUJIT7MwUcIqOMtQUDN7Vx18FdO3D4B1Ym2PJbVwThIBgJqqYFqf16hLQBnsm0SUAmoSniZauehKr2Uy0Iz2WHomMah9ki1Sin1QEDN7TwIqARUJawQUCkiKmdEVMhISwmSfHLMNBkIqPmBGjLNsPztwJ13dtbec0+r/Hfz9u3HlBxtAIVmmm36oUJK+fqhRcV7kIGWPiIioBY3zlLaJQFVr/ag/lG8PZyUIKA60ZbHsqV0XBQRFW8sao/Sf+AQUKeGXZZ6KEBnf1W8xcZLEFCdaMtjWXLgpXfg9AVe3GhLaZcSqNxkN2VL1br9oe+WUg6dHbgOeiCgFu83uUoQUN3pzVUtHToKyTDedKQL+sDJ7shkE9Q/XDn3dCUCqhftOaxLnZUcODnw/J2G+gf1Dx37hxM3T0B1oi2PZclhkMPQ0WHoYJeUYtQrMqT2cOfsCaju9Oaqlg6Oi2TQy3FRe1B76PiRRUB15eJBQHWnN1e1yHlShKqj89TBLsmB6/VhQe3hysW7Aqo8HaEbwJPpR+4B8JV8j6eNHfTqKDo4Tx1kIIehl11Se1B75GKILr5CFa9uItSVAL4G4A8BJIo9iICqV0fRwUB1kIEcuF52Se1B7TFTgXojgAcA1AJ4GcCdAH5FEWqxT4vS7pmaTxodYKaDDOTAyYHr6sCpf+hnm8W9e6qESoQ6G8DW9A1/AEDuN7kawDcBfBzAJgAyahVbtmy5izG2Ofvh69atU5WHypEGSAOkAdIAaeCsBtra2lQ4pYXGVAStB/CZtLS/BPAOACv9x0ynfRcC6Mj1RpTy1etrS4evXx1koAhVL7uk9qD20DVj4ITUKkDNvt/d8hAEAJ8HcBWAHwJoo5RvcbXrABKSQS/HRe1B7ZHtOXSwCfrAKe7Pc5VwA9R5AJ5KR6ZyUpJM8T5GQC3eADp0FJKBHDg58Px9lfoH9Y/injx/CTdAzdytBUBXsYdTypcMlBw4OfBifoIiIr38BLWHisVOLuMFqEpPJKDq1VHoC5zagz5w6ANHxXmTr1DR0sQyBFTnOnNdgww0pTod9KCLHDroQgcZqD30+tCj9nDn5gmo7vTmqpYOjotk0MtxUXtQe1DGQO+MgRNnT0B1oi2PZcl5UoSqo/PUwS4pItLrw4Law52zJ6C605urWjo4LpJBL8dF7UHtoeNHFgHVlYtX2inJ3Z3TtWhSEjkMchh6p7R0gDo5cL38BLWHO+xRhOpOb65q6eC4SAa9HBe1B7UHfXDq/cHpxNkHDtR//ud/FsPDw05korKkAdIAaYA0QBrAnDlz8JnPfCZwTvml6sAF1SHlq4MMssF0kINkGO86pIuULnTQgy5y6KALHWSg9nCHWAKqO725qqVDRyEZCKjZxquDTZAD18suqT1cufiZMSmJHIZenZXag9ojl7vSwS5IBrJNdyhN1aII1Yv2HNalzkopRh2jQx3skiIivUBG7eHQuaeLBw5Ueej4pk2b7nInnj+1dJBBvokOcpAM4zZFukjpQgc96CKHDrrQQQZqD3fsCRyo7sSiWqQB0gBpgDRAGphaGiCgTq32ImlJA6QB0gBpQFMNlBOoFQAsAHGbbgwAlQCGfNZXNYARANzn+6rcrib9PsJWOApA/j+mcgMfyswCcCat78ztgtJ1PnFr020gD6W3X/LnAz68o+otQgCkPrrL2B65ZC11e0g9NADoKXN75NJFqfuHtMHBdJ8sV//I5Q+lLKXoH058sRdfmssX5vqZl2eo+oFAypUDqFJZFwK4F8A/APg/6Tf7NIC/ANAJQHb227KcnhsFzAbwAADpxBcD+AaA77u5kYs6cwBcBOAnAJYBOJl+L/nOlwIwAbwK4L8HCPpFAB5M61HqQD7vbwEEoet8KqoC8AgACQwJ9UMA7gRwGYDvAjicbpvPAvidCz07rfL/pe3vg2VoDwkKCfIn00LvAfCVEreHfPRGADemdS8/YDcAuKCE7SHt8p9tDXcegNcB/GHaJ5Sqf8gPq2+lP+ia03Yq/UMp+4f0h/8vgDoA9QD2ArgDwCUlaA8nvlgGAG59aS5fmOtn5fTXTv1IzvLlAOrFAD4J4PcB/M80UCVAZaQqv5j7053tuJwv4fEtpeOQX3hfAtACQN5TGlEptm76GICrAfwlgLlpoF4F4B8BvMvmUD8D4Nce3zNf9S8DCAPYDEB+hcooXX5YSIj5ret8MrwHwDoAf55uCwlV2XG2pR3JfwKQuvoTABJyQV43A/jTNEjls0rdHisBfC0NjkykHpTt59Oj/Lj7efojTzrJ9wJ4B8CPytAeUkZpjz8FsBaABGsp+8enAHwEwK1pW/gegPMD8kX52kMGDvKPlEN+dEofJX2jtBMJ2iD7hxNfLG3FrS/N5Qtz/ayc/toXv1MOoGYEl1HLj9NAPQfAUwDa0r+UUZv8QpNRi5fr2+n7bk8vEZIpX/mMg15u6rCuNMQMUP8oDdn/lr7H/wXwvwH80OE9VYvL6EM+fzTdSf8ewHUAfhGArovJdH0ampG08ziadmLybxmRyKhN6imoaymAf01H6PJDQwK11O0ho0L5lS8d08vpSL09INvPp8ffA3BP+qNCfmTKrI103KVuj4x8MoMi217CrNTtMQ/AawCeBiA//CTMZUYpCF+Urz3kh8Rfp+1R9lf5sS8BL/uq/OArRf9Q8cXSj0i9ePGldl+Y0Yf9Zzr4a0/+pxRAldHI1rSUPwDwbPrf9kaUqdGHAZyb/t0nAFwL4I89vR3wEFJ/5LPkdQLAuwFIJ1aqy24wn09/hcsPBnl9B8Cv0tFBUPJIgG0C8D8A/EF6zCwIXReTX8JEtqt0IPLLWKa2ZHvLL3IJu2cALCx2E5e/l9G51LP8QJORuVzGJYFa6vb4AIDVAL4J4OPpdpHOU9qo37afT1UyKpPwel/aeT+a7hNvlLA9MrJl2l3+LTNUpW4PaQPyY/bf0jqQcxok3ErZP2SGQqb+3wbQmP7g/lDaZ5Wqf6j4YpmS9upLiwFVB3/t0sWkqpUCqHJcQKY15fVLALLjysveiJkvM5nykEqXaVJ5yfFGL9dX0+N28stTjln2ph1qKScn2Y1IwuSLAGTqUV4y1SVTO0GNHUqQSCOVjkJCXMIrKF3nayeZ3pY6kBGZvF4A8E9p5ynb+RUAlwOQbZXRi5c2z1VXOk6Z5pQySHtckXaiMu1cyvaQHzdyIp78I+1Rpn2XA9iXTvf5afv5dCjTiXIIJDPsIOEqP2ZkHy1Ve2Rkk0M6UgdyHFlepe4f8t1lultG7DJrIIcjMkMifvuiQjYtoSpTvjI6/Zt0CliO5ZaqPVR8cUY/XnxpMaDq4K89+Z5SADWfgPZGlGXkpAT5hfpm2vnJcT85fuDlkg76C+loRI7jSed5pZcbuqhrN6Km9KQc2Wnl1+jOdFQmx42DuD6XnnySDaogdJ1PfpnqleOnH00XkF/j8gtcRotyhqmcnCZTjnKWZcax+q0LOTGqNX1TOZQg7UDagxxTlpOkStUedwOQk1+knct0noyO5BBEKdtDPm8/ADkpRM6mlzYo7UPaSqnaI9O+0hbk+GHmg7LU/UPO4ZDR8e1pG/ht2k7kR57fviifTcvJef+S9ksyIpUffnIITEK+VO2h4ovlx7lXX1oMqDr4a0++p9xAlRMh5DiivKQy5f/l9Xh64oZ9qYmbF5XR2BMAVqUjMzl+KDtNKS/5DtJ5ZZZpyPS37Kzyi08a6H0BCiO/wGWKz37J6ExO/vBb1/leQ8JMfm3LFL685Li5BJp07L9J/6wv7VBOB6iLzK1lZCZnOmcmQJWyPeSYnRyHklGZ/CM/Gh8LyPYLqVJmK/4qnbmQGQw5JFDq9pB9Qg7ByJnP9uVjpWwPOWYvU96yXeQls0Vy1m8Qvihfe8hIWNqAnHEsJ0Tdkg4kStkeEqjFfLEEqldfmu0LpU7sP9PBX3tyQeUEai7BpfOVKTmZmvTzkmNzXVlrXv28v9N7yXFl6URkiqlcV1C6zvc+MiKXKS05QSpzyVTX/PTEC68fT170WOr2kJOBpD3ar1K3h3Re0pnb13zP1PaQNig/eO1r4kvdHtIm5Ael/eOinO2R7/1L4UtL8Qwv/iJvXd2AGshL0k1JA6QB0gBpgDQQtAYIqEFrmO5PGiANkAZIAzNCAwTUGdHM9JKkAdIAaYA0ELQGCKhBa5juTxogDZAGSAMzQgME1BnRzPSSpAHSAGmANBC0BgioQWuY7j+TNPD/t3fGKBEEQRStg4h4DGNTQxM9gKmJBzETNvEKXsFAQTyAmYmhNzCTh1Ugi8EEy1o1vgYxmGWpecXyqenp/3kzkuMw+0oR+k9svVcJtCegoLZvkQUOIcA5Qo49kKKCkcXShVsQpuAcm+BcpksCEhhKQEEd2jjLbkeAc51Yp2GtiKXk0oWRAXF2mAtsn01d+h1+TgISaEBAQW3QBEtYBQGcr/CqxnkItx0SfXDlwqXrIA3pEU9+cxgueR7KAAAB3UlEQVSwEyOHgQnh6icpqJ8ZCEEoBAYYJMHgN8wfh90x0icthrQicl1JanFJQAJNCCioTRphGeMJ/Hzki4UdPqys2zR9R1jxDMaVCa/Y14h4SBtKPseEepn2d6ThkKWLVSb/MdUnLQefVzyAMdM/buT8Nb553oAEdkFAQd0FRb9DAt9erLWHWoLKpIrp/EXmoOIRizk/1wn6fouIxxRNBJXUF+LlNhFxlHF37LEy0ZKPWSlMeDGTkuKSgAQaEVBQGzXDUkYT+E1QecSL8TyG52RsIqjkwiKyFTpfAQaHEfEeER8ZLVcwiJxjTxYjfSZXVonxaGAWL4G1EVBQ19ZR7+evCCwVVI7VkNpxl9Mp2bDsvzKh3uejXCLveER8ni86MfmyH/uc158yvYdcVZcEJNCEgILapBGWMZ5ACSoBzMTDsYdaj2vPIoKILCZU9kGZOMmEZZVIcmyGPFDyYU/zGi84Mc2+ZCg6e7BXEXGdEXg346l5AxJYEQEFdUXN9FZGEeDNXyZPIu22FyHkTJ/7yIcdBc1iJdCZgILauTvWJgEJSEACYwgoqGNaZaESkIAEJNCZgILauTvWJgEJSEACYwgoqGNaZaESkIAEJNCZgILauTvWJgEJSEACYwh8AYJK7y8YqSNbAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<VegaLite 3 object>\n",
+       "\n",
+       "If you see this message, it means the renderer has not been properly enabled\n",
+       "for the frontend that you are using. For more information, see\n",
+       "https://altair-viz.github.io/user_guide/troubleshooting.html\n"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.plot(kind='bar', width=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.vegalite.v3+json": {
+       "$schema": "https://vega.github.io/schema/vega-lite/v3.4.0.json",
+       "config": {
+        "mark": {
+         "tooltip": null
+        },
+        "view": {
+         "height": 300,
+         "width": 400
+        }
+       },
+       "data": {
+        "name": "data-74a83de18a3c59bc7cc9d0ccacb63bfd"
+       },
+       "datasets": {
+        "data-74a83de18a3c59bc7cc9d0ccacb63bfd": [
+         {
+          "index": 0,
+          "x": 0.10174192426040822,
+          "y": 0.31973437326889537,
+          "z": -0.24087925640418273
+         },
+         {
+          "index": 1,
+          "x": 0.46377109678002576,
+          "y": 0.39284953965450403,
+          "z": -0.8470307992657274
+         },
+         {
+          "index": 2,
+          "x": 0.5427920704495576,
+          "y": 2.0215438525479135,
+          "z": -0.5041337657185385
+         },
+         {
+          "index": 3,
+          "x": 0.691790393493323,
+          "y": 1.4080784951558476,
+          "z": -1.5530227427069885
+         },
+         {
+          "index": 4,
+          "x": 0.5438454859014044,
+          "y": 2.282289197786082,
+          "z": -2.47969679801141
+         },
+         {
+          "index": 5,
+          "x": 0.8412672776574759,
+          "y": 0.9336365164416933,
+          "z": 0.11586844310132616
+         },
+         {
+          "index": 6,
+          "x": 0.4440696728540403,
+          "y": 0.5846040675015804,
+          "z": 1.198605562039081
+         },
+         {
+          "index": 7,
+          "x": 0.37689265681375916,
+          "y": 1.8445078498152159,
+          "z": 2.1971366928099076
+         },
+         {
+          "index": 8,
+          "x": 1.7088994296520779,
+          "y": -0.2965165131611587,
+          "z": 2.4854050834183345
+         },
+         {
+          "index": 9,
+          "x": 0.7594255157953386,
+          "y": -0.7840081732519648,
+          "z": 2.530393125472639
+         }
+        ]
+       },
+       "encoding": {
+        "color": {
+         "field": "column",
+         "title": null,
+         "type": "nominal"
+        },
+        "column": {
+         "field": "index",
+         "type": "quantitative"
+        },
+        "opacity": {
+         "value": 1
+        },
+        "tooltip": [
+         {
+          "field": "index",
+          "type": "quantitative"
+         },
+         {
+          "field": "x",
+          "type": "quantitative"
+         },
+         {
+          "field": "y",
+          "type": "quantitative"
+         },
+         {
+          "field": "z",
+          "type": "quantitative"
+         }
+        ],
+        "x": {
+         "field": "column",
+         "title": null,
+         "type": "nominal"
+        },
+        "y": {
+         "field": "value",
+         "title": null,
+         "type": "quantitative"
+        }
+       },
+       "mark": "bar",
+       "selection": {
+        "selector007": {
+         "bind": "scales",
+         "encodings": [
+          "x",
+          "y"
+         ],
+         "type": "interval"
+        }
+       },
+       "transform": [
+        {
+         "as": [
+          "column",
+          "value"
+         ],
+         "fold": [
+          "x",
+          "y",
+          "z"
+         ]
+        }
+       ]
+      },
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA2oAAAF3CAYAAADU/LhnAAAgAElEQVR4Xu29C5QtV33e+bWEJSMhDDaPGwuZMc0ErMlgm9jWIGVihufYwxA7uCUZTGzADjHDOxnrhZACkfrGzIrBYfwIcpANlq9kTDK2zAAjDMmYTECsOCz5EQ2oQzxidEGOhWRLoEFSz9r3Vuue27dPn6ra369PVdd31tKyuV311f5++7+r9nd2VZ0V5RMCIRACIRACIRACIRACIRACITAoAiuDak0aEwIhEAIhEAIhEAIhEAIhEAIhoAS1FEEIhEAIhEAIhEAIhEAIhEAIDIxAgtrAOiTNCYEQCIEQCIEQCIEQCIEQCIEEtdRACIRACIRACIRACIRACIRACAyMQILawDokzQmBEAiBCRH4Bknlv/sm5DlWQyAEQiAEQqAVgQS1VpiyUQiEQAiEAEDgH0v6GUkHJH2ppf5jJN0l6Z2S3tRyn2wWAiEQAiEQAqMjkKA2ui5Lg0MgBEJg3xD4HyT9DUlXSfrLlq62gto/lfT6lvtksxAIgRAIgRAYHYEEtdF1WRocAiEQAvuGwBskvUzSCyX9neb//4ikl0r6I0kXSfoTSU+X9IuSzpb0LyX9XUlbQe1vSvqfJD1b0iea//97JL1N0u9I+ieSflvS/ZL+tqSv7Rt6MRICIRACIbCvCSSo7evujbkQCIEQGDSB2Vsfyy2Qb5b0x5J+T9JrJf2SpJ9uwtnfkvQrkp7VBLYS1C6V9BeSPinpw5LeLqkEvR+U9H9Ieo6k35L0Ekk/3OgMGkgaFwIhEAIhEAJbBBLUUgshEAIhEALLIrBTUPsvJP0nSf+PpD+XdG5zW+S1kl4h6XlNCCtB7f+UdEPz363N358k6dGSvlnSFxpj/1zSq5ZlMscNgRAIgRAIgT4EEtT6UMs+IRACIRACDgI7BbVvknSPpBK8ym2K/2MT3LZeHrIq6fPNrY93SLpa0nWSNmYaVHRPl/Q5SWdI+oXmlkhHm6MRAiEQAiEQAntCIEFtTzDnICEQAiEQAjsQaBPUvlPSpyU9WdLfb4Lb+U1Qu7G51bEEtV+W9A8kPdDc6vgvJJXbJcttkec1z8F9NL0QAiEQAiEQAmMhkKA2lp5KO0MgBEJg/xHYCmpPbF4cUp5R276iVoLaD0j6UGO/PL9Wnj37eUnlZSTlhSNlvyc0z6v9kKRvk/TeJsyVY9wu6cuS/qqku/cfxjgKgRAIgRDYjwQS1PZjr8ZTCIRACOw/Aqc1z52V0LX9c3ITzspzbWVFLZ8QCIEQCIEQGD2BBLXRd2EMhEAIhEAIhEAIhEAIhEAI7DcCCWr7rUfjJwRCIARCIARCIARCIARCYPQEEtRG34UxEAIhEAIhEAIhEAIhEAIhsN8IJKjttx6NnxAIgRAIgRAIgRAIgRAIgdETSFAbfRfGQAiEQAiEQAiEQAiEQAiEwH4jkKC233o0fkIgBEIgBEIgBEIgBEIgBEZPIEFt9F0YAyEQAiEQAiEQAiEQAiEQAvuNQILafuvR+AmBEAiBEAiBEAiBEAiBEBg9gQS10XdhDIRACIRACIRACIRACIRACOw3Aglq+61H4ycEQiAEQiAEQiAEQiAEQmD0BBLURt+FMRACIRACIRACIRACIRACIbDfCCSo7bcejZ8QCIEQCIEQCIEQCIEQCIHRE0hQG30XxkAIhEAIhEAIhEAIhEAIhMB+I5Cgtt96NH5CIARCIARCIARCIARCIARGTyBBbfRdGAMhEAIhEAIhEAIhEAIhEAL7jUCC2n7r0fgJgRAIgRAIgRAIgRAIgRAYPYEEtdF3YQyEQAiEQAiEQAiEQAiEQAjsNwIJavutR+MnBEIgBEIgBEIgBEIgBEJg9AQS1EbfhTEQAiEQAiEQAiEQAiEQAiGw3wgkqO23Ho2fEAiBEAiBEAiBEAiBEAiB0RNIUBt9F8ZACIRACIRACIRACIRACITAfiMwxaB2qqRNSf/ffuvMJfh5tKR7lnDc/XTI0xoz9+0nU0vwcoakr0p6YAnH3m+HPF3SyRnb+61bR+nnEZIeI+nPRtn6NHq/ESjzx/K5f78Z22M/3yjpQUlf3+PjjvJwUwpq5YT/c5K+u5mE/DtJr5P00Ch7brmNfqqk75f0Zkn/1XKbMtqjf4OkayU9WdJGU5OvkvS10TpaTsNL0P2ApJOaYPEfJV20nKbsi6OeIun3JX1Q0sF94WjvTXxM0t0zXxq8PBO7Xp1wsaQXSfpPkh4p6UfDsTPHH5D06pm9niPpEkn/a2el7PDzzZcGJWTcIemNzZf+IdOeQPkS8H+RVL7k/yZJ/7ek/7kJbe1VJrbllILauZLeKen7mj6+VdIrJX1yYn3usFsuoP+1pO9KUOuN829KulrS32gUPi7pFyT9Zm/Fae5Y+K1JeoOksqpWVngfJ+k/TxNHteuflfQMSZ9IUOvN8jZJ/6Wkcn0t3xrn051A+TLwI5LK/y13wJTz5X+Q9OXuUtmjIVBC709K+uEEjM41UeqwfLn/2OZL1bKi9q1NYOssNuEdXiap/PeDzZerJfD+LUn/dsJMFlqfUlD7MUnnSfrphsq/lPRbkt63kFI22IlAmcz9RoJa7+IoK7zlm7m/bFbVbpH01yT9aW/Fae+49c1xWREqF4F8uhP4IUnPkvTnTcjIilp3hmUiV/j9RbOqVr6M+cXuMpPf43mS/rGkcp48IOkdzTfxkwfTE0C51nxOUuFavqTOpzuBf93c8VLu4vhKs9rbXWXaezxb0qWSXtCskpdHPs7PF9S7F8WUgtprJH1Hc7tjofIrksoqxvunPW56u09Q643uuB0vkPQeSVdK+iceyUmqlG+Lyy1m5ULwnZIOT5JCf9Orkm6Q9N8258hybUhQ687zSZL+vqS3Sfo2Sf9eUvm3L3aXmvQePyHpvZL+O0llMvc7ks6R9IVJU+lvvnxR/cLmHNlfZbp7ntmsqJXb7MtjCxdKKv9WvpDJpz2B8sVL+aLgjyR9c7N4Uuryo+0lprfllIJamcCVZ6pe3HTzbzcX089Mr9stjhPU6jGWb5bKbQAlYJTbKvLpTqDcylxujbq52fX/kvQuSYe6S016j7dL+rvN80DlucnyeUvzJcKkwXQ0XyYi5bq69ZB8uc5cl3rsSPHo7VCXzTyqUELbv2qe6+0slh306WY8Z0LcrxjKFwclnP33ze7lOd7yrFW5MyufbgTKObLc9VK+gCnXnTIHKs/p5zOHwJSC2rdIKi8aKJOQkuT/QNJZze0pKZDuBBLUujOb3ePsZkX3r6YGq0CWWx7L82l/u1Ep39aVb+j+uEp1ejuX5/rKbXvlU55jKd8aX5Vn/ToXQrm1rHxRUJ7fLc9M/omkZ2ZFrTPHssL7eUlPkHRvc70uX7Lmtr3OKI/cOlqeBSpjOm/F7c6v7FFWc/95M5bLc6elDsut4uWRhXzaE/jrza3g5Rb7pzXPoX576nJ3gFMKaoVEuZWn3AJZLqCvzZuP2o+uHbZMUKvCp61be2ZVysttyjfH+bQnUJ4XKG/PLG8hLZ9fb1bO2ytky+0Eyq17ZVKXWx+710a5pv6L5jb78s3xP2uetequlD3KW5l/pvkpnXJbbnlbYT7dCZRA8fdmVoO6K2SPQqA8k1/emll+2unGmfcdhE57AuXtzIVd+VKwvDH8R3Lb42J4UwtqhUj55rgMtPz+1+L6yBYhMBYCZZW83EqRnzcYS4/t73aWOzhmX9G/v91y7spr+cvkrqyq5RMCyyZQftOv/KRT5o91PVFWectLl/J7xi04TjGotcCSTUIgBEIgBEIgBEIgBEIgBEJgeQQS1JbHPkcOgRAIgRAIgRAIgRAIgRAIgR0JJKilMEIgBEIgBEIgBEIgBEIgBEJgYAQS1AbWIWlOCIRACIRACIRACIRACIRACCSopQZCIARCIARCIARCIARCIARCYGAEEtQG1iFpTgiEQAiEQAiEQAiEQAiEQAgkqKUGQiAEQiAEQiAEQiAEQiAEQmBgBBLUBtYhaU4IhEAIhEAIhEAIhEAIhEAIdA1qp0h6RPPDsvPonS7pq82PAoZwCIRACIRACIRACIRACIRACIRARwJdgtpBSc+R9MeSyq+zv0zSvTPHe5yk6yQ9IOnJkt4h6dqO7cnmIRACIRACIRACIRACIRACITB5Am2DWlkl+7ik72uI/b6kn5X02zMEL5Z0hqTLJB2QdIekst99k6ccACEQAiEQAiEQAiEQAiEQAiHQgUDboLYl+dckvULSj0l6uqS7Zo51jaSbJB2SVHQfkrQqaaNDe7JpCIRACIRACIRACIRACIRACEyeQNeg9gxJP93c9vhDkn5vhuANksp/H2j+7UuSzpH0hfX19StXVlau2Eb7Ez/yIz/y7JWVrk0YdZ9trq6unuR28PnPf34zHOuobm5urtx2220PhWMdx7J36rGeYeqxnmFRCMdwrCBgv16nHit6Y2bXcAzHCgL2cV3Rlla7tk1JZ0r6Hkn/W6P6dknlmbQS2rY+b5V0j6R3Sjq5WW0rz7KVlbUTPgcPHtxcW1vTU57yFHtwaeV8CRttbGw8tLq62pZ56xbedtttm+HYGteOG5YT/8bGxoNPecpTSu1O4pN69HRzqRv3FzATrcdwNJRk6tEAsdwKlHFtARmOFoypRw9GO8cXXXxos03Tbjx4Ye+5f9sdHyvpP0j6bkmHJb1P0r+S9M+aVbNbJD1P0mslvUDSmqQ3S3rWPANbQY0ILm2gLWObEqgIv5TuMhi1OSbhd2ti7J5wt/GzjG0av9gXB0SdL4NTm2OWlVh33Uy0HrGg5u6fNnWxjG2ouqF0l8GozTEpv5RuG0/L2IbyS+kug1GbY1J+Kd02npaxDeF3SEGtMC0rZv9A0t2SPivp5c2qWVlFO3KLo6QPSTpb0iMlPV/SpxLUjhEgAkZRp3SXMZDaHJPwSwzgNl6WtU2Cmo98glo9S2r8Ubr1jhkFyi+ly1CoV6X8Urr1jhkFyi+ly1CoV6X8Urr1jhkFwm9lUHuXpC82L2e8RNI3SHrbdvdtV9S29isB7Bu3vURku+ZZzarb13dDnRU1XyESwcXXOr8S4ZcYwH7nPsUENR/LBLV6ltT4o3TrHTMKlF9Kl6FQr0r5pXTrHTMKlF9Kl6FQr0r5pXTrHTMKhN/KoFZeyvgnkl4s6dclfUcT3I4D0DWo2eglqNlQZkXNgJIYwIZmYRIJaj60CWr1LKnxR+nWO2YUKL+ULkOhXpXyS+nWO2YUKL+ULkOhXpXyS+nWO2YUCL+VQa0YLS9avLJ558cv7eQ8QY2phx1ViZWgciBKdw/RdDoU4ZcYwJ1M7fHGCWo+4Alq9Syp8Ufp1jtmFCi/lC5DoV6V8kvp1jtmFCi/lC5DoV6V8kvp1jtmFAi/hqB2kaSDkn5c0q8lqDF931qVCBgJaq3x77ohMYA9LWNUEtR8XBPU6llS44/SrXfMKFB+KV2GQr0q5ZfSrXfMKFB+KV2GQr0q5ZfSrXfMKBB+K4PaUyX9u+ZFjO9ufnv6zu3us6LG1MOOqglqHtgER2IAe9wyKglqPq4JavUsqfFH6dY7ZhQov5QuQ6FelfJL6dY7ZhQov5QuQ6FelfJL6dY7ZhQIv5VB7aOS/rWkf9S8Rb+8TOQVCWpM/7dSJQJGOTCl28rUEjYi/BIDeAloWh8yQa01qoUbJqgtRLRwA2r8UboLDS1pA8ovpbskTAsPS/mldBcaWtIGlF9Kd0mYFh6W8kvpLjS0pA0Iv5VBrRWJrKi1wuTZiAgYCWqeviEGsKdljEqCmo9rglo9S2r8Ubr1jhkFyi+ly1CoV6X8Urr1jhkFyi+ly1CoV6X8Urr1jhkFwm+CGtNXS1NNUPOgJzgSA9jjllFJUPNxTVCrZ0mNP0q33jGjQPmldBkK9aqUX0q33jGjQPmldBkK9aqUX0q33jGjMFa/WVFj6mFHVSJglANRunuIptOhCL9jHcCdwM1snKDWl9yJ+yWo1bOkxh+lW++YUaD8UroMhXpVyi+lW++YUaD8UroMhXpVyi+lW++YURir3wQ1ph4S1ECuCWr1cBPU6hluKSSo1bOkLqCUbr1jRoHyS+kyFOpVKb+Ubr1jRoHyS+kyFOpVKb+Ubr1jRmGsfhPUmHpIUAO5JqjVw01Qq2eYoOZjSF1AKV2fc68S5ZfS9br3qVF+KV2fc68S5ZfS9br3qVF+KV2fc68S4ffeqw5stmnl6Zcd7p23eu/YpmG7bXPw4MHNtbU1ra6uLq0NtR667k8EjNIGSrerv73anvBLDOC94tHnOAlqfajtvE9W1OpZUuOP0q13zChQfildhkK9KuWX0q13zChQfildhkK9KuWX0q13zCgQfhPUmL5amioRMBLUPN1JDGBPyxiVBDUf1wS1epbU+KN06x0zCpRfSpehUK9K+aV06x0zCpRfSpehUK9K+aV06x0zCoTfyqD2QUkHJX1a0vdI+hlJ5293v7TVrKyo+QqRCoC+FnqVCL/EAPa69qolqPl4JqjVs6TGH6Vb75hRoPxSugyFelXKL6Vb75hRoPxSugyFelXKL6Vb75hRIPxWBrWrGqeXSXqbpHIb5RUJakz/t1IlAkY5MKXbytQSNiL8EgN4CWhaHzJBrTWqhRsmqC1EtHADavxRugsNLWkDyi+luyRMCw9L+aV0Fxpa0gaUX0p3SZgWHpbyS+kuNLSkDQi/lUHtr0u6TtLTJP2RpB+T9AcJaksqEDJQEcFliZgWHprwSwzghUaWuEGCmg9+glo9S2r8Ubr1jhkFyi+ly1CoV6X8Urr1jhkFyi+ly1CoV6X8Urr1jhkFwm9lUCt3Nf6ppFdJ+hVJ39asqh0HILc+MvWwoyoRMMgAuIdoOh2K4EgM4E6m9njjBDUf8AS1epbU+KN06x0zCpRfSpehUK9K+aV06x0zCpRfSpehUK9K+aV06x0zCoTfyqBWjJZn1NYkHZJUboE84ZOgxtRDghrINUGtHm6CWj3DLYUEtXqWxAW0tIrSrXfMKFB+KV2GQr0q5ZfSrXfMKFB+KV2GQr0q5ZfSrXfMKBB+DUHt+yR9StJ3SfpsghrT961ViYBRDk7ptja2xxsSfokBvMdYOh0uQa0Trl03TlCrZ0mNP0q33jGjQPmldBkK9aqUX0q33jGjQPmldBkK9aqUX0q33jGjQPg1BLVnSvolSSWw7fjpuqL2CEmPkvSVWox562MtwWP7E8HF1zq/EuGXGMB+5z7FBDUfywS1epbU+KN06x0zCpRfSpehUK9K+aV06x0zCpRfSpehUK9K+aV06x0zCoTfyqD2MklvlfQ6SR91BLU3S3p1s0T3aEkXSbp1RvhUSXdK+nDzb+Vvl887cIKarxCJ4OJrnV+J8EsMYL9zn2KCmo9lglo9S2r8Ubr1jhkFyi+ly1CoV6X8Urr1jhkFyi+ly1CoV6X8Urr1jhmFAfotC18PSbpvN8dtV9ROkXR/s5p2r6S3SHpikwK39J/e/A7ASyU9sAhzgtoiQu3/TgSX9kff+y0JvwMcwCjYBDUf3gS1epbU+KN06x0zCpRfSpehUK9K+aV06x0zCpRfSpehUK9K+aV06x0fr/Cn55//SofmWddf/96NjY0HV1dXT3Lo7ZVG26BW2vNYSXdJOk3SxyS9q3lLyVZbX9T8HsAZkm5uVtw+Ps9Igpqvi4ng4mudX4nwO5YTlotmgpqL5JFnRB9yn/gnWo/2C2g4euo8HMOxDwGqbijdPh73Yh/KL6XrZnL7BeeXH4Ku/px56PqT9ntQK5DKQ2/vlfSHzXv/vzZD7rnN398t6QJJl0gqq2yb6+vrV66srJzwa9tra+WNlNP6rK6udgnHreCU4NJqw320kZtjOWGVCffKir17Bk3dzbGYnWA9bhJBbYL1GI6es0U4hqOHgEcl9RiOVQROvbTEifrP/VevFxFrPbYNkU+6/obek8suO5YgVn5B+/WSrt8BWbk98sHmv5Ob2x/PknT7TnizolZfdFsKxAqTr3V+JcLvWL5ZctHMipqLZFbUHCSp8UfpOjwTGpRfSpdg4NCk/FK6Ds+EBuWX0nUzuP2C8/+zQ/PMQ9c/jlgJGhFHy2IEsaI2pKBWAt3dkp4n6dPbCu8cSbc0tzo+XtJrJJ0r6X2SVucVaYKaY/ge1SCCi691fiXC71hOWC6aCWoukglqDpLU+KN0HZ4JDcovpUswcGhSfildh2dCg/JL6boZtJ3ELzouETDKMcNxEfnFf2/bx3NW1MpLGn985ii/Lulntx+17YraUyV9btvOvyrpJyTdI6mEtfLK/pualbTyMpFyq+ONCWrHCBABI0Ft8UBqs8VYTlhtvLTZJkGtDaV22+QZtXacdtuKGn+Ubr1jRoHyS+kyFOpVKb+Ubr1jRoHyS+m6KbSdxC86boLacJ9Ra9vHc4Lat0h6jKRy92F5p8dzmv97XEm0DWqL6mj27wckHV60Q1bUFhFq/3cqALZvwd5uSfgdy4nfRTpBzUUyK2oOktT4o3QdngkNyi+lSzBwaFJ+KV2HZ0KD8kvpuhm0ncQvOm6C2r4NaqXry+9Tf0LSRyS9fadaIILaopo78vcEtVaYWm1EBJdWB17SRoTfsZz4XcgT1FwkE9QcJKnxR+k6PBMalF9Kl2Dg0KT8UroOz4QG5ZfSdTNIUPMQHTLHtm3b5WUiV0v6Hkk/0Lzj4wRoCWqeOmqlQgSMcmBKt5WpJWxE+B3Lid+FO0HNRTJBzUGSGn+UrsMzoUH5pXQJBg5Nyi+l6/BMaFB+KV03g7aT+EXHzYravl1RK+HsWknfududiAlqi0aI8e9EwEhQ83TQWE78HrcPP0Rcfv/Lfg6g6tzl3a2TZ9TqiVLjj9Ktd8woUH4pXYZCvSrll9Ktd8woUH4pXTeFBDUP0SFzbNu2OStqvy/pPEl/0ZC6QdJPbqdmn6S17Zbc+tiW1OLtJjgxLr+DYa3dsZz4F1dDuy2yotaOU5utEtTaUNp9G2r8Ubr1jhkFyi+ly1CoV6X8Urr1jhkFyi+l66bQdhK/6LhZUdu3K2qLuv7I362T3VZHbDZKUOtCa/dtE9TqWY7lxF/v9KhCgpqLZG59dJCkxh+l6/BMaFB+KV2CgUOT8kvpOjwTGpRfStfNIEHNQ3TIHNu2ba9+8NpDPEHNHo4T1OpLcywn/nqnCWouhls6WVGrJ0qNP0q33jGjQPmldBkK9aqUX0q33jGjQPmldN0U2k7iFx03K2rDXVFb1HeOv9tDQ9tGZUWtLanF2yWoLWa0aIuxnPgX+Wj796yotSW1eLsEtcWMFm1BjT9Kd5GfZf2d8kvpLovTouNSfindRX6W9XfKL6Xr5pSg5iE6dI4el/NVEtRowjP6VKCidPcQTadDEX7HcuLvBGqXjRPUXCTHdevjfVcduNXh/LTLDj/NobOlQY0/Stfp3alF+aV0nd6dWpRfStfp3alF+aV0nd6L1tADRji6e5zRS1BjuO6oSgSMciBKdw/RdDoU4XcsJ6xOoBLUXLh21RnTitq9Vx3YdEA5/bLD1msHNf4oXQdDQoPyS+kSDByalF9K1+GZ0KD8UrpuBglqHqJD5+hxOV/FerHt0tjc+tiF1u7bEsHF1zq/EuF3LCd+F82sqLlIjmtFLUHN1+9DVKLOY5TuEBmWNlF+Kd1wHCaBoQeMsdTj0DnS1ZegRhOe0ScCRpGndPcQTadDEX7HcsLqBGqXjRPUXCQT1BwkqfFH6To8ExqUX0qXYODQpPxSug7PhAbll9J1Mxh6wAhHd48zeglqDNcdVYmAkaDm6cCxnLA8bvN6fhfHZvyVHw4/yalJ1WNW1Jy9NDwtqm4o3eERPNoiyi+l6+b4pxdc8L0OzbMOHfrMxsbGg2M5Pzo8z2okqHmIDp2jx+V8lQQ1mvCMfoKaBzbBcSwXUA/BBDUXxwQ1D0lq/FG6Htd+Fcovpesn4FGk/FK6HtfHVIY+MQ5HT4+Ho4cjrZKgRhNOULMTTlCrR5pbH+sZbinkZSL1LKkJA6Vb75hRoPxSugyFelXKL6Vb7/h4hQQ1D9FwnAZHj8v5KglqNOEENTvhBLV6pAlq9QwT1HwMqQkspetz7lWi/FK6Xvc+NcovpetzflQpAcNDNBynwdHjMkGN5thKnwgY5cCUbitTS9iI8DuWC6gLd4Kai2ReJuIgSY0/StfhmdCg/FK6BAOHJuWX0nV4ntVIwPAQDcdpcPS4TFCjObbSJwJGglor9As3GssFdKGRlhskqLUE1WKz3PrYAtKCTajxR+nWO2YUKL+ULkOhXpXyS+nWOz5eIQHDQzQcp8HR4zJBjebYSj9BrRWmhRsRHMdyAV0Ip+UGCWotQbXYLEGtBaQEtXpILRSo8xil28LSUjah/FK6bkgJGB6i4TgNjh6XvqD2CEmPkvSVXRp2uqSvSnpot8bnB699XUsEF1/r/EqE37FcQF00E9RcJHPro4MkNf4oXYdnQoPyS+kSDByalF9K1+F5ViMBw0M0HKfB0ePSE9TeLOnVkj4l6dGSLpJ064z04yRdJ+kBSU+W9A5J1847dIKar2uJ4OJrnV+J8DuWC6iLZoKai2SCmoMkNf4oXYdnQoPyS+kSDByalF9K1+E5Qc1NMS9lcREdeuB1+Zyn0/atj6dIur9ZTbtX0lskPVHS62aEL5Z0hqTLJB2QdIeksrp2304HT1DzdS0RXHyt8ysRfsdyAXXRTFBzkUxQc5Ckxh+l6/BMaFB+KV2CgUOT8kvpOjwnqLkpJqi5iCaotSf5WEl3STpN0sckvUvSoZndr5F0U/NvJQCWWx9XJW0kqB0lQAQMUrd9aeztlgRH6gJ679UH5q4qd6F2+qWHf6LL9ou2TVBbRKj93/OMWntW87akxh+lW++YUaD8UroMhXpVyi+lW+/4eIWhT4zD0dPj4ejhSKu0XVHbasczJb1X0h9KepWkr8008AZJ5b8PNP/2JUnnSPpCglqCmrOQRxXUrjqw6fB++mWHu47VXQ+boPVyD4cAACAASURBVObolYfH9UOrq6sn+RQl6gJ677Dr8cGxcHT2tVOLqhtK1+ndqUX5pXSd3otWgpqHaDhOg6PH5XyVLpO/5zbPoL1e0vU7SL5V0j2S3inp5Gb17TFlZW19ff3KlZWVK7bvs7a2RvsbnP7q6moX5q3aX4JLqw330UZujuUCWlZGVla83XPg0HkW6ocv/KRFZ7uIm2PRn2A9bhIBY4L1OBqOyGD0iYajh+VkOZ566SUWgvdfvV50wrGSZjgOux4ru3fh7m1npWW7uyU9T9Knt6mWVbNbmr+9VtILJJUEVl4+8qx5Lcgzagv7pvUGxApT64MvYUPCL/VN58BXMMpKUNtzQOueJvqn9cGXsGFufayHTo0/SrfeMaNA+aV0GQr1qpRfSrfe8fEKWQnyEA3HaXD0uJyv0naS9lRJn9sm86uSynMzZRVt6xbHD0k6W9IjJT2/eUPkjkdPUPN17QQnxuUbura12wo0dQFNUGuFf9QbJajVdx81/ijdeseMAuWX0mUo1KtSfindescJam6GRS9BzUN16Bw9LuuDWpd2nCXpsKSv77ZTgloXpLtvm6BWz5K6gCao1ffN0BUS1Op7iBp/lG69Y0aB8kvpMhTqVSm/lG694wQ1N8MENR/RBDUfy05KCWqdcO26cYJaPUvqApqgVt83Q1dIUKvvIWr8Ubr1jhkFyi+ly1CoV6X8Urr1jhPU3AwT1HxEE9R8LDspJah1wpWgNkOACKbUBTRBzVfnQ1VKUKvvGWr8Ubr1jhkFyi+ly1CoV6X8Urr1jhPU3AwT1HxEE9R8LDspJah1wpWglqBGPJOXl4kYhmGCWj1EagJL6dY7ZhQov5QuQ6FelfJL6dY7TlBzM0xQ8xFNUPOx7KSUoNYJV4JaglqCmm/IWJUS1OpxUhNYSrfeMaNA+aV0GQr1qpRfSrfecYKam2GCmo9ogpqPZSelBLVOuBLUEtQS1HxDxqqUoFaPk5rAUrr1jhkFyi+ly1CoV6X8Urr3XnXga/WupdMvO/yNCRgOkkc1hh4wqHr0ERwHR7ff7XrWyV+XxiaodaG1+7bEM1u+1vmVCL/UCSvPqPn7f2iKCWr1PUKNP0q33jGjQPmldBkK9aqUX0rXfZ1JwKivoQQ1D8MxcPQ53VkpQY0mPKNPBIwiT+nuIZpOhyL8juUC2gnULhs3fvOMmgFoglo9RGr8Ubr1jhkFyi+ly1CoV6X8UroJavV9Tigk8HqoDp2jx+V8lQQ1mnCCmp1wglo90gS1eoZbCglq9SypCSylW++YUaD8UroMhXpVyi+lm6BW3+eEwtADBlWPbpZD5+j2u10vQY0mnKBmJ5ygVo80Qa2eYYKajyE1YaB0fc69SpRfStfr3qdG+aV0E9R8fe9UGnrAoOrRybBoDZ2j22+CGk10F30iYJTDUbpLRLXroQm/1AnLfQF19UmCmovkkfFXbiE9yacoTbQeHxwLR2dfO7WouqF0nd6dWpRfStd9nRn6xJji6KyhMQSMcHT3OKOXFTWG646qRMBIUPN0IHXCcl9APW4fDgJ5Rs0ANEGtHiI1/ijdeseMAuWX0mUo1KtSfild93UmQa2+hhLUPAzHwNHndGelBDWa8Ix+gpoHNsFxLBdQD8EENRfH5ouSrKhVAqXGH6VbaRfbnfJL6WIgKoUpv5TuVIPaG6+5+d2VXX1k999Zv/D1Dp3tGgm8HqpD5+hxOV8lQY0mnKBmJ5ygVo80tz7WM9xSyIpaPUtqAkvp1jtmFCi/lC5DoV6V8kvpTjWoveE9N1vmsDcevNCik6BWP/Z2UkhQY7guVM3vqC1E1HoDIri0PvgSNiT8juUC6sKdoOYimWfUHCSp8UfpOjwTGpRfSpdg4NCk/FK6CWp1vZ6g5n3Guq43Ttw7Qc1NtKVeglpLUC02I4JLi8MubRPC71guoC7oCWoukglqDpLU+KN0HZ4JDcovpUswcGhSfindBLW6Xk9QS1CrqyB2b2S5t02TE9TaUGq3DRFc2h15OVsRfsdyAXURT1BzkUxQc5Ckxh+l6/BMaFB+KV2CgUOT8kvpJqjV9XqCWoJaXQWxeyeosXyPUycCRjkApbuHaDodivA7lgtoJ1C7bJyg5iKZoOYgSY0/StfhmdCg/FK6BAOHJuWX0k1Qq+v1BLUEtboKYvdOUGP5JqgBfBPU6qEmqNUz3FLIy0TqWVITWEq33jGjQPmldBkK9aqUX0o3Qa2uzxPUEtTqKojdu09Qe5SkeyVt1jQttz7W0Dt+XyK4+FrnVyL8juUC6qKZoOYimRU1B0lq/FG6Ds+EBuWX0iUYODQpv5RuglpdryeoJajVVRC7d5eg9gRJz5D0QUlPlfTlbU07VdKdkj7c/Putki6f1/wENV/HEsHF1zq/EuF3LBdQF80ENRfJBDUHSWr8UboOz4QG5ZfSJRg4NCm/lG6CWl2vJ6glqNVVELt3l6D2EknnSXqTpCfuENSeLultkl4q6YFFzU5QW0So/d+J4NL+6Hu/JeF3LBdQF+0ENRfJBDUHSWr8UboOz4QG5ZfSJRg4NCm/lG6CWl2vJ6glqNVVELt3l6C21ZJyy+NOQe1Fkq6TdIakmyVdJOnjWVE7RoAIGEWd0mVLr7864XcsF9D+1I7fM0HNRTJBzUGSGn+UrsMzoUH5pXQJBg5Nyi+lm6BW1+sJaglqdRXE7u0Mas+V9ExJ75Z0gaRLJJVVth2fZcuKmq9jieDia51fifA7lguoi2aCmotkgpqDJDX+KF2HZ0KD8kvpEgwcmpRfSjdBra7XE9QS1OoqiN3bGdROkfRg89/Jze2PZ0m6fX19/cqVlZUrtltZW1tj3Q1QfXV1tQ/zXZ2U4DJAq2iT3BzLBbS8vW9lxds9Bw6Vu4XrP4cv/GS9yA4Kbo7lEBOsx83VVe+FbqL1OBqOyGD0iYajh+VoOLqvM6deWr5nr//cf/V6EcE4vvGaz9Q3UtK7fup7LTrbRcbC0T3vccMcOke33+16fWal2299PEfSLc2tjo+X9BpJ50p6n6TVeQayoubrWmKFydc6vxLhdyzfdLpoZkXNRTIrag6S1PijdB2eCQ3KL6VLMHBoUn4p3ayo1fV6VtS8XzTW9caJe99+wfmWxYgzD11/0sbGxoPuL1bdfl1BrbwBsrzhsXzukVTC2lck3dSspJWXiZQVtBsT1I4RIAJGUad06eLrq0/4HcsFtC+z7fslqLlIJqg5SFLjj9J1eCY0KL+ULsHAoUn5pXQT1Op6PUEtQa2ugti9+6yoLWrRAUmHF22UFbVFhNr/nQgu7Y++91sSfsdyAXXRTlBzkUxQc5Ckxh+l6/BMaFB+KV2CgUOT8kvpJqjV9XqCWoJaXQWxexNBrVWLE9RaYWq1ERFcWh14SRsRfsdyAXUhH1tQ+4urD5zt8H7GpYf/2KEzq1GebXTfSjHRerTfkkJxdNeQS4/yS+m6fLt1KL+UboJaXQUkqCWo1VUQu3eCGsv3OHUiYJQDULp7iKbToQi/Y7mAdgK1y8ZjC2ruiYiLYzP+EtQqgVLjj9KttIvtTvmldDEQlcKUX0rXfX4c+jNBWxzf8J6bLXPYBLUEtcpTBrq7pcj7tDAran2o7bwPEVx8rfMrEX7HcgF10UxQc5HMrY8OktT4o3QdngkNyi+lSzBwaFJ+Kd0EtbpeT1BLUKurIHbvBDWWb1bUAL4JavVQE9TqGW4p5NbHepbUBJbSrXfMKFB+KV2GQr0q5ZfSTVCr6/MEtQS1ugpi905QY/kmqAF8E9TqoSao1TNMUPMxpCawlK7PuVeJ8kvpet371Ci/lG6CWl3fJ6glqNVVELt3ghrLN0EN4JugVg81Qa2eYYKajyE1gaV0fc69SpRfStfr3qdG+aV0E9Tq+j5BLUGtroLYvRPUWL4JagDfBLV6qAlq9QwT1HwMqQkspetz7lWi/FK6Xvc+NcovpZugVtf3CWoJanUVxO6doMbyTVAD+Cao1UNNUKtnmKDmY0hNYCldn3OvEuWX0vW696lRfindBLW6vk9QS1CrqyB27wQ1lm+CGsA3Qa0eaoJaPcMENR9DagJL6fqce5Uov5Su171PjfJL6Sao1fV9glqCWl0FsXsnqLF8E9QAvglq9VAT1OoZJqj5GFITWErX59yrRPmldL3ufWqUX0o3Qa2u7xPUEtTqKojdO0GN5ZugBvBNUKuHmqBWzzBBzceQmsBSuj7nXiXKL6Xrde9To/xSuglqdX2foJagVldB7N4JaizfBDWAb4JaPdQEtXqGCWo+htQEltL1OfcqUX4pXa97nxrll9JNUKvr+wS1BLW6CmL3TlBj+SaoAXwT1OqhJqjVM0xQ8zGkJrCUrs+5V4nyS+l63Uu3X7B2k0PzzEM3PH9jY+PB1VXvBJbimKBW1+sJat46r+uNE/e+/YLzNx2aZx66/iRiXDvatptGghpNeEafCBhFntLdQzSdDkX4HcsFtBOoXTZOUHORPDL+HprqhM5FkRp/lK7Lt1uH8kvpuv0PfUJHcUxQq6ukBLUEtboKYvdOUGP5ZkUN4JugVg81Qa2eYVbUfAypCSyl63PuVaL8Urpe92VFbdjfvFMcE9TqKilBLUGtroLYvRPUWL4JagDfBLV6qAlq9QwT1HwMqQkspetz7lWi/FK6XvcJarU8T7/s8JE54VgC7xvec7NlDpuglqBWO3bI/S1F3qeBBw8e3FxbW9Pq6urS2tCn3TX7EAGjtIfSrfFK7kv4pSYi7m86XVwT1Fwkc+ujgyQ1/ihdh2dCg/JL6boZjCVguG+Vdl9nxsIxQa1uBGVc1/Hbq72XFpIS1HxdTAQXX+v8SoRf6oTlvoC6aCaouUgmqDlIUuOP0nV4JjQov5Sum8FYAkaCWl3Pb9VjgpqHo7se61p14t5DH9duv9v1EtRowjP6RMDIipqnA6mJSIKap3+GyrEZf3mZSGU3U+OP0q20i+1O+aV03SCGPqGjOLrPj2PhmKBWN4KoeqxrVYKaI6g9StK9kua9LvN0SV+V9NBunZUVNV8pUwHQ10KvEuGXOmG5L6AukllRc5HMipqDJDX+KF2HZ0KD8kvpuhmMJWC4VzDc15mxcExQqxtBGdd1/PZq7y4rak+Q9AxJH5T0VElf3tbIx0m6TtIDkp4s6R2Srp1nJEHN18VEcPG1zq9E+KVOWO4LqItmgpqLZIKagyQ1/ihdh2dCg/JL6boZjCVgJKjV9Xxufazjt7V3xrWHI63SJai9RNJ5kt4k6Yk7BLWLJZ0h6TJJByTdIamsrt23k4kENV/XEsHF1zq/EuGXOmElqHn6f6gci7v8jlp9H1Pjj9Ktd8woUH4pXTeFBLU6onnrYx2/7XtPtR69FIf/FlK33+16XYLawyF8TlC7RtJNkg5JKrrl1sdVSRsJakcJEAGD1KWLr68+wZGaiAw1YGRFrW/1nbhfglo9S2r8Ubr1jhkFyi+l66Yw1Ymx+zozFo659bFuBGVc1/Hbq72dQe0GSeW/DzSN/5KkcyR9YX19/cqVlZUrtpsqr+ef2of4OYISXMKxjkA5YZUJ98pKnyEx/9gHDpVF6PrP4Qs/WS+yg8JY6nHgHDfdtzJNtB5HwxEZjD7RyXI89dJLLBTvv3q96IyGo/v8OBaOb7zmM5b+ftdPfa9FZ7vIWDi65z1umEPn6Pa7Xa/PrLSEgp1ufXyrpHskvVPSyZLukvSYeS8Vya2Pvq4lVph8rfMrEX6pb5bc33S6aGZFzUUytz46SFLjj9J1eCY0KL+UrpvBWFaC3F/suK8zY+GYFbW6EZRxXcdvr/Z2BLWyanaLpOdJeq2kF0gqS2VvlvSseUYS1HxdTAQXX+v8SoRf6oTlvoC6aCaouUgmqDlIUuOP0nV4JjQov5Sum8FYAkaCWl3P52Uidfy29s649nCkVfoGtfIGyDubxpVVtCO3OEr6kKSzJT1S0vMlfSpB7RgBImAUdUqXLr6++oRf6oSVoNa3l4/fb6gcm/GX31Gr7GZq/FG69779wA9WWj6y++mXHy7XTNuH8kvp2ow3QglqdUTzMpE6ftv3nmo9einmZSJ9gtqiPjhL0mFJX99tw6yoLcLY/u9EcGl/9L3fkvBLTUSGGjCyouar27xMpJ4lNf4o3YGP6wfdKzYUx/rKOV5hqhNjdz2OhWNufawbQRnXdfz2am8iqLVqe4JaK0ytNiKCS6sDL2kjwi91wnJfQF3IE9RcJHPro4MkNf4o3YGP6wS1yqI889D1J21sbIyGo7seE9QqC2jiK7weesdUhl6Pbr/b9RLUaMIz+kTAKPKU7h6i6XQowu9EJ3Tllj37OYDoH/dEpFPBLdg4K2r1NKnxR+kOtR4pv5RufeVkRa0QcNfj0CfGeUbNM3Iyrj0caRX7JK1tg7Oi1pbU4u2IifHioy5vC8IvdcJyX0Bd1LOi5iKZFTUHSWr8UboDH9ejWQly1M6sxlgChvvWVHc9joVjbn2sG0HU+bGuVSfuPfR6dPvNihpNdBd9ImBkRc3TodQJy30B9biVEtRcJBPUHCSp8Xfsm/dPP8fRzhsP/ugniBUMR9uKBs3RHTBcvrd0hj6ho/rHfZ0ZC8cEtboRRNVjXasS1BLU3BXUQS9BrQOsPQ681AnLfQH1EExQc3FsvijJWx8rgVLjj7pFauDjOitqlfWYZ9TOL7+XW/2hOSao1XURdd6ta1WCWoKau4I66CWodYCVoHYcga3XJnsIJqi5OCaoeUhSE4YEtWH3j6d1x1TGshLkXpl0f3EwFo4JanUjiDrv1rUqQS1BzV1BHfQS1DrASlBLUJsh4J6IeCrxqEpeJlJPk5owJKjV901RoPrH07oENff5MUHNU5lj4ej+4sBDbzzj2u03QY0muscBo5kobhJv71siql0PTQReaiLivoC6+iTPqLlIJqg5SFLjL0HN0TsJah6KHEf3dWYsASMranWVSZ1361p14t5Dr0e33wQ1mmiCGk44Qa0ecYJaPcMthayo1bOkJgwJavV9kxU1D0OSY4JaXR/dePBC5A3oQw8YM+fHT9cRPLr3jQcv/G8cOts1hs6R8DyriRRnm0bn9fxtKLXbhggu7Y68nK0Iv9RE0X0BdRFPUHORzIqagyQ1/hLUHL3DrQR5WndMZegTOqrO3deZsXDMilrdCKLOj3WtOnHvodej2+92vQQ1mvCMPhEwijylu4doOh2K8DuWC2gnULtsnKDmIpmg5iBJjT9qIuKeGDsYFg2aY55lqespqn/c9Tj0iTE1rut6d3wBIxzdPc7oJagxXHdUJQJGgpqnA8dyAfW45d/6+Jpf+Tff6mjrR65++R1Fxz0RcbRtSyO3PtbTpMYfNREZaj3SHBPU6mqd6h93PSao1fXz1t7hOA2OHpfzVRLUaMJZUbMTJgLvWC6gLpj0itob3nOzpalbzw64JyKWxjUiCWr1NKnxl6BW3zfkSp2ndcdUxjIxdgde9/lxLBxz62PdCKLOj3WtOnHvodej2+92vQQ1mnCCmp1wglo90gS1eoZZUfMxTFDzsKQ5ugOGx3WCWoJaXSXlZSI3W7LAVDnWVd/ivS2ds/gwJ26Rl4n0obbzPkRw8bXOr0T4pSY47guoi2aCmotknlFzkKTGH/WN8cDH9YPuQEX1j6N2ZjWG/s07xdFdj2PhmBW1uhFEnR/rWpUVtayouSuogx4RMMrhKd0O1vZ0U8LvWC6gLtAJai6SCWoOktT4oyYi7omxg2HRoDm6A6DL95bOWAKGm6O7HsfCMUGtbgRR58e6ViWoJai5K6iDHhEwEtQ6dMAum1ITHPcF1OOWf5lInlGr66mJ1iO2EuSe0A18XGMc3QGjbpSMb0I3lnGdoOapzHCcBkePy/kqufWRJjyjn6DmgU1wHMsF1EMwQc3Fsfmi5CH3BHai9YgFjAS1uoqn6vEv3n7g2XUtO7r3GZcf/kT5v2OZGLvPF+4vDsbC0T2uHbU4qxGOHqJD5+hx6QtqJ0l6ZHlbdm3D8oxaLcFj+xPBxdc6vxLhl5qIuC+gLpq59dFFMrc+OkhS44+6tWfg4xoLvAkYddVO1bm7Hoc+MabGdV3vjneFN4HX3fNevS4raq+Q9EZJX5T0CEkvk3TnTHNObf73h5t/u1XS5fOam6Dm60giuPha51ci/I7lAuqimaDmIskGtde+89byxVj153//pz94fxFxT+iqG9YIUOOPmtBNlWOCWl3FU3XurscEtbp+3to7HKfB0eNyvkrboFaC2dclPUbS3ZJ+XlL5Idr1GemnS3qbpJdKemBRwxPUFhFq/3ciuLQ/+t5vSfidmdAdmdDWfm48eOGRCbb7Alrbrq39E9RcJNmg5v6mc+D1iK0EhWNdvSdg1PHbdt6117l7XCdgePo7HKfB0eOyPqh9u6SbJK02Uq+T9F2SXjUj/SJJ15XbxSWVX7u9SNLH5x06Qc3XtURw8bXOr0T4neg37+XZqrZf1rTuyNI/eZlIa1w7bjjRerRPYMOxrg4TMFbL4x62TwKvByU1rj2tO6aSoOYhOnSOHpf1Qe0Zkn5T0tMaqZdL+n5JPzkj/VxJz5T0bkkXSLpEUlll21xfX79yZWXliu3NWFtbo/0NTp+aGA/OKNwgN8dy4r/tttseeuM1n7G0/F0/9b1HdA4cOs+id/jCT1p0tou4ORZ9Z1AbCcdN9y1hE63HcPSMcozjyor3ex33+fHUS8u0o/5z/9VHbhYKx0qUNEf39brS7gm7j6Uew9Hd8169tmfdchvXfZLKt0ubkt7UNOPnZppziqQHm/9Obm5/PKu8iGmnJmdFzdeRxAqTr3V+JcIv9Q2d+5YUF83c+ugimVsfHSSplYaJjmtsZdL9hYT7/Dj0b96pOp8qR/ctzY5z2azGWOoxHN0979VrG9TKUT8r6TWSbpH0EUllheyjks5p/q3c6vj4ZptzJb1v5lbJE1qdoObryGYF43qH4o0HL7zQoUNqJKjV001Qq2e4pVBWYt0T2AQMT/+Eo5eju86nGjDCsa4uqXFd16oT905Q8xAdOkePy/kqXYLaiyW9v5H63ealIWV17Z4mrH2leY6tvEik/FeC3I3zDp2g5uta561mNx68sEtN+Ex0UEpQ6wBrzqYJavUME9R8DKmVBmpC5w4YLpI4x2s+8wuOtt64fsFri46b49AndFT/TJVjVoLqRiN1fqxr1fgCr9vvdr2uk/LTJH1T88bHeW07IOnwooYnqC0i1P7vCWrtWc3bkjphuS+g9U6PKiSouUjm1kcHSWoCO9Fxjd366J4Yu8+PCWp1o/H0yw4fmROOhaO7HuvojS9gUOfHqXF0+60Narb2JKjZUFpf3pAVtZu7fnmxY0ducXRPRFxVk6DmIpmg5iCZoOag+PAXMAlqlTjPPHT9SRsbGxjH3PpY10EJGHX8tvYORw9HWsUyKe3TyAS1PtR23odYUbv3qgOfcrTw9MsOl2cYrZ/c+liPM0GtnuGWQp5Rq2eZoFbPsChMneNYVoIS1OrqPQGjjl+CmvdnNzy9MV8lQY0mPKNPBIwiDwW18vxh9WfrVopqIZgjdeLPilpdzw99ZbIZf3mZSF03Tz5gVOJ7ePcEtfMt1y16Re0N77n5zxx9fuPBC59QdNzXmbEE3tz6WFdF1LynrlUn7j30enT73a6XoEYThgNGgpqnA6kTlvsC6nGbZ9RcHBPUPCSnHjA8FLOiNvQJ3ViuM1Pl6BqHWzrh6CE6dI4el/NVEtRowglq9hojVibHcgF1lWtufXSRzDNqDpIJag6KCWpDn9CN5TozVY6eUXhMJRw9RIfO0eNyQkHt3qsOfMYB7fTLDn+PQ2dWgwgYWVHz9NJYLqAet1lRc3HMipqHZIJaONYQmPrbCt13bgx9Ykxdr2tqcKd9w9FDdOgcPS6nFdQs96iP5dmqBDXPEKFO/O4LqMdtgpqLY4Kah2SCWjjWEEhQO2Cd9wx9Ykxdr2tqMEFNot4aPvR6dNfNdj37bWltG0y99XGoE+OtQLW6umpnnpeJtK26+dtRJ/6h1mNufayvmS2FvPWxnmWCWj3DojB1jkOf0I3lOjNVjp5ReEwlHD1Eh87R4zIrap05ZkXN+w1d5w7YZQfiFtKxXEBdHBPUXCTzjJqD5NQDhoNhgtp0f6jZ/YXg0CfG1PXaNQ63dMLRQ3ToHD0uE9Q6c0xQS1DrXDQzOwz9tfIJajW9e/y+WVGrZ5mgVs8wQS1BrbaKpn4LaS2/7fsPPWAk8Lp7nNGz34bXtpm59bEtqcXb5dbHxYwWbUGdsNzfdC7y0fbvCWptSS3eLkFtMaNFWySoLSLU7u9T5zjVibH7OjNVju1GWfutwrE9q922HDpHj8usqHXmmBW1rKh1LpqsqB0hMMEvDvKD1zWDJc9WVdI7tnuC2mh+8NryJTl158bQJ8bUF6u2gdgIhaOH6NA5elwmqHXmmKCWoNa5aBLUEtRqimZmX2oi4v7m3WR38i/BCMc6AlO/Zc89roc+MabOj3VVeOLe4eghOnSOHpcJap05JqglqHUumgS1BLWaoklQe3B1dfUkE8IjMtSEzj0xdnnOilpW1GpqaeqBt4bdTvsOPWBQ58epcXT73a5nWX7v08g8o9aH2s77TPBWs033zxxQJ6yBT+jKLXv2c8AE6zG3PlaezqYeMCrxPbz71DlOdWLsvs5MlaNrHG7phKOH6NA5elxmRa0zx6yoZUWtc9FkRS0rajVFkxW1rKhV1k+CWlbUakooK2o19E7cd+gBg/qC2ktx+G9zdfvNilpLoglqCWotS2XHzaiHvGvaNLtv3vroIpnfUXOQnHrA+OL553/QwfFbr7/+JRsbG5MNvFOdGGdFrW70bF2v61QS1KbK0V03gwtqb3jPzV9ymLzx4IUHio77hOVo25YG8UPNRXuCt5rl1sfKwkxQqwQ4s3tez1/PcupBLQGjroamvhLknvdMtR7rqjBBLUHNXUFH9bo+n1IeCE2d+gAAIABJREFU9H5kyUO7NOd0SV+V9NBuTd56Ru0N77nZ4mzoKxhbgSrPBNV3NxF4qVsA3BfQenpHFRLUXCSzouYgmaCWW/Zq6ihBzXsHTIJaTTUe2zccp8HR43K+Speg9gpJb5T0RUmPkPQySXfOSD9O0nWSHpD0ZEnvkHTtvEMnqPm6Nitq9SwT1OoZbilMsB7zMpHK8klQS1CrKaEEtQS1mvqZ6koQNe+p6Yud9h164HX73a7XNqiVYPZ1SY+RdLekn5d0h6T1GcGLJZ0h6TJJ5TbE8veyunbfTiYS1HxdO8GJcW59rCyfrKhVApzZPbc+1rNMUEtQq6miBLUEtZr6SVC7uW0W2BXzVDnW1F6bfdt2zrdLuknSaiP6OknfJelVMwe5ptnmUHNLZbn1sWy/kaB2lABxy96Wbm4hbVPu87ehvlnKrY91/TKSW5qzolbXzZP/weuhf2M8lvNjONYNxKkH3jp6J+491XqcGke3374ras+Q9JuSntYIvFzS90v6yRnBGySV/z7Q/Ft5Scg5kr6wIKi9z2HyxoMX/p2ic9/VB37NoXfapYeP6N1+4VrxWv150qHffB8c1MKxopdmJiLvr5B5eNeh1+OZv3HD+zc2NsjfUZtSPZJBbUr1SL6tcNgcL7jAct0689ChH4ff+hiOFReI0VxnJlqPf/mP/oplvveot9xx5Pp3ezhWjBZpLByrTLbYue2KWnmBSLmFsbxMZFPSmxrtn5s5xlsl3SPpnZJOlnRXc6vkQ+vr61eurKxcsb09a2trLZq43E1OvfQSSwPuv/roXaLUy0QsjQRFhs6xXEDLLWwrK22HBAhrF+mhcyxNL19ILIdO+6OaOZZbccu50faZaD1OlqOtcI4KhaMHaDhOjOOBQ+dZHB++8JMWnW0io6nHqXEkOntWs8us9LOSXiPpFkkfkVSC10ebVbPyb8+T9FpJL5BUEtibJT1rnoGtZ9SI4OKE5lq6ftL1N5QgYH+2amtiHI51vU49I1PXqhP3dtXjmYeuP4lcUZtYPWIrau4AOPB6xFbUhs7R1S/UeYzSdfl261B+KV23f5ce5ZfSHfijCqM5P06No2u8zNPpEtReLGnrtofflfTSZnWtrKJt3eL4IUlnN6/wf76kTyWoHSWQoOZ5WJ7iSJ343QM4Qc1D1MWxqccEtcpuab44GM1EpNIutjt1HqN0MRCVwpRfSrfSLrY75ZfSnVrACEes9K3CXYJaOfBpkr6peaPjvIacJelw85bIuY3NipqvH6mVOl8Ly73aCWoOni6OWVGz1mOCWmVxJ6hVAmx2pyZelK7HtV+F8kvp+gl4FCm/lG6Cmqffp8bRQ22+StegZmtPgpoNJfY2SV8LE9RcLBPUPCRdHLOi5gm8CWqeuqYmsJSux7VfhfJL6foJeBQpv5Tu1AJGOHrqnFZJUFtA2DyhyzNqlRWdWx+tE2PsrY95Rq2u0KkLaF2rTtzbdX5MUPP0DFU3lK7HtV+F8kvp+gl4FCm/lG6Cmqffp8bRQy0rar05uiYiVMAoxnLrY+/ufXhH6sRf37LjFVz1mFsfPYE3K2oejglqnjMFdR6jdD2u/SqUX0rXT8CjSPmldKcWMMLRU+e0SlbUsqJG19gRfVfAoAIvdcJyw3VxTFDzBIwENQ/HBDXPmYI6j1G6Htd+Fcovpesn4FGk/FK6CWqefp8aRw+1rKj15uiaGFMBIytqvbv2uB2pE7+ndcdUXPWYoOYJGAlqHo4Jap4zBXUeo3Q9rv0qlF9K10/Ao0j5pXSnFjDC0VPntEpW1LKiRtdYVtSMhBPUPDBdHBPUEtQ8FelRoSZelK7HtV+F8kvp+gl4FCm/lG6Cmqffp8bRQy0rar05mid0eZlI7544uiO1Mkmd+CvtnrC7qx6zouYJGAlqHo5ZUfOcKajzGKXrce1XofxSun4CHkXKL6U7tYARjp46p1WyopYVNbrGsqJmJJyg5oHp4piglqDmqUiPCjXxonQ9rv0qlF9K10/Ao0j5pXQT1Dz9PjWOHmpZUevN8fYLz/83vXee2fFJh244l3o7I6Xr8L2lYZ4Y21cmqRO/k2HRcnHMiponYCSoeThmRc1zpqDOY5Sux7VfhfJL6foJeBQpv5Tu1AJGOHrqnFbJihpNeEafClSUrhONK2Dk1kfrxDi/o1ZZ5Alq1np8cHV19aTKLjlud2oi4myjU4vyS+k6vTu1KL+UrtO7U4vyS+kmqHl6f2ocPdSyokZzbKVPBSpKt5WplhslqLUEtWAzF8esqHkCRoKah2NW1DznB2oCS+l6XPtVKL+Urp+AR5HyS+lOLWCEo6fOaZWsqNGEs6J2hIArYGRFzToxzopa5fhPULPWY1bUKuuRmnhRupV2sd0pv5QuBqJSmPJL6d571RP/oNLykd1Pv+xL3+3Q2dKg/FK6Uwu8zr7eSStBjSacoJagZqwxV+DNiponYCSoeThmRc1zkqAmXpSux7VfhfJL6foJeBQpv5Sux7VfhfJL6SaoeWsgQc3Lc1c16hZFSteJxhUwsqJmnRhnRa2yyBPUrPWYFbXKeqQmXpRupV1sd8ovpYuBqBSm/FK6lXax3Sm/lG6CmrcUEtS8PBPU5hBIUPMUmotjVtQ8ASNBzcMxK2qe8wM18aJ0Pa79KpRfStdPwKNI+aV0Pa79KpRfSjdBzVsDCWpenglqCWpoRSWoefC6OCaoJah5KtKjQk28KF2Pa78K5ZfS9RPwKFJ+KV2Pa78K5ZfSTVDz1kCCmpdnglqCGlpRroCRFTVPwEhQ83DMiprntEFNvChdj2u/CuWX0vUT8ChSfildj2u/CuWX0k1Q89ZAgpqXZ4JaghpaUQlqHrwujglqCWqeivSoUBMvStfj2q9C+aV0/QQ8ipRfStfj2q9C+aV0E9S8NdA1qJUfI32kpHtrm3Hw4MHNtbU1ra6udm1D7aGXtj/10g9K1wnKPDHedNcNdcJyMixaLo5ZUfMEjAQ1D8esqHnOFNR5jNL1uParUH4pXT8BjyLll9L1uParUH4p3QQ1bw10CUmvkPRGSV+U9AhJL5N050xzTm3+94ebf7tV0uXzmpug5uvIBLV6ltQJq75lxyskqHmIujgmqCWoeSrSo0Kdxyhdj2u/CuWX0vUT8ChSfildj2u/CuWX0k1Q89ZA26BWgtnXJT1G0t2Sfl7SHZLWZ5rzdElvk/RSSQ8samaC2iJC7f+eoNae1bwtqRNWfcsS1NwMi16Cmoeqi2NW1Dz9QZ3HKF2Pa78K5ZfS9RPwKFJ+KV2Pa78K5ZfSTVDz1kDboPbtkm6StNoc/nWSvkvSq2aa8yJJ10k6Q9LNki6S9PF5zU1Q83Vkglo9S+qEVd+yBDU3wwQ1H9EENR9LhxJ1HqN0HZ4JDcovpUswcGhSfildh2dCg/JL6Saoeatgt6B2rqRXNocrAewXJT2t+d8vl/T9kn5ypjnPlfRMSe+WdIGkSySVVbbNnZqcoObryAS1epbUCau+ZQlqboYJaj6iCWo+lg4l6jxG6To8ExqUX0qXYODQpPxSug7PhAbll9JNUPNWwW5B7WxJL2wOd0jS/yupvEykBK83Nf/+czPNOUXSg81/Jze3P55V7jJaX1+/cmVl5YrtTS8vE5nax/0SjMKvBLWhczz10pLb6z/3X330bls3x3LCuu222x5aWWm7yFzvpY/Cyp//eZ/dTthn85u/GeE40XosL7cp50bbZyz1aB7Xk+VoK5yjQuHoARqO4egh4FEZTT0eOHSexfHhCz9p0dkmYudINHJWs8us9LOSXiPpFkkfkVSC10clndP8W7nV8fHNNmU17n0zt0qe4CMrar6uzYpaPUvqm6X6ljEKjd+H3IF3K6gRuk4SrpWgvEwkLxNx1mWtFnUeo3Rr/VL7U34pXYpDrS7ll9Kt9UvtT/mldLOi5q2ELkHtxZLe3xz+d5uXhpSVnHuasPaV5jm28iKR8l8JcjfOa26Cmq8jE9TqWVInrPqWMQoJap6AkaDm4ZiXiXjGOXUeo3Q9rv0qlF9K10/Ao0j5pXQ9rv0qlF9KN0HNWwNdglo58mmSvql54+O8lhyQdHhRMxPUFhFq//cEtfas5m1JnbDqW8YoJKh5AkaCmodjgppnnFPnMUrX49qvQvmldP0EPIqUX0rX49qvQvmldBPUvDXQNajZjp6gZkN55Bm1id1qZvdLnbB8vexVSlDzBIwENQ/HBDXP+KbOY5Sux7VfhfJL6foJeBQpv5Sux7VfhfJL6SaoeWsgQc3Lc1c1KlBRuk405meCEtQqOydBzRMwEtQ8HBPUKgd0szs18aJ0Pa79KpRfStdPwKNI+aV0Pa79KpRfSjdBzVsDCWpenglqcwgkqO1hobU4VIKaJ2AkqHk4Jqi1GLQtNqEmXpRuC0tL2YTyS+kuBVKLg1J+Kd0WlpayCeWX0k1Q85ZJgpqXZ4JagtoeVlT/QyWoeQJGgpqHY4Ja/7E8uyc18aJ0Pa79KpRfStdPwKNI+aV0Pa79KpRfSjdBzVsDCWpenglqCWp7WFH9D5Wg5gkYCWoejglq/cdygpqHXTiGo5+AR5EKVJRugpqn37dUEtS8PBPUEtT2sKL6HypBzRMwEtQ8HBPU+o/lBAwPu3AMRz8BjyIVqCjdBDVPvyeoeTm2UqNe+kHptjLVcqM8o9YS1B5tlqDmCRgJah6OCWqegU9NvChdj2u/CuWX0vUT8ChSfildj2u/CuWX0k1Q89ZAVtS8PLOilhW1Payo/odKUPMEjAQ1D8cEtf5jOStBHnbhGI5+Ah5FKlBRuglqnn7PipqXYys1auWL0m1lquVGWVFrCWqPNktQ8wSMBDUPxwQ1z8CnJl6Urse1X4XyS+n6CXgUKb+Urse1X4XyS+kmqHlrICtqXp5ZUcuK2h5WVP9DJah5AkaCmodjglr/sZyVIA+7cAxHPwGPIhWoKN0ENU+/Z0XNy7GVGrXyRem2MtVyo6yotQS1R5slqHkCRoKah2OCmmfgUxMvStfj2q9C+aV0/QQ8ipRfStfj2q9C+aV0E9S8NZAVNS/PrKhlRW0PK6r/oRLUPAEjQc3DMUGt/1jOSpCHXTiGo5+AR5EKVJTuvVf/lVc7nJ9+6R2/7NDZ0qD8Otu4k1aCGk14Rp9a+aJ0nWiyouakWa+VoOYJGAlqHo4JavVjuihQExFK1+Par0L5pXT9BDyKlF9K1+Par0L5pXT9BDyKY/WboObp/1YqVKCidFuZarlRglpLUHu0WYKaJ2AkqHk4Jqh5Bj41EaF0Pa79KpRfStdPwKNI+aV0Pa79KpRfStdPwKM4Vr8Jap7+b6VCBSpKt5WplhvdfsH5f9xy0103e9L1N5xN+B3rAO7LNEHNEzAS1DwcE9T6juTj96POY5Sux7VfhfJL6foJeBQpv5Sux7VfhfJL6foJeBTH6jdBzdP/rVSIgFEOTOm2MrWEjQi/Yx3AffEnqHkCRoKah2OCWt+RnKDmIReO4UgQ8GhS8xNK1+ParzJWvwlq/lqYq0gEjAQ1TweOdQD3dZ+g5gkYCWoejglqfUdyAoaHXDiGI0HAo0nNTyhdj2u/ylj9Jqj5ayFBDWZKBN6xDuC+qBPUPAEjQc3DMUGt70hOwPCQC8dwJAh4NKn5CaXrce1XGavfBDV/LSSowUwT1OoBJ6h5AkaCmodjglr9mC4K1ESE0vW49qtQfildPwGPIuWX0vW49qtQfildPwGP4lj99glqj5J0b7kmzEF3uqSvSnpoN7QHDx7cXFtb0+rqap82eHptj1WIgFEsULp7jKf14Qi/Yx3AraFt2zBBzRMwEtQ8HBPU+o7krAR5yIVjOBIEPJrU/ITS9bj2q4zVb5eQ9ARJz5D0QUlPlfTlbRgfJ+k6SQ9IerKkd0i6dh7qBDVfERLBxdc6vxLhd6wDuC/dBDVPwEhQ83BMUOs7khMwPOTCMRwJAh5Nan5C6Xpc+1XG6rdLUHuJpPMkvUnSE3cIahdLOkPSZZIOSLpDUlldu28n3AlqviIkgouvdX4lwu9YB3BfuglqnoCRoObhmKDWdyQnYHjIhWM4EgQ8mtT8hNL1uParjNVvl6C2Ra3c8rhTULtG0k2SDkkquuXWx1VJGwlqRwkQAYPU9Q8TjyLBcawDuC/RBDVPwEhQ83BMUOs7khMwPOTCMRwJAh5Nan5C6Xpc+1XG6ne3oHaupFc2qC5vVsjK/5wX1G6QVP77QLPPlySdI+kL6+vrV66srFyxHXt5Rm1qH+KZvBJcwrGOQBnAt91220MrK32+u6g79jL3nmo9nnrpJRbs91+9fuScuLq6epJFsBEZSz2Go7PXbVqTrUcbwaNC4egBGo7h6CHgUbHXo6dZ81V2m5WeLemFza7lWbO7tuYQc1bU3irpHknvlHRys/1j5r1UJLc++rqWWGHytc6vRPgd6zctfelmRc2zEpQVNQ/HrKj1HcnH70edxyhdj2u/CuWX0vUT8ChSfildj2u/CuWX0vUT8CiO1W+f5YPtK2pl1ewWSc+T9FpJL5BUlsreLOlZ8/AmqHkKr6gQwcXXOr8S4XesA7gv3QQ1T8BIUPNwTFDrO5IT1DzkwjEcCQIeTWp+Qul6XPtVxuq3b1Arb4C8s8FYVtGO3OIo6UOSykrcIyU9X9KnEtSOESACRoKaZzCPdQD3dZ+g5gkYCWoejglqfUdyAoaHXDiGI0HAo0nNTyhdj2u/ylj99glqi+idJemwpK/vtmFW1BZhbP93KgC2b8Hebkn4HesA7ks+Qc0TMBLUPBwT1PqO5AQMD7lwDEeCgEeTmp9Quh7XfpWx+iWCWiu6CWqtMLXaiAgurQ68pI0Iv2MdwH27IEHNEzAS1DwcE9T6juQEDA+5cAxHgoBHk5qfULoe136VsfpNUPPXwlxFImCUg1G6e4im06EIv2MdwJ3AzWycoOYJGAlqHo4Jan1HcgKGh1w4hiNBwKNJzU8oXY9rv8pY/Sao+WshQQ1mmqBWDzhBzRMwEtQ8HBPU6sd0UaAmIpSux7VfhfJL6foJeBQpv5Sux7VfhfJL6foJeBTH6jdBzdP/rVSIgJEVtVboF2401gG80NicDRLUPAEjQc3DMUGt70jOSpCHXDiGI0HAo0nNTyhdj2u/ylj9Jqj5ayErajBTIvCOdQD3RZ2g5gkYCWoejglqfUdyAoaHXDiGI0HAo0nNTyhdj2u/ylj9Jqj5ayFBDWaaoFYPOEHNEzAS1DwcE9Tqx3RRoCYilK7HtV+F8kvp+gl4FCm/lK7HtV+F8kvp+gl4FMfqN0HN0/+tVIiAUQ5M6bYytYSNCL9jHcB98SeoeQJGgpqHY4Ja35GclSAPuXAMR4KAR5Oan1C6Htd+lbH6TVDz10JW1GCmCWr1gBPUPAEjQc3DMUGtfkxnRc3DMBzD0UfAo0QFDErX49qvMla/CWr+WkhQg5kmqNUDTlDzBIwENQ/HBLX6MZ2A4WEYjuHoI+BRogIGpetx7VcZq98ENX8tJKjBTBPU6gEnqHkCRoKah2OCWv2YTsDwMAzHcPQR8ChRAYPS9bj2q4zVb4KavxYS1GCmCWr1gBPUPAEjQc3DMUGtfkwnYHgYhmM4+gh4lKiAQel6XPtVxuo3Qc1fCwlqMNMEtXrACWqegJGg5uGYoFY/phMwPAzDMRx9BDxKVMCgdD2u/Spj9Zug5q+FBDWYaYJaPeAENU/ASFDzcExQqx/TCRgehuEYjj4CHiUqYFC6Htd+lbH6TVDz10KCGsw0Qa0ecIKaJ2AkqHk4JqjVj+kEDA/DcAxHHwGPEhUwKF2Pa7/KWP0mqPlrIUENZpqgVg84Qc0TMBLUPBwT1OrHdAKGh2E4hqOPgEeJChiUrse1X2WsfhPU/LWQoAYzTVCrB5yg5gkYCWoejglq9WM6AcPDMBzD0UfAo0QFDErX49qvMla/CWr+WkhQg5kmqNUDTlDzBIwENQ/HBLX6MZ2A4WEYjuHoI+BRogIGpetx7VcZq98ENX8tJKjBTBPU6gEnqHkCRoKah2OCWv2YTsDwMAzHcPQR8ChRAYPS9bj2q4zVb5+g9ihJ90rarMF48ODBzbW1Na2urvZpQ82hl7YvETCKGUp3aaAWHJjwO9YB3LePEtQ8ASNBzcMxQa3vSD5+P+o8Rul6XPtVKL+Urp+AR5HyS+l6XPtVKL+Urp+AR3GsfruEpCdIeoakD0p6qqQvb0N3qqQ7JX24+fdbJV0+D2+CmqfwEtQ8HMc6gPu6T1DzBIwENQ/HBLW+IzlBzUMuHMORIODRpOYnlK7HtV9lrH67BLWXSDpP0pskPXGHoPZ0SW+T9FJJDyxCnKC2iFD7vxMrTO2PvvdbEn7HOoD70k9Q8wSMBDUPxwS1viM5AcNDLhzDkSDg0aTmJ5Sux7VfZax+uwS1LWrllsedgtqLJF0n6QxJN0u6SNLHs6J2jAARMLKi5hnMYx3Afd0nqHkCRoKah2OCWt+RnIDhIReO4UgQ8GhS8xNK1+ParzJWv7sFtXMlvbJBVW5hvKP5/+cFtedKeqakd0u6QNIlksoq2+b6+vqVKysrV2zHXp5Rm9qHeCavBMBwrCNQBvBtt9320MpKn+8u6o69zL2nWo+nXlpOT/Wf+69eLyKbq6urJ9WrHVMYSz2Go7PXbVqTrUcbwaNC4egBGo7h6CHgUbHXo6dZ81V2m5WeLemFza7XSrprQVA7RdKDzX8nN7c/niXp9p0On1sffV1LrdT5WuhVIvyO9ZuWvmSzouZZCcqKmodjVtT6juTj96POY5Sux7VfhfJL6foJeBQpv5Sux7VfhfJL6foJeBTH6rfP8sH2FbVzJN3S3Or4eEmvkVRW494naXUe3gQ1T+EVFSK4+FrnVyL8jnUA96WboOYJGAlqHo4Jan1HcoKah1w4hiNBwKNJzU8oXY9rv8pY/fYNauUNkOUNj+Vzj6QS1r4i6aZmJa28TKTc6nhjgtoxAkTASFDzDOaxDuC+7qce1P70/PN/tC+72f2+7YYbfqPcMkvc+rixsfGgW9fheVbj9gsS1NxMa/So8xilW+OV3JfyS+mSLGq0Kb+Ubo1Xcl/KL6VLsqjRHqvfPkFtEacDkg4v2igraosItf87FQDbt2BvtyT8jnUA9yU/9aDWl9tO+yWo1dPMilo9w6JAnccoXY9rvwrll9L1E/AoUn4pXY9rvwrll9L1E/AojtUvEdRaEU1Qa4Wp1UZEcGl14CVtRPgd6wDu2wUJan3Jnbhfglo9ywS1eoYJah6G4RiOPgIeJWp+Qul6XPtVxuo3Qc1fC3MViYBRDkbp7iGaToci/I51AHcCN7NxglpfcglqswRy66OvjhxK1HmM0nV4JjQov5QuwcChSfmldB2eCQ3KL6VLMHBojtVvgpqj91tqEAEjQa0l/AWbjXUA93WfoNaXXIJagpqvdtxK1HmM0nX7d+lRfildl2+3DuWX0nX7d+lRfildl2+3zlj9Jqi5K2EXvQQ1D2yC41gHcF+iCWp9ySWoJaj5asetRJ3HKF23f5ce5ZfSdfl261B+KV23f5ce5ZfSdfl264zVb4KauxIS1HCiCWr1iBPU6hluKeQZtXqWeUatnmFRoCYilK7HtV+F8kvp+gl4FCm/lK7HtV+F8kvp+gl4FMfqN0HN0/+tVIiAUQ5M6bYytYSNCL9jHcB98Seo9SV34n4JavUsE9TqGSaoeRiGYzj6CHiUqPkJpetx7VcZq98ENX8tzFUkAkaCmqcDxzqA+7pPUOtLLkFtlkBeJuKrI4cSdR6jdB2eCQ3KL6VLMHBoUn4pXYdnQoPyS+kSDByaY/WboObo/ZYaCWotQS3YjOA41gHcl2iCWl9yCWoJar7acStR5zFK1+3fpUf5pXRdvt06lF9K1+3fpUf5pXRdvt06Y/WboOauhF30iIBRDkfp7iGaToci/I51AHcCN7NxglpfcglqCWq+2nErUecxStft36VH+aV0Xb7dOpRfStft36VH+aV0Xb7dOmP1m6DmroQENZxoglo94gS1eoZbCnlGrZ5lnlGrZ1gUqIkIpetx7Veh/FK6fgIeRcovpetx7Veh/FK6fgIexbH6TVDz9H8rFSJglANTuq1MLWEjwu9YB3Bf/AlqfcmduF+CWj3LBLV6hglqHobhGI4+Ah4lan5C6Xpc+1XG6jdBzV8LcxWJgJGg5unAsQ7gvu4T1PqSS1CbJZCXifjqyKFEnccoXYdnQoPyS+kSDByalF9K1+GZ0KD8UroEA4fmWP0mqDl6v6VGglpLUAs2IziOdQD3JZqg1pdcglqCmq923ErUeYzSdft36VF+KV2Xb7cO5ZfSdft36VF+KV2Xb7fOWP0mqLkrYRc9ImCUw1G6e4im06EIv2MdwJ3AzWycoNaXXIJagpqvdtxK1HmM0nX7d+lRfildl2+3DuWX0nX7d+lRfildl2+3zlj9Jqi5KyFBDSeaoFaPOEGtnuGWQp5Rq2eZZ9TqGRYFaiJC6Xpc+1Uov5Sun4BHkfJL6Xpc+1Uov5Sun4BHcax+E9Q8/d9KhQgY5cCUbitTS9iI8DvWAdwXf4JaX3In7pegVs8yQa2eYYKah2E4hqOPgEeJmp9Quh7XfpWx+k1Q89fCXEUiYCSoeTpwrAO4r/sEtb7kEtRmCeRlIr46cihR5zFK1+GZ0KD8UroEA4cm5ZfSdXgmNCi/lC7BwKE5Vr8Jao7eb6mRoNYS1ILNCI5jHcB9iSao9SWXoJag5qsdtxJ1HqN03f5depRfStfl261D+aV03f5depRfStfl260zVr9dg9ojJD1K0ld2AXi6pK9Kemg3yAcPHtxcW1vT6upq1za4+27P9IiAURpP6e4ZmI4HIvyOdQB3RPfw5glqfcklqCWo+WrHrUSdxyhdt3+XHuWX0nX5dutQfildt3+XHuWX0nX5duuM1W+XkPRmSa+W9ClJj5Z0kaRbZ0A+TtJ1kh6Q9GRJ75B07TyLxovYAAAO60lEQVTQCWq+EiSCi691fiXC71gHcF+6CWp9ySWoJaj5asetRJ3HKF23f5ce5ZfSdfl261B+KV23f5ce5ZfSdfl264zVb9ugdoqk+5vVtHslvUXSEyW9bgbkxZLOkHSZpAOS7pBUVtfu2wl2gpqvBIng4mudX4nwO9YB3JduglpfcglqCWq+2nErUecxStft36VH+aV0Xb7dOpRfStft36VH+aV0Xb7dOmP12zaoFV6PlXSXpNMkfUzSuyQdmgF5jaSbmn8ruuXWx1VJGwlqRwkQAYPUdQ8Slx7BcawDuC/TBLW+5BLUEtR8teNWos5jlK7bv0uP8kvpuny7dSi/lK7bv0uP8kvpuny7dcbqd7egdq6kVzagLm9WyJ4p6b2S/lDSqyR9bQbkDZLKfx9o/u1Lks6R9IUEtQQ154BLUKunmaBWz3BLIa/nr2eZ1/PXMywK1ESE0vW49qtQfildPwGPIuWX0vW49qtQfildPwGP4lj97hbUzpb0wgZPedashLTyDNrrJV2/A7a3SrpH0jslndysvj2mrKytr69fubKycsX2fcrLRKb2IV6eUoJLONYRKAO4TLhXVrosMtcdcwh7px4tvbC5urp6kkWpERlLPZ566SUW2/dfvX4kZ0yVowXiMZFw9AANx3D0EPCopB4HytHTrPkqbWelZbu7JT1P0qe3yZVVs1uav71W0gsklQRWXj7yrHmHzjNqvq4lVph8rfMrEX7H+k1LX7pZUetL7sT9sqJWzzIravUMjyTdzc2VjY2NB4nAS+h6XPtVwtHDNBzD0UPAo0LVo6d19UHtqZI+t03mVyX9RLOKtnWL44cklZW4R0p6fvOGyB2PnqDm61oiuPha51ci/I51APelm6DWl1yC2iyB/OC1r44cStR5jNJ1eCY0KL+ULsHAoUn5pXQdngkNyi+lSzBwaI7Vb9sVtS6MzpJ0WNLXd9spQa0L0t23JYKLr3V+JcLvWAdwX7oJan3JJaglqPlqx61EnccoXbd/lx7ll9J1+XbrUH4pXbd/lx7ll9J1+XbrjNUvEdRasU1Qa4Wp1UZEcGl14CVtRPgd6wDu2wUJan3JJaglqPlqx61EnccoXbd/lx7ll9J1+XbrUH4pXbd/lx7ll9J1+XbrjNVvgpq7EnbRIwJGORylu4doOh2K8DvWAdwJ3MzGCWp9ySWoJaj5asetRJ3HKF23f5ce5ZfSdfl261B+KV23f5ce5ZfSdfl264zVb4KauxIS1HCiCWr1iBPU6hluKeRlIvUs8zKReoZFgZqIULoe134Vyi+l6yfgUaT8Uroe134Vyi+l6yfgURyr3wQ1T/+3UiECRjkwpdvK1BI2IvyOdQD3xZ+g1pfcifslqNWzTFCrZ5ig5mEYjuHoI+BRouYnlK7HtV9lrH4T1Py1MFeRCBgJap4OHOsA7us+Qa0vuQS1WQJ566OvjhxK1HmM0nV4JjQov5QuwcChSfmldB2eCQ3KL6VLMHBojtVvgpqj91tqJKi1BLVgM4LjWAdwX6IJan3JJaglqPlqx61EnccoXbd/lx7ll9J1+XbrUH4pXbd/lx7ll9J1+XbrjNVvgpq7EnbRIwJGORylu4doOh2K8DvWAdwJ3MzGCWp9ySWoJaj5asetRJ3HKF23f5ce5ZfSdfl261B+KV23f5ce5ZfSdfl264zVb4KauxIS1HCiCWr1iBPU6hluKeQZtXqWeUatnmFRoCYilK7HtV+F8kvp+gl4FCm/lK7HtV+F8kvp+gl4FMfqN0HN0/+tVIiAUQ5M6bYytYSNCL9jHcB98Seo9SV34n4JavUsE9TqGSaoeRiGYzj6CHiUqPkJpetx7VcZq98ENX8tzFUkAkaCmqcDxzqA+7pPUOtLLkFtlkBeJuKrI4cSdR6jdB2eCQ3KL6VLMHBoUn4pXYdnQoPyS+kSDByaY/WboObo/ZYaCWotQS3YjOA41gHcl2iCWl9yCWoJar7acStR5zFK1+3fpUf5pXRdvt06lF9K1+3fpUf5pXRdvt06Y/WboOauhF30iIBRDkfp7iGaToci/I51AHcCN7NxglpfcglqCWq+2nErUecxStft36VH+aV0Xb7dOpRfStft36VH+aV0Xb7dOmP1m6DmroQENZxoglo94gS1eoZbCnlGrZ5lnlGrZ1gUqIkIpetx7Veh/FK6fgIeRcovpetx7Veh/FK6fgIexbH6TVDz9H8rFSJglANTuq1MLWEjwu9YB3Bf/AlqfcmduF+CWj3LBLV6hglqHobhGI4+Ah4lan5C6Xpc+1XG6jdBzV8LcxWJgJGg5unAsQ7gvu4T1PqSS1CbJZCXifjqyKFEnccoXYdnQoPyS+kSDByalF9K1+GZ0KD8UroEA4fmWP0mqDl6v6VGglpLUAs2IziOdQD3JZqg1pdcglqCmq923ErUeYzSdft36VF+KV2Xb7cO5ZfSdft36VF+KV2Xb7fOWP0mqLkrYRc9ImCUw1G6e4im06EIv2MdwJ3AzWycoNaXXIJagpqvdtxK1HmM0nX7d+lRfildl2+3DuWX0nX7d+lRfildl2+3zlj9Jqi5KyFBDSeaoFaPOEGtnuGWQp5Rq2eZZ9TqGRYFaiJC6Xpc+1Uov5Sun4BHkfJL6Xpc+1Uov5Sun4BHcax+E9Q8/d9KhQgY5cCUbitTS9iI8DvWAdwXf4JaX3In7pegVs8yQa2eYYKah2E4hqOPgEeJmp9Quh7XfpWx+u0a1B4h6VGSvlKL8ODBg5tra2taXV3t2obaQy9tfyJgJKh5unOsA7iv+wS1vuQS1GYJ5GUivjpyKFHnMUrX4ZnQoPxSugQDhybll9J1eCY0KL+ULsHAoTlWv11C0pslvVrSpyQ9WtJFkm6dgXeqpDslfbj5t/K3y+fBTVBzlN1RDSoA+lroVSL8jnUA9yWboNaXXIJagpqvdtxK1HmM0nX7d+lRfildl2+3DuWX0nX7d+lRfildl2+3zlj9tg1qp0i6v1lNu1fSWyQ9UdLrZkA+XdLbJL1U0gOLACeoLSLU/u9EcGl/9L3fkvA71gHcl36CWl9yCWrbgtrtDpJnHrr+rI2NjQdXV1dPcuhtaUx0XIdjZRFRdUPpVtrFdqf8UroYiEphyi+lW2kX232sftsGtQLusZLuknSapI9JepekQzNEXyTpOklnSLq5WXH7+DziCWq+WiSCi691fiXC71gHcF+6CWp9ySWo+cgdU6LGH6VLMHBoUn4pXYdnQoPyS+kSDByalF9K1+GZ0KD8UroEA4fmWP3uFtTOlfTKBk65hfEOSc+U9F5JfyjpVZK+NgPvuc3f3y3pAkmXSCqrbJvr6+tXrqysXLEN9CfW1tae7YA/Jg3imbwSXMbEwNFWN8et4OJo25g03ByL9wnW4ya0EvTQmGrJ0NZwNEAs19zUowVkOFowph49GMNxqBxN7Zors1tQO1vSC5s9r21CWFkxe72k63dQLLdHPtj8d3Jz++NZkubeGjMnwNGel6a/srJy5UUXXfQP3Q0IRw/RcAzHPgQyrvtQO3GfcAxHDwGPSuoxHD0EPCqpx2Fz9LRuZ5W2tz6W7e6W9DxJn94mdY6kW5pbHR8v6TWSymrc+ySt1ja+3CJ58cUXt23nwsMNXW+hgZ4bDN23u309MS3czd3OoestBNJzg6H7drevJ6aFu7nbOXS9hUB6bjB03+729cS0cDd3O4eutxBIzw2G7tvdvp6YFu7mbufQ9RYC6bnB0H2729cTE7Zb2wD0VEmf29aKX5X0E5LukVTCWnll/03NSlp5mUi51fHG2pa7O2DoerW85u0/dN/u9oUjRcCj6+7voet5qJ2oMnTf7vaFI0XAo+vu76HreahlXIcjRcCjO/Rx6G6fh5pPpW1Q63LEA5IOd9lht23dHTB0PRe37TpD9+1uXzhSBDy67v4eup6HWiZ04UgR8OgOfRy62+ehlnEdjhQBj6573Axdz0PNp0IENV/rJA29Q93ts8KbEXO3c+h64UgR8OgOvX7c7fNQy4QuHCkCHl33uBm6nodaxnU4UgQ8ukMfh+72eaj5VAYf1MoLHi655JIrXZaHrufyuV1n6L7d7QtHioBH193fQ9fzUDtRZei+3e0LR4qAR9fd30PX81DLuA5HioBHd+jj0N0+DzWfyuCDms9qlEIgBEIgBEIgBEIgBEIgBEJgHASGHNTKGyS/KukvZ1CWnwwoLzX5eg+83ybpSZL+rSTH7xM9UtKjJN0505ZnSPqj5icKejQR2SUcPVjDMRzLz48M5ZN69PREOIZjxnX7Gsi8J/PHzMPbjxfLlkMOaluv+H+ZpJslvU7S2ySVl5Xc18P9d0j6gKRHS7pG0iFJt/bQ2drlOZI+Jul8Sb/Z/GMJaeUNmLPhsuIQll3D0YLx4Z+cSD3W8Uw91vHb2jscwzHXmfY1kOt15j2ZP7YfL7nOdGeF7THkoFZM/4Ck8mPbfybpLkmvqgxXRbMEth+W9OOS/lzSLzRB62sdKZcTf3l27kxJvybp7c3vyQ0tqIVjx47dZfPUo4dlOIajh4BHJfUYjh4CHpXUYzh6CHhUUo8ejr1VhhzUStvK77S9S9J/bH5wuwS17b/n1sX8KZKe3QS1sjLye00I/F5J393xlsgS1Erg+4dN0Cu3QD6rCYJD+qYzHLtUyPxtwzEcM67b10DOj0evD7nOtK+Z7Vvmei3d3XxBnXlPtzrK9bobr3lbh6OHY5XKkINaCVS/LOlHJf17ST8tab3i1sdnSvpE8wxZWaX7rSakFYC/IelySZ/vQHNrIlJuySwXlBIo/56kMwZ262M4dujUXTYNx3AcUlBLPaYeU4/tayDX66N3J2Xe0+/RmcwfMw9vf7YxbznkoPYtzbNo5YUiW5+nSdro+TKR8mxbeflHlzC2G+7Crvw3+2KSMpg/O7CXiYSjZ9CEYzgO6aUDqcfUY+qxfQ3ket2eVeY9JxLI/DHzcM8I6qEy5KDWw052CYEQCIEQCIEQCIEQCIEQCIHxE0hQG38fxkEIhEAIhEAIhEAIhEAIhMA+I5Cgts86NHZCIARCIARCIARCIARCIATGTyBBbfx9GAchEAIhEAIhEAIhEAIhEAL7jMD/D0VjklAYkW47AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<VegaLite 3 object>\n",
+       "\n",
+       "If you see this message, it means the renderer has not been properly enabled\n",
+       "for the frontend that you are using. For more information, see\n",
+       "https://altair-viz.github.io/user_guide/troubleshooting.html\n"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.head(10).plot(kind='bar', width=100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import altair as alt\n",
+    "from vega_datasets import data\n",
+    "\n",
+    "source = data.barley()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
[x] added `examples` folder
[x] tweaked pytest to use parametrized cases (up for discussion)
[x] added area chart for dataframe, with hardcoded default `alpha`
    [] perhaps would be better to have alpha as part of vega config
[x] added bar  charts for dataframe, with a hardcoded switch between grouped and overlapping
[ ] figure out a better-grouped chart behavior, right now goes beyond the width of the page
[ ] support stacked bar charts
[ ] support horizontal charts 
