### PR TITLE
Add hexbin plot

### DIFF
--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -409,3 +409,31 @@ def test_hexbin(dataframe, gridsize):
     assert encoding["y"]["bin"]["step"] == pytest.approx(y_step)
     assert encoding["color"]["field"] == "x"
     assert encoding["color"]["aggregate"] == "count"
+
+
+@pytest.mark.parametrize(
+    "reduce_C_function, first_color_value",
+    [
+        (None, 1.5),
+        (np.max, 3),
+        (np.sum, 6),
+    ],
+)
+def test_hexbin_C(reduce_C_function, first_color_value):
+    dataframe = pd.DataFrame(
+        {"x": np.arange(20), "y": np.arange(20, 40), "C": np.arange(20)}
+    )
+    chart = dataframe.plot(
+        kind="hexbin",
+        x="x",
+        y="y",
+        C="C",
+        reduce_C_function=reduce_C_function,
+        gridsize=5,
+    )
+    spec = chart.to_dict()
+
+    dataset = spec["datasets"]
+    assert dataset[list(dataset.keys())[0]][0]["C"] == first_color_value
+    assert spec["encoding"]["color"]["aggregate"] == "median"
+    assert spec["encoding"]["color"]["title"] == "C"

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -388,3 +388,24 @@ def test_set_alpha_kde(dataframe):
     chart = dataframe.plot(kind="kde", alpha=alpha)
     spec = chart.to_dict()
     assert spec["mark"]["opacity"] == alpha
+
+
+@pytest.mark.parametrize("gridsize", [None, 10, (5, 15)])
+def test_hexbin(dataframe, gridsize):
+    chart = dataframe.plot(kind="hexbin", x="x", y="y", gridsize=gridsize)
+    spec = chart.to_dict()
+
+    if np.iterable(gridsize):
+        x_bins, y_bins = gridsize
+    else:
+        x_bins = 100 if gridsize is None else gridsize
+        y_bins = x_bins
+
+    x_step = (dataframe["x"].max() - dataframe["y"].min()) / x_bins
+    y_step = (dataframe["y"].max() - dataframe["y"].min()) / y_bins
+
+    encoding = spec["encoding"]
+    assert encoding["x"]["bin"]["step"] == pytest.approx(x_step)
+    assert encoding["y"]["bin"]["step"] == pytest.approx(y_step)
+    assert encoding["color"]["field"] == "x"
+    assert encoding["color"]["aggregate"] == "count"

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -447,3 +447,10 @@ def test_hexbin_C_equals_x(dataframe):
 
     dataset = spec["datasets"]
     assert dataset[list(dataset.keys())[0]][0]["reduced_x"] == 1
+
+
+def test_hexbin_cmap(dataframe):
+    chart = dataframe.plot(kind="hexbin", x="x", y="y", cmap="blue")
+    spec = chart.to_dict()
+
+    assert spec["encoding"]["color"]["scale"]["scheme"] == "blue"

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -437,3 +437,13 @@ def test_hexbin_C(reduce_C_function, first_color_value):
     assert dataset[list(dataset.keys())[0]][0]["C"] == first_color_value
     assert spec["encoding"]["color"]["aggregate"] == "median"
     assert spec["encoding"]["color"]["title"] == "C"
+
+
+def test_hexbin_C_equals_x(dataframe):
+    chart = dataframe.plot(
+        kind="hexbin", x="x", y="y", C="x", reduce_C_function=lambda df: 1
+    )
+    spec = chart.to_dict()
+
+    dataset = spec["datasets"]
+    assert dataset[list(dataset.keys())[0]][0]["reduced_x"] == 1


### PR DESCRIPTION
Adds [hexbin](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.plot.hexbin.html) plots.

Important to note that Vega-Lite does not currently support hexagonal binning plots, so as a fallback a cartesian heatmap is returned.

```python
df = pd.DataFrame(np.random.randn(1000, 2), columns=["a", "b"])
df["b"] = df["b"] + np.arange(1000)
df["z"] = np.random.uniform(0, 3, 1000)

df.plot.hexbin(
    x="a", y="b", C="z", reduce_C_function=np.max, gridsize=25, backend="matplotlib"
)
```

<img width="428" alt="Screen Shot 2021-02-13 at 4 51 10 PM" src="https://user-images.githubusercontent.com/30049606/107995117-ea323780-6f92-11eb-81aa-297ddfafc3ea.png">

```python
df.plot.hexbin(
    x="a", y="b", C="z", reduce_C_function=np.max, gridsize=25, backend="altair"
)
```

<img width="498" alt="Screen Shot 2021-02-13 at 4 51 27 PM" src="https://user-images.githubusercontent.com/30049606/107995145-fc13da80-6f92-11eb-9048-ad48f5f38b62.png">


One important thing to note is that this implementation supports arbitrary callables as arguments for `reduce_C_function`. However the implementation is a little hacky. It uses Panda's `.transform` to apply the callable across bins, and then when it comes to plotting Altair is told to find the median of those values—which are all identical across the bins.
