### PR TITLE
Make kde plot more consistent with other plots

### DIFF
--- a/altair_pandas/_core.py
+++ b/altair_pandas/_core.py
@@ -107,12 +107,12 @@ class _PandasPlotter:
             alt.Chart(data, mark=self._get_mark_def("area", kwargs))
             .transform_fold(
                 data.columns.to_numpy(),
-                as_=["Measurement_type", "value"],
+                as_=["Column", "value"],
             )
             .transform_density(
                 density="value",
                 bandwidth=bandwidth,
-                groupby=["Measurement_type"],
+                groupby=["Column"],
                 # Manually setting domain to min and max makes kde look
                 # more uniform
                 extent=[data.min().min(), data.max().max()],

--- a/altair_pandas/_core.py
+++ b/altair_pandas/_core.py
@@ -126,7 +126,7 @@ class _PandasPlotter:
         # If there is only one column, do not encode color so that user
         # can pass optional color kwarg into mark
         if 1 < data.shape[1]:
-            chart.encode(color=alt.Color("Measurement_type:N"))
+            chart = chart.encode(color=alt.Color("Column", type="nominal"))
         return chart
 
 

--- a/altair_pandas/_core.py
+++ b/altair_pandas/_core.py
@@ -127,6 +127,7 @@ class _PandasPlotter:
                     alt.Tooltip("Column", type="nominal"),
                 ],
             )
+            .interactive()
         )
         # If there is only one column, do not encode color so that user
         # can pass optional color kwarg into mark

--- a/altair_pandas/_core.py
+++ b/altair_pandas/_core.py
@@ -119,8 +119,8 @@ class _PandasPlotter:
                 steps=steps,
             )
             .encode(
-                x=alt.X("value:Q"),
-                y=alt.Y("density:Q", stack="zero"),
+                x=alt.X("value", type="quantitative"),
+                y=alt.Y("density", type="quantitative", stack="zero"),
             )
         )
         # If there is only one column, do not encode color so that user

--- a/altair_pandas/_core.py
+++ b/altair_pandas/_core.py
@@ -121,6 +121,11 @@ class _PandasPlotter:
             .encode(
                 x=alt.X("value", type="quantitative"),
                 y=alt.Y("density", type="quantitative", stack="zero"),
+                tooltip=[
+                    alt.Tooltip("value", type="quantitative"),
+                    alt.Tooltip("density", type="quantitative"),
+                    alt.Tooltip("Column", type="nominal"),
+                ],
             )
         )
         # If there is only one column, do not encode color so that user

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -364,6 +364,8 @@ def test_kde(data, bw_method, bandwidth, ind, steps):
     ]
     assert density_attributes["groupby"] == ["Column"]
     assert density_attributes["steps"] == steps
+    if 1 < len(data.shape) and 1 < data.shape[1]:
+        assert spec["encoding"]["color"]["field"] == "Column"
 
 
 def test_kde_warns_callable_bw_method(dataframe):

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -362,7 +362,7 @@ def test_kde(data, bw_method, bandwidth, ind, steps):
         data.to_numpy().min(),
         data.to_numpy().max(),
     ]
-    assert density_attributes["groupby"] == ["Measurement_type"]
+    assert density_attributes["groupby"] == ["Column"]
     assert density_attributes["steps"] == steps
 
 


### PR DESCRIPTION
#36 implemented kde plots, but they were inconsistent with the other plots in the library. This PR addresses this by:

- Adding a tooltip
- Making the chart interactive by default
- Renaming the color legend to be more general
- Fixing a bug where colors were not properly assigned to different columns
