### PR TITLE
Add boxplot

### DIFF
--- a/altair_pandas/__init__.py
+++ b/altair_pandas/__init__.py
@@ -1,6 +1,6 @@
 """Altair plotting extension for pandas."""
 __version__ = "0.1.0dev0"
-__all__ = ["plot", "hist_frame", "hist_series", "scatter_matrix"]
+__all__ = ["boxplot_frame", "plot", "hist_frame", "hist_series", "scatter_matrix"]
 
-from ._core import plot, hist_frame, hist_series
+from ._core import boxplot_frame, plot, hist_frame, hist_series
 from ._misc import scatter_matrix

--- a/altair_pandas/_core.py
+++ b/altair_pandas/_core.py
@@ -438,7 +438,7 @@ class _DataFramePlotter(_PandasPlotter):
 
         if return_type is not None:
             warnings.warn(
-                "Different return types are not implimented for the" " Altair backend.",
+                "Different return types are not implimented for the Altair backend.",
                 category=UserWarning,
             )
 
@@ -586,3 +586,28 @@ def hist_frame(data, **kwargs):
 
 def hist_series(data, **kwargs):
     return _PandasPlotter.create(data).hist_series(**kwargs)
+
+
+def boxplot_frame(
+    data,
+    column=None,
+    by=None,
+    fontsize=None,
+    rot=0,
+    grid=True,
+    figsize=None,
+    layout=None,
+    return_type=None,
+    **kwargs,
+):
+    return _PandasPlotter.create(data).box(
+        column=column,
+        by=by,
+        fontsize=fontsize,
+        rot=rot,
+        grid=grid,
+        figsize=figsize,
+        layout=layout,
+        return_type=return_type,
+        **kwargs,
+    )

--- a/altair_pandas/_core.py
+++ b/altair_pandas/_core.py
@@ -10,6 +10,22 @@ def _valid_column(column_name):
     return str(column_name)
 
 
+def _get_fontsize(size_name):
+    """Return a fontsize based on matplotlib labels."""
+    font_sizes = {
+        "xx-small": 5.79,
+        "x-small": 6.94,
+        "small": 8.33,
+        "medium": 10.0,
+        "large": 12.0,
+        "x-large": 14.4,
+        "xx-large": 17.28,
+        "larger": 12.0,
+        "smaller": 8.33,
+    }
+    return font_sizes[size_name]
+
+
 def _get_layout(panels, layout=None):
     """Compute the layout for a gridded chart.
 

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -487,3 +487,24 @@ def test_boxplot_column(column, fold, with_plotting_backend):
     spec = chart.to_dict()
 
     assert spec["transform"][0]["fold"] == fold
+
+
+@pytest.mark.parametrize("by, field", [("X", "X"), ("Y", "Y"), (["X", "Y"], "X, Y")])
+def test_boxplot_by(by, field, with_plotting_backend):
+    df = pd.DataFrame(np.random.randn(10, 3), columns=["Col1", "Col2", "Col3"])
+    df["X"] = pd.Series(["A", "A", "A", "A", "A", "B", "B", "B", "B", "B"])
+    df["Y"] = pd.Series(["A", "B", "A", "B", "A", "B", "A", "B", "A", "B"])
+    chart = df.boxplot(by=by)
+    spec = chart.to_dict()
+
+    assert spec["facet"]["field"] == "Column"
+    assert spec["spec"]["encoding"]["x"]["field"] == field
+
+
+def test_boxplot_fontsize(dataframe, with_plotting_backend):
+    fontsize = 100
+    chart = dataframe.boxplot(fontsize=fontsize)
+    axis = chart.to_dict()["config"]["axis"]
+
+    assert axis["labelFontSize"] == 100
+    assert axis["titleFontSize"] == 100

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -184,7 +184,7 @@ def test_dataframe_boxplot(dataframe, vert, with_plotting_backend):
     spec = chart.to_dict()
     assert spec["mark"] == "boxplot"
     assert spec["transform"][0]["fold"] == ["x", "y"]
-    fields = ["column", "value"] if vert else ["value", "column"]
+    fields = ["Column", "Value"] if vert else ["Value", "Column"]
     assert spec["encoding"]["x"]["field"] == fields[0]
     assert spec["encoding"]["y"]["field"] == fields[1]
 
@@ -544,3 +544,8 @@ def test_boxplot_layout(with_plotting_backend):
     chart = df.boxplot(by="X", layout=(3, 1))
 
     assert chart.to_dict()["columns"] == 1
+
+
+def test_boxplot_warn_return_type(dataframe, with_plotting_backend):
+    with pytest.warns(UserWarning):
+        dataframe.boxplot(return_type="dict")

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -516,3 +516,11 @@ def test_boxplot_rot(dataframe, with_plotting_backend):
     x_encoding = chart["encoding"]["x"]
 
     assert x_encoding["axis"]["labelAngle"] == 360 - rot
+
+
+def test_boxplot_grid(dataframe, with_plotting_backend):
+    chart = dataframe.boxplot(grid=False)
+    encoding = chart.to_dict()["encoding"]
+
+    assert encoding["x"]["axis"]["grid"] is False
+    assert encoding["y"]["axis"]["grid"] is False

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -524,3 +524,15 @@ def test_boxplot_grid(dataframe, with_plotting_backend):
 
     assert encoding["x"]["axis"]["grid"] is False
     assert encoding["y"]["axis"]["grid"] is False
+
+
+def test_boxplot_figsize(dataframe, with_plotting_backend):
+    width = 500
+    height = 300
+    chart = dataframe.boxplot(figsize=(width, height))
+    view = chart.to_dict()["config"]["view"]
+
+    assert view["continuousHeight"] == 300
+    assert view["continuousWidth"] == 500
+    assert view["discreteHeight"] == 300
+    assert view["discreteWidth"] == 500

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -468,3 +468,22 @@ def test_boxplot(dataframe, with_plotting_backend):
     assert encoding["x"]["type"] == "nominal"
     assert encoding["y"]["field"] == "Value"
     assert encoding["y"]["type"] == "quantitative"
+
+
+@pytest.mark.parametrize(
+    "column, fold",
+    [
+        (None, ["Col1", "Col2", "Col3"]),
+        ("Col1", ["Col1"]),
+        ("Col2", ["Col2"]),
+        (["Col1", "Col3"], ["Col1", "Col3"]),
+    ],
+)
+def test_boxplot_column(column, fold, with_plotting_backend):
+    df = pd.DataFrame(np.random.randn(10, 3), columns=["Col1", "Col2", "Col3"])
+    df["X"] = pd.Series(["A", "A", "A", "A", "A", "B", "B", "B", "B", "B"])
+    df["Y"] = pd.Series(["A", "B", "A", "B", "A", "B", "A", "B", "A", "B"])
+    chart = df.boxplot(column=column)
+    spec = chart.to_dict()
+
+    assert spec["transform"][0]["fold"] == fold

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -456,3 +456,15 @@ def test_hexbin_cmap(dataframe):
     spec = chart.to_dict()
 
     assert spec["encoding"]["color"]["scale"]["scheme"] == "blue"
+
+
+def test_boxplot(dataframe, with_plotting_backend):
+    chart = dataframe.boxplot()
+    spec = chart.to_dict()
+    encoding = spec["encoding"]
+
+    assert spec["mark"] == "boxplot"
+    assert encoding["x"]["field"] == "Column"
+    assert encoding["x"]["type"] == "nominal"
+    assert encoding["y"]["field"] == "Value"
+    assert encoding["y"]["type"] == "quantitative"

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -508,3 +508,11 @@ def test_boxplot_fontsize(dataframe, with_plotting_backend):
 
     assert axis["labelFontSize"] == 100
     assert axis["titleFontSize"] == 100
+
+
+def test_boxplot_rot(dataframe, with_plotting_backend):
+    rot = 45
+    chart = dataframe.boxplot(rot=rot)
+    x_encoding = chart["encoding"]["x"]
+
+    assert x_encoding["axis"]["labelAngle"] == 360 - rot

--- a/altair_pandas/test_plotting.py
+++ b/altair_pandas/test_plotting.py
@@ -536,3 +536,11 @@ def test_boxplot_figsize(dataframe, with_plotting_backend):
     assert view["continuousWidth"] == 500
     assert view["discreteHeight"] == 300
     assert view["discreteWidth"] == 500
+
+
+def test_boxplot_layout(with_plotting_backend):
+    df = pd.DataFrame(np.random.randn(10, 3), columns=["Col1", "Col2", "Col3"])
+    df["X"] = pd.Series(["A", "A", "A", "A", "A", "B", "B", "B", "B", "B"])
+    chart = df.boxplot(by="X", layout=(3, 1))
+
+    assert chart.to_dict()["columns"] == 1


### PR DESCRIPTION
Implemented [`pandas.DataFrame.boxplot`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.boxplot.html) by extending the existing `pandas.DataFrame.plot.box` to accept `boxplot`'s arguments. The only (listed, non `**kwarg`) argument not supported is `return_type`—which doesn't seem to make too much sense in the context of Altair. When a value is passed to the `return_type` arg it raises a user warning saying it is unsupported.

```python
df = pd.DataFrame(np.random.randn(10, 3),
                  columns=['Col1', 'Col2', 'Col3'])
df['X'] = pd.Series(['A', 'A', 'A', 'A', 'A',
                     'B', 'B', 'B', 'B', 'B'])
df['Y'] = pd.Series(['A', 'B', 'A', 'B', 'A',
                     'B', 'A', 'B', 'A', 'B'])
df.boxplot(column=['Col1', 'Col2'], by=['X', 'Y'], backend="matplotlib")
```

<img width="446" alt="Screen Shot 2021-02-28 at 12 39 21 PM" src="https://user-images.githubusercontent.com/30049606/109432853-0fc33600-79c2-11eb-9f68-c252d62ab002.png">

```python
df.boxplot(column=['Col1', 'Col2'], by=['X', 'Y'], backend="altair")
```

<img width="286" alt="Screen Shot 2021-02-28 at 12 39 32 PM" src="https://user-images.githubusercontent.com/30049606/109432862-1d78bb80-79c2-11eb-928b-46e9d1af1c27.png">
