### PR TITLE
ENH: Area chart should be stacked by default

### DIFF
--- a/altair_pandas/_core.py
+++ b/altair_pandas/_core.py
@@ -177,7 +177,7 @@ class _DataFramePlotter(_PandasPlotter):
             return data.reset_index()
         return data
 
-    def _xy(self, mark, x=None, y=None, **kwargs):
+    def _xy(self, mark, x=None, y=None, stack=False, **kwargs):
         data = self._preprocess_data(with_index=True)
 
         if x is None:
@@ -198,7 +198,7 @@ class _DataFramePlotter(_PandasPlotter):
             .transform_fold(y_values, as_=["column", "value"])
             .encode(
                 x=x,
-                y=alt.Y("value:Q", title=None),
+                y=alt.Y("value:Q", title=None, stack=stack),
                 color=alt.Color("column:N", title=None),
                 tooltip=[x] + y_values,
             )
@@ -208,8 +208,9 @@ class _DataFramePlotter(_PandasPlotter):
     def line(self, x=None, y=None, **kwargs):
         return self._xy("line", x, y, **kwargs)
 
-    def area(self, x=None, y=None, **kwargs):
-        return self._xy("area", x, y, **kwargs)
+    def area(self, x=None, y=None, stacked=True, **kwargs):
+        mark = "area" if stacked else {"type": "area", "line": True, "opacity": 0.5}
+        return self._xy(mark, x, y, stacked, **kwargs)
 
     # TODO: bars should be grouped, not stacked.
     def bar(self, x=None, y=None, **kwargs):

--- a/altair_pandas/_core.py
+++ b/altair_pandas/_core.py
@@ -177,7 +177,7 @@ class _DataFramePlotter(_PandasPlotter):
             return data.reset_index()
         return data
 
-    def _xy(self, mark, x=None, y=None, stack=False, **kwargs):
+    def _xy(self, mark, x=None, y=None, **kwargs):
         data = self._preprocess_data(with_index=True)
 
         if x is None:
@@ -198,7 +198,7 @@ class _DataFramePlotter(_PandasPlotter):
             .transform_fold(y_values, as_=["column", "value"])
             .encode(
                 x=x,
-                y=alt.Y("value:Q", title=None, stack=stack),
+                y=alt.Y("value:Q", title=None),
                 color=alt.Color("column:N", title=None),
                 tooltip=[x] + y_values,
             )
@@ -209,8 +209,11 @@ class _DataFramePlotter(_PandasPlotter):
         return self._xy("line", x, y, **kwargs)
 
     def area(self, x=None, y=None, stacked=True, **kwargs):
-        mark = "area" if stacked else {"type": "area", "line": True, "opacity": 0.5}
-        return self._xy(mark, x, y, stacked, **kwargs)
+        if stacked is True:
+            chart = self._xy("area", x, y, **kwargs)
+            chart.encoding.y.stack = True
+            return chart
+        return self._xy({"type": "area", "line": True, "opacity": 0.5}, x, y, **kwargs)
 
     # TODO: bars should be grouped, not stacked.
     def bar(self, x=None, y=None, **kwargs):

--- a/altair_pandas/_core.py
+++ b/altair_pandas/_core.py
@@ -177,7 +177,7 @@ class _DataFramePlotter(_PandasPlotter):
             return data.reset_index()
         return data
 
-    def _xy(self, mark, x=None, y=None, **kwargs):
+    def _xy(self, mark, x=None, y=None, stacked=False, **kwargs):
         data = self._preprocess_data(with_index=True)
 
         if x is None:
@@ -198,7 +198,7 @@ class _DataFramePlotter(_PandasPlotter):
             .transform_fold(y_values, as_=["column", "value"])
             .encode(
                 x=x,
-                y=alt.Y("value:Q", title=None),
+                y=alt.Y("value:Q", title=None, stack=stacked),
                 color=alt.Color("column:N", title=None),
                 tooltip=[x] + y_values,
             )
@@ -209,11 +209,8 @@ class _DataFramePlotter(_PandasPlotter):
         return self._xy("line", x, y, **kwargs)
 
     def area(self, x=None, y=None, stacked=True, **kwargs):
-        if stacked is True:
-            chart = self._xy("area", x, y, **kwargs)
-            chart.encoding.y.stack = True
-            return chart
-        return self._xy({"type": "area", "line": True, "opacity": 0.5}, x, y, **kwargs)
+        mark = "area" if stacked else {"type": "area", "line": True, "opacity": 0.5}
+        return self._xy(mark, x, y, stacked, **kwargs)
 
     # TODO: bars should be grouped, not stacked.
     def bar(self, x=None, y=None, **kwargs):

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -211,6 +211,17 @@ def test_dataframe_mark_properties(dataframe, kind, with_plotting_backend):
 def test_series_mark_properties(series, kind, with_plotting_backend):
     chart = series.plot(kind=kind, alpha=0.5, color="red")
     spec = chart.to_dict()
-    assert spec["mark"]["type"] == _expected_mark(kind)
-    assert spec["mark"]["opacity"] == 0.5
-    assert spec["mark"]["color"] == "red"
+    assert spec['mark']['type'] == _expected_mark(kind)
+    assert spec['mark']['opacity'] == 0.5
+    assert spec['mark']['color'] == 'red'
+
+
+@pytest.mark.parametrize("stacked", [True, False])
+def test_dataframe_area(dataframe, stacked, with_plotting_backend):
+    chart = dataframe.plot.area(stacked=stacked)
+    spec = chart.to_dict()
+    mark = "area" if stacked else {"type": "area", "line": True, "opacity": 0.5}
+    assert spec["mark"] == mark
+    for k, v in {"x": "index", "y": "value", "color": "column"}.items():
+        assert spec["encoding"][k]["field"] == v
+    assert spec["transform"][0]["fold"] == ["x", "y"]

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -211,17 +211,18 @@ def test_dataframe_mark_properties(dataframe, kind, with_plotting_backend):
 def test_series_mark_properties(series, kind, with_plotting_backend):
     chart = series.plot(kind=kind, alpha=0.5, color="red")
     spec = chart.to_dict()
-    assert spec['mark']['type'] == _expected_mark(kind)
-    assert spec['mark']['opacity'] == 0.5
-    assert spec['mark']['color'] == 'red'
+    assert spec["mark"]["type"] == _expected_mark(kind)
+    assert spec["mark"]["opacity"] == 0.5
+    assert spec["mark"]["color"] == "red"
 
 
 @pytest.mark.parametrize("stacked", [True, False])
 def test_dataframe_area(dataframe, stacked, with_plotting_backend):
     chart = dataframe.plot.area(stacked=stacked)
     spec = chart.to_dict()
-    mark = {"type": "area"} if stacked else {
-        "type": "area", "line": True, "opacity": 0.5}
+    mark = (
+        {"type": "area"} if stacked else {"type": "area", "line": True, "opacity": 0.5}
+    )
     assert spec["mark"] == mark
     for k, v in {"x": "index", "y": "value", "color": "column"}.items():
         assert spec["encoding"][k]["field"] == v

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -220,7 +220,8 @@ def test_series_mark_properties(series, kind, with_plotting_backend):
 def test_dataframe_area(dataframe, stacked, with_plotting_backend):
     chart = dataframe.plot.area(stacked=stacked)
     spec = chart.to_dict()
-    mark = "area" if stacked else {"type": "area", "line": True, "opacity": 0.5}
+    mark = {"type": "area"} if stacked else {
+        "type": "area", "line": True, "opacity": 0.5}
     assert spec["mark"] == mark
     for k, v in {"x": "index", "y": "value", "color": "column"}.items():
         assert spec["encoding"][k]["field"] == v


### PR DESCRIPTION
```python
data = pd.DataFrame(np.random.rand(10, 4), columns=['a', 'b', 'c', 'd'])
data.plot.area() | data.plot.area(stacked=False)
```

![image](https://user-images.githubusercontent.com/3757165/63854259-66f5de00-c9ba-11e9-8146-866e81ded2a0.png)

Earlier it was defaulting to area layers.

If this is good, will add a test.