### PR TITLE
ENH: xy charts support for subplots (line, bar, barh, area, hist)

### DIFF
--- a/altair_pandas/_core.py
+++ b/altair_pandas/_core.py
@@ -206,7 +206,7 @@ class _DataFramePlotter(_PandasPlotter):
         )
 
         if subplots:
-            nrows, ncols = _get_layout(len(y_values), kwargs.get("layout"))
+            nrows, ncols = _get_layout(len(y_values), kwargs.get("layout", (-1, 1)))
             chart = chart.encode(facet=alt.Facet("column:N", title=None)).properties(
                 columns=ncols
             )
@@ -257,7 +257,7 @@ class _DataFramePlotter(_PandasPlotter):
             raise ValueError("orientation must be 'horizontal' or 'vertical'.")
 
         mark = self._get_mark_def({"type": "bar", "orient": orientation}, kwargs)
-        return (
+        chart = (
             alt.Chart(data, mark=mark)
             .transform_fold(list(data.columns), as_=["column", "value"])
             .encode(
@@ -266,6 +266,14 @@ class _DataFramePlotter(_PandasPlotter):
                 color="column:N",
             )
         )
+
+        if kwargs.get("subplots"):
+            nrows, ncols = _get_layout(data.shape[1], kwargs.get("layout", (-1, 1)))
+            chart = chart.encode(facet=alt.Facet("column:N", title=None)).properties(
+                columns=ncols
+            )
+
+        return chart
 
     def hist_frame(self, column=None, layout=(-1, 2), **kwargs):
         if column is not None:

--- a/altair_pandas/_core.py
+++ b/altair_pandas/_core.py
@@ -177,7 +177,7 @@ class _DataFramePlotter(_PandasPlotter):
             return data.reset_index()
         return data
 
-    def _xy(self, mark, x=None, y=None, stacked=False, **kwargs):
+    def _xy(self, mark, x=None, y=None, stacked=False, subplots=False, **kwargs):
         data = self._preprocess_data(with_index=True)
 
         if x is None:
@@ -193,7 +193,7 @@ class _DataFramePlotter(_PandasPlotter):
             assert y in data.columns
             y_values = [y]
 
-        return (
+        chart = (
             alt.Chart(data, mark=self._get_mark_def(mark, kwargs))
             .transform_fold(y_values, as_=["column", "value"])
             .encode(
@@ -204,6 +204,14 @@ class _DataFramePlotter(_PandasPlotter):
             )
             .interactive()
         )
+
+        if subplots:
+            nrows, ncols = _get_layout(len(y_values), kwargs.get("layout"))
+            chart = chart.encode(facet=alt.Facet("column:N", title=None)).properties(
+                columns=ncols
+            )
+
+        return chart
 
     def line(self, x=None, y=None, **kwargs):
         return self._xy("line", x, y, **kwargs)

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -71,9 +71,12 @@ def test_series_basic_plot(series, kind, with_plotting_backend):
 
 
 @pytest.mark.parametrize("stacked", [True, False])
+@pytest.mark.parametrize("subplots", [False, True])
 @pytest.mark.parametrize("kind", ["line", "area", "bar", "barh"])
-def test_dataframe_basic_plot(dataframe, kind, stacked, with_plotting_backend):
-    chart = dataframe.plot(kind=kind, stacked=stacked)
+def test_dataframe_basic_plot(
+    dataframe, kind, stacked, subplots, with_plotting_backend
+):
+    chart = dataframe.plot(kind=kind, stacked=stacked, subplots=subplots)
     spec = chart.to_dict()
 
     x, y = "x", "y"
@@ -89,6 +92,11 @@ def test_dataframe_basic_plot(dataframe, kind, stacked, with_plotting_backend):
     assert spec["encoding"][y]["stack"] == stacked
     assert spec["encoding"]["color"]["field"] == "column"
     assert spec["transform"][0]["fold"] == ["x", "y"]
+    if subplots:
+        assert spec["encoding"]["facet"]["field"] == "column"
+        assert spec["columns"] == 1
+    else:
+        assert "facet" not in spec["encoding"]
 
 
 def test_series_barh(series, with_plotting_backend):


### PR DESCRIPTION
[See subplots: 1](https://pandas.pydata.org/pandas-docs/stable/user_guide/visualization.html#subplots), [2](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.plot.line.html)

```python
df = pd.DataFrame(np.random.rand(10, 2), columns=['a', 'b'])
for kind in ['line', 'bar', 'barh', 'area']:
    df.plot(kind=kind, subplots=True, layout=(1, -1))
```
![image](https://user-images.githubusercontent.com/3757165/64038101-e62f1180-cb74-11e9-8165-de0ae369aa6f.png)
