### PR TITLE
ENH: scatter plot support for colormap

### DIFF
--- a/altair_pandas/_core.py
+++ b/altair_pandas/_core.py
@@ -230,6 +230,12 @@ class _DataFramePlotter(_PandasPlotter):
         if s is not None:
             encodings["size"] = _valid_column(s)
         columns = list(set(encodings.values()))
+        if kwargs.get("colormap"):
+            if c is None:
+                raise ValueError("'c' should be defined for using 'colormap'")
+            encodings["color"] = alt.Color(
+                encodings["color"], scale=alt.Scale(scheme=kwargs.get("colormap"))
+            )
         data = self._preprocess_data(with_index=False, usecols=columns)
         encodings["tooltip"] = columns
         mark = self._get_mark_def("point", kwargs)


### PR DESCRIPTION
[See: pandas.DataFrame.plot.scatter](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.plot.scatter.html#pandas.DataFrame.plot.scatter)

```python
df = pd.DataFrame(np.random.rand(50, 4), columns=['a', 'b', 'c', 'd'])
df.plot.scatter(x='a', y='b', c='c', colormap='viridis')
```

![image](https://user-images.githubusercontent.com/3757165/64027193-d526d600-cb5d-11e9-8bab-1293bb8e9c9b.png)

If this looks good, I'll update tests.