### PR TITLE
Add kde plot

### DIFF
--- a/altair_pandas/_core.py
+++ b/altair_pandas/_core.py
@@ -75,7 +75,7 @@ class _PandasPlotter:
         if bw_method == "scott" or bw_method is None:
             bandwidth = 0
         elif bw_method == "silverman":
-            # Implimentation taken from
+            # Implementation taken from
             # https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.gaussian_kde.html
             n = data.shape[0]
             d = 1

--- a/altair_pandas/_core.py
+++ b/altair_pandas/_core.py
@@ -96,7 +96,7 @@ class _PandasPlotter:
             steps = 1_000
         elif isinstance(ind, np.ndarray):
             warnings.warn(
-                "The Altair plotting backend does not support sequences" " for ind",
+                "The Altair plotting backend does not support sequences for ind",
                 category=UserWarning,
             )
             steps = 1_000
@@ -366,6 +366,10 @@ class _DataFramePlotter(_PandasPlotter):
         if not vert:
             chart.encoding.x, chart.encoding.y = chart.encoding.y, chart.encoding.x
         return chart
+
+    def kde(self, bw_method=None, ind=None, **kwargs):
+        data = self._preprocess_data(with_index=False)
+        return self._kde(data, bw_method=bw_method, ind=ind, **kwargs)
 
 
 def plot(data, kind="line", **kwargs):

--- a/altair_pandas/_core.py
+++ b/altair_pandas/_core.py
@@ -216,6 +216,10 @@ class _SeriesPlotter(_PandasPlotter):
             chart.encoding.x, chart.encoding.y = chart.encoding.y, chart.encoding.x
         return chart
 
+    def kde(self, bw_method=None, ind=None, **kwargs):
+        data = self._preprocess_data(with_index=False)
+        return self._kde(data, bw_method=bw_method, ind=ind, **kwargs)
+
 
 class _DataFramePlotter(_PandasPlotter):
     """Functionality for plotting of pandas DataFrames."""

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -332,3 +332,35 @@ def test_scatter_multiindex(indx, data, with_plotting_backend):
 
     for k, v in spec["repeat"].items():
         assert set(v) == cols
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pd.DataFrame({"a": np.arange(12), "b": np.arange(12, 24)}),
+        pd.DataFrame({"a": np.arange(12)}),
+        pd.Series(np.arange(12)),
+    ],
+)
+@pytest.mark.parametrize(
+    "bw_method, bandwidth",
+    [
+        (None, 0),
+        ("scott", 0),
+        ("silverman", 0.6443940149772542),
+        (lambda data: 0.3, 0.3),
+    ],
+)
+@pytest.mark.parametrize("ind, steps", [(None, 1_000), (500, 500)])
+def test_kde(data, bw_method, bandwidth, ind, steps):
+    chart = data.plot(kind="kde", bw_method=bw_method, ind=ind)
+    spec = chart.to_dict()
+
+    density_attributes = spec["transform"][1]
+    assert density_attributes["bandwidth"] == pytest.approx(bandwidth)
+    assert density_attributes["extent"] == [
+        data.to_numpy().min(),
+        data.to_numpy().max(),
+    ]
+    assert density_attributes["groupby"] == ["Measurement_type"]
+    assert density_attributes["steps"] == steps

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -374,3 +374,10 @@ def test_kde_warns_callable_bw_method(dataframe):
 def test_kde_warns_array_ind(series):
     with pytest.warns(UserWarning):
         series.plot(kind="kde", ind=np.arange(5))
+
+
+def test_set_color_kde(series):
+    mark_color = "#6300EE"
+    chart = series.plot(kind="kde", color=mark_color)
+    spec = chart.to_dict()
+    assert spec["mark"]["color"] == mark_color

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -369,3 +369,8 @@ def test_kde(data, bw_method, bandwidth, ind, steps):
 def test_kde_warns_callable_bw_method(dataframe):
     with pytest.warns(UserWarning):
         dataframe.plot(kind="kde", bw_method=lambda data: 0)
+
+
+def test_kde_warns_array_ind(series):
+    with pytest.warns(UserWarning):
+        series.plot(kind="kde", ind=np.arange(5))

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -381,3 +381,10 @@ def test_set_color_kde(series):
     chart = series.plot(kind="kde", color=mark_color)
     spec = chart.to_dict()
     assert spec["mark"]["color"] == mark_color
+
+
+def test_set_alpha_kde(dataframe):
+    alpha = 0.2
+    chart = dataframe.plot(kind="kde", alpha=alpha)
+    spec = chart.to_dict()
+    assert spec["mark"]["opacity"] == alpha

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -364,3 +364,8 @@ def test_kde(data, bw_method, bandwidth, ind, steps):
     ]
     assert density_attributes["groupby"] == ["Measurement_type"]
     assert density_attributes["steps"] == steps
+
+
+def test_kde_warns_callable_bw_method(dataframe):
+    with pytest.warns(UserWarning):
+        dataframe.plot(kind="kde", bw_method=lambda data: 0)


### PR DESCRIPTION
Implements [kde plots](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.plot.kde.html). Additionally raises warnings when some parameters behave differently than they would with a Matplotlib backend—such as using a callable for `bw_method` and when a NumPy array is passed into `ind`.

I'm still working to understand the `extent` parameter in `transform_density`. It seems to give nicer results when the domain is manually set to the min and max of the data. So for now it's set to do just that.
